### PR TITLE
One-liner to install latest bosh2 cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Relevant documentation pages from bosh.io:
 
 - [Installing BOSH](https://bosh.io/docs#install)
 
+To install the very latest `bosh2` CLI on OS X (assuming `~/bin` is in `$PATH`): 
+
+```
+version=$(curl -s https://api.github.com/repos/cloudfoundry/bosh-cli/releases/latest | jq -r .tag_name | sed -e "s/^v//") && wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-$version-darwin-amd64 && mv bosh-cli-$version-darwin-amd64 ~/bin/bosh2 && chmod +x ~/bin/bosh2
+```
+
+
 ## Client Library
 
 This project includes [`director`](director/interfaces.go) and [`uaa`](uaa/interfaces.go) packages meant to be used in your project for programmatic access to the Director API.


### PR DESCRIPTION
Perhaps helpful to others to get latest greatest `bosh2` regularly whilst its being updated twice a day.
