### PR TITLE
`spec.id` returns a unique identifier rather than `unknown` in bosh C…

### DIFF
--- a/cmd/env_factory.go
+++ b/cmd/env_factory.go
@@ -146,7 +146,7 @@ func NewEnvFactory(deps BasicDeps, manifestPath string, manifestVars boshtpl.Var
 
 	{
 		erbRenderer := bitemplateerb.NewERBRenderer(deps.FS, deps.CmdRunner, deps.Logger)
-		jobRenderer := bitemplate.NewJobRenderer(erbRenderer, deps.FS, deps.Logger)
+		jobRenderer := bitemplate.NewJobRenderer(erbRenderer, deps.FS, deps.UUIDGen, deps.Logger)
 
 		builderFactory := biinstancestate.NewBuilderFactory(
 			bistatepkg.NewCompiledPackageRepo(biindex.NewInMemoryIndex()),

--- a/installation/installer_factory.go
+++ b/installation/installer_factory.go
@@ -98,7 +98,7 @@ type installerFactoryContext struct {
 func (c *installerFactoryContext) JobRenderer() JobRenderer {
 
 	erbRenderer := bierbrenderer.NewERBRenderer(c.fs, c.runner, c.logger)
-	jobRenderer := bitemplate.NewJobRenderer(erbRenderer, c.fs, c.logger)
+	jobRenderer := bitemplate.NewJobRenderer(erbRenderer, c.fs, c.uuidGenerator, c.logger)
 	jobListRenderer := bitemplate.NewJobListRenderer(jobRenderer, c.logger)
 
 	return NewJobRenderer(

--- a/templatescompiler/job_renderer.go
+++ b/templatescompiler/job_renderer.go
@@ -10,6 +10,7 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	biproperty "github.com/cloudfoundry/bosh-utils/property"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
+	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 )
 
 type JobRenderer interface {
@@ -19,6 +20,7 @@ type JobRenderer interface {
 type jobRenderer struct {
 	erbRenderer bierbrenderer.ERBRenderer
 	fs          boshsys.FileSystem
+	uuidGen     boshuuid.Generator
 	logger      boshlog.Logger
 	logTag      string
 }
@@ -26,18 +28,20 @@ type jobRenderer struct {
 func NewJobRenderer(
 	erbRenderer bierbrenderer.ERBRenderer,
 	fs boshsys.FileSystem,
+	uuidGen boshuuid.Generator,
 	logger boshlog.Logger,
 ) JobRenderer {
 	return &jobRenderer{
 		erbRenderer: erbRenderer,
 		fs:          fs,
+		uuidGen:     uuidGen,
 		logger:      logger,
 		logTag:      "jobRenderer",
 	}
 }
 
 func (r *jobRenderer) Render(releaseJob bireljob.Job, releaseJobProperties *biproperty.Map, jobProperties biproperty.Map, globalProperties biproperty.Map, deploymentName string, address string) (RenderedJob, error) {
-	context := NewJobEvaluationContext(releaseJob, releaseJobProperties, jobProperties, globalProperties, deploymentName, address, r.logger)
+	context := NewJobEvaluationContext(releaseJob, releaseJobProperties, jobProperties, globalProperties, deploymentName, address, r.uuidGen, r.logger)
 
 	sourcePath := releaseJob.ExtractedPath()
 

--- a/templatescompiler/job_renderer_test.go
+++ b/templatescompiler/job_renderer_test.go
@@ -56,12 +56,12 @@ var _ = Describe("JobRenderer", func() {
 
 		logger := boshlog.NewLogger(boshlog.LevelNone)
 
-		context = NewJobEvaluationContext(*job, &releaseJobProperties, jobProperties, globalProperties, "fake-deployment-name", "1.2.3.4", logger)
+		context = NewJobEvaluationContext(*job, &releaseJobProperties, jobProperties, globalProperties, "fake-deployment-name", "1.2.3.4", nil, logger)
 
 		fakeERBRenderer = fakebirender.NewFakeERBRender()
 
 		fs = fakesys.NewFakeFileSystem()
-		jobRenderer = NewJobRenderer(fakeERBRenderer, fs, logger)
+		jobRenderer = NewJobRenderer(fakeERBRenderer, fs, nil, logger)
 
 		fakeERBRenderer.SetRenderBehavior(
 			filepath.Join(srcPath, "templates/director.yml.erb"),


### PR DESCRIPTION
…LI v2

- helpful for `bosh-cli`-deployed machines (no BOSH Director)
  on vSphere, esp. if > 2 Concourse workers who register
  with `spec.id` (if both are "unknown", the last one
  wins, the first one, forgotten)

[#129632439](https://www.pivotaltracker.com/story/show/129632439)

Signed-off-by: Dmitriy Kalinin <dkalinin@pivotal.io>