### PR TITLE
Statically compile bosh-cli linux binaries

### DIFF
--- a/ci/tasks/build-linux.yml
+++ b/ci/tasks/build-linux.yml
@@ -14,6 +14,7 @@ outputs:
 params:
   GOOS:   linux
   GOARCH: amd64
+  CGO_ENABLED: 0
   BOSHIO_BEARER_TOKEN: replace_me
 
 run:


### PR DESCRIPTION
- Fixes "no such file or directory" error on alpine docker images due to
  missing glibc
- CGO_ENABLED defaults to true if your build box is the same arch as the
  target arch