### PR TITLE
Allow interpolated variable to contain `=`

### DIFF
--- a/director/template/var_kv.go
+++ b/director/template/var_kv.go
@@ -13,7 +13,7 @@ type VarKV struct {
 }
 
 func (a *VarKV) UnmarshalFlag(data string) error {
-	pieces := strings.Split(data, "=")
+	pieces := strings.SplitN(data, "=", 2)
 	if len(pieces) != 2 {
 		return bosherr.Errorf(
 			"Expected var '%s' to be in format 'name=value'", data)

--- a/director/template/var_kv_test.go
+++ b/director/template/var_kv_test.go
@@ -23,6 +23,12 @@ var _ = Describe("VarKV", func() {
 			Expect(arg).To(Equal(VarKV{Name: "name", Value: "val"}))
 		})
 
+		It("sets name and value when value contains a `=`", func() {
+			err := (&arg).UnmarshalFlag("public_key=ssh-rsa G4/+VHa1aw==")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arg).To(Equal(VarKV{Name: "public_key", Value: "ssh-rsa G4/+VHa1aw=="}))
+		})
+
 		It("returns error if string does not have 2 pieces", func() {
 			err := (&arg).UnmarshalFlag("val")
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
- Use case - Interpolate public key `-v public_key=ssh-rsa ...G4/+VHa1aw==`