### PR TITLE
If the release is an invalid URL, error includes URL

### DIFF
--- a/release/set/manifest/validator.go
+++ b/release/set/manifest/validator.go
@@ -43,7 +43,7 @@ func (v *validator) Validate(manifest Manifest) error {
 
 		matched, err := regexp.MatchString("^(file|http|https)://", release.URL)
 		if err != nil || !matched {
-			errs = append(errs, bosherr.Errorf("releases[%d].url must be a valid URL (file:// or http(s)://)", releaseIdx))
+			errs = append(errs, bosherr.Errorf("releases[%d].url ('%s') must be a valid URL (file:// or http(s)://)", releaseIdx, release.URL))
 		}
 
 		if strings.HasPrefix(release.URL, "http") && v.isBlank(release.SHA1) {

--- a/release/set/manifest/validator_test.go
+++ b/release/set/manifest/validator_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Validator", func() {
 
 			err := validator.Validate(manifest)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("releases[0].url must be a valid URL (file:// or http(s)://)"))
+			Expect(err.Error()).To(ContainSubstring("releases[0].url ('invalid-url') must be a valid URL (file:// or http(s)://)"))
 		})
 
 		It("validates releases are unique", func() {


### PR DESCRIPTION
It would have saved me about 1 hour this morning if the error message had included the URL. Really. Don't ask.

Ran unit tests. Did not run integration or acceptance tests.
