### PR TITLE
Logs collecting from multiple instances

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -114,9 +114,15 @@ func (c LogsCmd) buildTailCmd(opts LogsOpts) []string {
 }
 
 func (c LogsCmd) fetch(opts LogsOpts) error {
-	slug, ok := opts.Args.Slug.InstanceSlug()
-	if !ok {
-		return bosherr.Errorf("Expected single instance for fetching logs")
+	slug := opts.Args.Slug
+	name := c.deployment.Name()
+
+	if len(slug.Name()) > 0 {
+		name += "." + slug.Name()
+	}
+
+	if len(slug.IndexOrID()) > 0 {
+		name += "." + slug.IndexOrID()
 	}
 
 	result, err := c.deployment.FetchLogs(slug, opts.Filters, opts.Agent)
@@ -127,7 +133,7 @@ func (c LogsCmd) fetch(opts LogsOpts) error {
 	err = c.downloader.Download(
 		result.BlobstoreID,
 		result.SHA1,
-		opts.Args.Slug.Name(),
+		name,
 		opts.Directory.Path,
 	)
 	if err != nil {

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -25,7 +25,9 @@ var _ = Describe("LogsCmd", func() {
 	)
 
 	BeforeEach(func() {
-		deployment = &fakedir.FakeDeployment{}
+		deployment = &fakedir.FakeDeployment{
+			NameStub: func() string { return "dep" },
+		}
 		downloader = &fakecmd.FakeDownloader{}
 		uuidGen = &fakeuuid.FakeGenerator{}
 		nonIntSSHRunner = &fakessh.FakeRunner{}
@@ -60,7 +62,7 @@ var _ = Describe("LogsCmd", func() {
 				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
 				slug, filters, agent := deployment.FetchLogsArgsForCall(0)
-				Expect(slug).To(Equal(boshdir.NewInstanceSlug("job", "index")))
+				Expect(slug).To(Equal(boshdir.NewAllOrPoolOrInstanceSlug("job", "index")))
 				Expect(filters).To(BeEmpty())
 				Expect(agent).To(BeFalse())
 
@@ -69,7 +71,7 @@ var _ = Describe("LogsCmd", func() {
 				blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
 				Expect(blobID).To(Equal("blob-id"))
 				Expect(sha1).To(Equal("sha1"))
-				Expect(prefix).To(Equal("job"))
+				Expect(prefix).To(Equal("dep.job.index"))
 				Expect(dstDirPath).To(Equal("/fake-dir"))
 			})
 
@@ -85,17 +87,29 @@ var _ = Describe("LogsCmd", func() {
 				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
 				slug, filters, agent := deployment.FetchLogsArgsForCall(0)
-				Expect(slug).To(Equal(boshdir.NewInstanceSlug("job", "index")))
+				Expect(slug).To(Equal(boshdir.NewAllOrPoolOrInstanceSlug("job", "index")))
 				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
 				Expect(agent).To(BeTrue())
 			})
 
-			It("returns error if trying to fetch logs for more than one instance", func() {
-				opts.Args.Slug = boshdir.NewAllOrPoolOrInstanceSlug("job", "")
+			It("fetches logs for more than one instance", func() {
+				opts.Args.Slug = boshdir.NewAllOrPoolOrInstanceSlug("", "")
+
+				result := boshdir.LogsResult{BlobstoreID: "blob-id", SHA1: "sha1"}
+				deployment.FetchLogsReturns(result, nil)
 
 				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("Expected single instance for fetching logs"))
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+
+				Expect(downloader.DownloadCallCount()).To(Equal(1))
+
+				blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
+				Expect(blobID).To(Equal("blob-id"))
+				Expect(sha1).To(Equal("sha1"))
+				Expect(prefix).To(Equal("dep"))
+				Expect(dstDirPath).To(Equal("/fake-dir"))
 			})
 
 			It("returns error if fetching logs failed", func() {

--- a/director/deployment.go
+++ b/director/deployment.go
@@ -107,7 +107,7 @@ func (d DeploymentImpl) Manifest() (string, error) {
 	return resp.Manifest, nil
 }
 
-func (d DeploymentImpl) FetchLogs(slug InstanceSlug, filters []string, agent bool) (LogsResult, error) {
+func (d DeploymentImpl) FetchLogs(slug AllOrPoolOrInstanceSlug, filters []string, agent bool) (LogsResult, error) {
 	blobID, sha1, err := d.client.FetchLogs(d.name, slug.Name(), slug.IndexOrID(), filters, agent)
 	if err != nil {
 		return LogsResult{}, err
@@ -196,11 +196,11 @@ func (c Client) FetchLogs(deploymentName, job, indexOrID string, filters []strin
 	}
 
 	if len(job) == 0 {
-		return "", "", bosherr.Error("Expected non-empty job name")
+		job = "*"
 	}
 
 	if len(indexOrID) == 0 {
-		return "", "", bosherr.Error("Expected non-empty index or ID")
+		indexOrID = "*"
 	}
 
 	query := gourl.Values{}

--- a/director/fakes/fake_deployment.go
+++ b/director/fakes/fake_deployment.go
@@ -193,10 +193,10 @@ type FakeDeployment struct {
 	cleanUpSSHReturns struct {
 		result1 error
 	}
-	FetchLogsStub        func(director.InstanceSlug, []string, bool) (director.LogsResult, error)
+	FetchLogsStub        func(director.AllOrPoolOrInstanceSlug, []string, bool) (director.LogsResult, error)
 	fetchLogsMutex       sync.RWMutex
 	fetchLogsArgsForCall []struct {
-		arg1 director.InstanceSlug
+		arg1 director.AllOrPoolOrInstanceSlug
 		arg2 []string
 		arg3 bool
 	}
@@ -905,10 +905,10 @@ func (fake *FakeDeployment) CleanUpSSHReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeDeployment) FetchLogs(arg1 director.InstanceSlug, arg2 []string, arg3 bool) (director.LogsResult, error) {
+func (fake *FakeDeployment) FetchLogs(arg1 director.AllOrPoolOrInstanceSlug, arg2 []string, arg3 bool) (director.LogsResult, error) {
 	fake.fetchLogsMutex.Lock()
 	fake.fetchLogsArgsForCall = append(fake.fetchLogsArgsForCall, struct {
-		arg1 director.InstanceSlug
+		arg1 director.AllOrPoolOrInstanceSlug
 		arg2 []string
 		arg3 bool
 	}{arg1, arg2, arg3})
@@ -926,7 +926,7 @@ func (fake *FakeDeployment) FetchLogsCallCount() int {
 	return len(fake.fetchLogsArgsForCall)
 }
 
-func (fake *FakeDeployment) FetchLogsArgsForCall(i int) (director.InstanceSlug, []string, bool) {
+func (fake *FakeDeployment) FetchLogsArgsForCall(i int) (director.AllOrPoolOrInstanceSlug, []string, bool) {
 	fake.fetchLogsMutex.RLock()
 	defer fake.fetchLogsMutex.RUnlock()
 	return fake.fetchLogsArgsForCall[i].arg1, fake.fetchLogsArgsForCall[i].arg2, fake.fetchLogsArgsForCall[i].arg3

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -115,7 +115,7 @@ type Deployment interface {
 	CleanUpSSH(AllOrPoolOrInstanceSlug, SSHOpts) error
 
 	// Instance specifics
-	FetchLogs(InstanceSlug, []string, bool) (LogsResult, error)
+	FetchLogs(AllOrPoolOrInstanceSlug, []string, bool) (LogsResult, error)
 	TakeSnapshot(InstanceSlug) error
 	EnableResurrection(InstanceSlug, bool) error
 


### PR DESCRIPTION
```
Logs can be collected from 1 instance, instances of 1 job and all instances in the deployment.

[#126754759](https://www.pivotaltracker.com/story/show/126754759)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>
```
