### PR TITLE
quick simplification of env command in favor of alias-env and read-only env commands

### DIFF
--- a/cmd/alias_env.go
+++ b/cmd/alias_env.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	cmdconf "github.com/cloudfoundry/bosh-cli/cmd/config"
+	boshui "github.com/cloudfoundry/bosh-cli/ui"
+)
+
+type AliasEnvCmd struct {
+	sessionFactory func(cmdconf.Config) Session
+
+	config cmdconf.Config
+	ui     boshui.UI
+}
+
+func NewAliasEnvCmd(
+	sessionFactory func(cmdconf.Config) Session,
+	config cmdconf.Config,
+	ui boshui.UI,
+) AliasEnvCmd {
+	return AliasEnvCmd{sessionFactory: sessionFactory, config: config, ui: ui}
+}
+
+func (c AliasEnvCmd) Run(opts AliasEnvOpts) error {
+	updatedConfig, err := c.config.AliasEnvironment(opts.URL, opts.Args.Alias, opts.CACert)
+	if err != nil {
+		return err
+	}
+
+	sess := c.sessionFactory(updatedConfig)
+
+	director, err := sess.Director()
+	if err != nil {
+		return err
+	}
+
+	info, err := director.Info()
+	if err != nil {
+		return err
+	}
+
+	err = updatedConfig.Save()
+	if err != nil {
+		return err
+	}
+
+	InfoTable{info, c.ui}.Print()
+
+	return nil
+}

--- a/cmd/alias_env_test.go
+++ b/cmd/alias_env_test.go
@@ -1,0 +1,149 @@
+package cmd_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-cli/cmd"
+	cmdconf "github.com/cloudfoundry/bosh-cli/cmd/config"
+	fakecmdconf "github.com/cloudfoundry/bosh-cli/cmd/config/fakes"
+	fakecmd "github.com/cloudfoundry/bosh-cli/cmd/fakes"
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	fakedir "github.com/cloudfoundry/bosh-cli/director/fakes"
+	fakeui "github.com/cloudfoundry/bosh-cli/ui/fakes"
+	boshtbl "github.com/cloudfoundry/bosh-cli/ui/table"
+)
+
+var _ = Describe("AliasEnvCmd", func() {
+	var (
+		sessions map[*fakecmdconf.FakeConfig2]*fakecmd.FakeSession
+		config   *fakecmdconf.FakeConfig2
+		ui       *fakeui.FakeUI
+		command  AliasEnvCmd
+	)
+
+	BeforeEach(func() {
+		sessions = map[*fakecmdconf.FakeConfig2]*fakecmd.FakeSession{}
+
+		sessionFactory := func(config cmdconf.Config) Session {
+			typedConfig, ok := config.(*fakecmdconf.FakeConfig2)
+			if !ok {
+				panic("Expected to find FakeConfig2")
+			}
+
+			for c, sess := range sessions {
+				if c.Existing == typedConfig.Existing {
+					return sess
+				}
+			}
+
+			panic("Expected to find fake session")
+		}
+
+		config = &fakecmdconf.FakeConfig2{
+			Existing: fakecmdconf.ConfigContents{
+				EnvironmentURL:    "curr-environment-url",
+				EnvironmentCACert: "curr-ca-cert",
+			},
+		}
+
+		ui = &fakeui.FakeUI{}
+
+		command = NewAliasEnvCmd(sessionFactory, config, ui)
+	})
+
+	Describe("Run", func() {
+		var (
+			opts            AliasEnvOpts
+			updatedSession  *fakecmd.FakeSession
+			updatedConfig   *fakecmdconf.FakeConfig2
+			updatedDirector *fakedir.FakeDirector
+		)
+
+		BeforeEach(func() {
+			opts = AliasEnvOpts{}
+
+			opts.URL = "environment-url"
+			opts.Args.Alias = "environment-alias"
+			opts.CACert = "environment-ca-cert"
+
+			updatedConfig = &fakecmdconf.FakeConfig2{
+				Existing: fakecmdconf.ConfigContents{
+					EnvironmentURL:    "environment-url",
+					EnvironmentAlias:  "environment-alias",
+					EnvironmentCACert: "environment-ca-cert",
+				},
+			}
+
+			updatedDirector = &fakedir.FakeDirector{}
+
+			updatedSession = &fakecmd.FakeSession{}
+			updatedSession.DirectorReturns(updatedDirector, nil)
+			updatedSession.EnvironmentReturns("environment-url")
+
+			sessions[updatedConfig] = updatedSession
+		})
+
+		act := func() error { return command.Run(opts) }
+
+		It("returns error if aliasing fails", func() {
+			config.AliasEnvironmentErr = errors.New("fake-err")
+
+			err := act()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
+
+			Expect(config.Saved.Called).To(BeFalse())
+		})
+
+		It("saves environment and shows director info if director is reachable", func() {
+			info := boshdir.Info{
+				Name:    "director-name",
+				UUID:    "director-uuid",
+				Version: "director-version",
+			}
+			updatedDirector.InfoReturns(info, nil)
+
+			err := act()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.Saved.Called).To(BeTrue())
+			Expect(config.Saved.EnvironmentURL).To(Equal("environment-url"))
+			Expect(config.Saved.EnvironmentAlias).To(Equal("environment-alias"))
+			Expect(config.Saved.EnvironmentCACert).To(Equal("environment-ca-cert"))
+
+			Expect(ui.Table).To(Equal(boshtbl.Table{
+				Rows: [][]boshtbl.Value{
+					{
+						boshtbl.NewValueString("Name"),
+						boshtbl.NewValueString("director-name"),
+					},
+					{
+						boshtbl.NewValueString("UUID"),
+						boshtbl.NewValueString("director-uuid"),
+					},
+					{
+						boshtbl.NewValueString("Version"),
+						boshtbl.NewValueString("director-version"),
+					},
+					{
+						boshtbl.NewValueString("User"),
+						boshtbl.NewValueString("(not logged in)"),
+					},
+				},
+			}))
+		})
+
+		It("returns an error and does not save environment if director is not reachable", func() {
+			updatedDirector.InfoReturns(boshdir.Info{}, errors.New("fake-err"))
+
+			err := act()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
+
+			Expect(config.Saved.Called).To(BeFalse())
+		})
+	})
+})

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,12 @@ func (c Cmd) Execute() (cmdErr error) {
 	deps := c.deps
 
 	switch opts := c.Opts.(type) {
+	case *EnvironmentOpts:
+		return NewEnvironmentCmd(deps.UI, c.director()).Run()
+
+	case *EnvironmentsOpts:
+		return NewEnvironmentsCmd(c.config(), deps.UI).Run()
+
 	case *CreateEnvOpts:
 		envProvider := func(path string, vars boshtpl.Variables, ops patch.Ops) DeploymentPreparer {
 			return NewEnvFactory(deps, path, vars, ops).Preparer()
@@ -64,15 +70,12 @@ func (c Cmd) Execute() (cmdErr error) {
 		stage := boshui.NewStage(deps.UI, deps.Time, deps.Logger)
 		return NewDeleteCmd(deps.UI, envProvider).Run(stage, *opts)
 
-	case *EnvironmentsOpts:
-		return NewEnvironmentsCmd(c.config(), deps.UI).Run()
-
-	case *EnvironmentOpts:
+	case *AliasEnvOpts:
 		sessionFactory := func(config cmdconf.Config) Session {
-			return NewSessionFromOpts(c.BoshOpts, config, deps.UI, false, false, deps.FS, deps.Logger)
+			return NewSessionFromOpts(c.BoshOpts, config, deps.UI, true, false, deps.FS, deps.Logger)
 		}
 
-		return NewEnvironmentCmd(sessionFactory, c.config(), deps.UI).Run(*opts)
+		return NewAliasEnvCmd(sessionFactory, c.config(), deps.UI).Run(*opts)
 
 	case *LogInOpts:
 		sessionFactory := func(config cmdconf.Config) Session {

--- a/cmd/config/fakes/fake_config.go
+++ b/cmd/config/fakes/fake_config.go
@@ -22,15 +22,16 @@ type FakeConfig struct {
 	resolveEnvironmentReturns struct {
 		result1 string
 	}
-	SetEnvironmentStub        func(urlOrAlias, alias, caCert string) config.Config
-	setEnvironmentMutex       sync.RWMutex
-	setEnvironmentArgsForCall []struct {
-		urlOrAlias string
-		alias      string
-		caCert     string
+	AliasEnvironmentStub        func(url, alias, caCert string) (config.Config, error)
+	aliasEnvironmentMutex       sync.RWMutex
+	aliasEnvironmentArgsForCall []struct {
+		url    string
+		alias  string
+		caCert string
 	}
-	setEnvironmentReturns struct {
+	aliasEnvironmentReturns struct {
 		result1 config.Config
+		result2 error
 	}
 	CACertStub        func(url string) string
 	cACertMutex       sync.RWMutex
@@ -129,38 +130,39 @@ func (fake *FakeConfig) ResolveEnvironmentReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeConfig) SetEnvironment(urlOrAlias string, alias string, caCert string) config.Config {
-	fake.setEnvironmentMutex.Lock()
-	fake.setEnvironmentArgsForCall = append(fake.setEnvironmentArgsForCall, struct {
-		urlOrAlias string
-		alias      string
-		caCert     string
-	}{urlOrAlias, alias, caCert})
-	fake.setEnvironmentMutex.Unlock()
-	if fake.SetEnvironmentStub != nil {
-		return fake.SetEnvironmentStub(urlOrAlias, alias, caCert)
+func (fake *FakeConfig) AliasEnvironment(url string, alias string, caCert string) (config.Config, error) {
+	fake.aliasEnvironmentMutex.Lock()
+	fake.aliasEnvironmentArgsForCall = append(fake.aliasEnvironmentArgsForCall, struct {
+		url    string
+		alias  string
+		caCert string
+	}{url, alias, caCert})
+	fake.aliasEnvironmentMutex.Unlock()
+	if fake.AliasEnvironmentStub != nil {
+		return fake.AliasEnvironmentStub(url, alias, caCert)
 	} else {
-		return fake.setEnvironmentReturns.result1
+		return fake.aliasEnvironmentReturns.result1, fake.aliasEnvironmentReturns.result2
 	}
 }
 
-func (fake *FakeConfig) SetEnvironmentCallCount() int {
-	fake.setEnvironmentMutex.RLock()
-	defer fake.setEnvironmentMutex.RUnlock()
-	return len(fake.setEnvironmentArgsForCall)
+func (fake *FakeConfig) AliasEnvironmentCallCount() int {
+	fake.aliasEnvironmentMutex.RLock()
+	defer fake.aliasEnvironmentMutex.RUnlock()
+	return len(fake.aliasEnvironmentArgsForCall)
 }
 
-func (fake *FakeConfig) SetEnvironmentArgsForCall(i int) (string, string, string) {
-	fake.setEnvironmentMutex.RLock()
-	defer fake.setEnvironmentMutex.RUnlock()
-	return fake.setEnvironmentArgsForCall[i].urlOrAlias, fake.setEnvironmentArgsForCall[i].alias, fake.setEnvironmentArgsForCall[i].caCert
+func (fake *FakeConfig) AliasEnvironmentArgsForCall(i int) (string, string, string) {
+	fake.aliasEnvironmentMutex.RLock()
+	defer fake.aliasEnvironmentMutex.RUnlock()
+	return fake.aliasEnvironmentArgsForCall[i].url, fake.aliasEnvironmentArgsForCall[i].alias, fake.aliasEnvironmentArgsForCall[i].caCert
 }
 
-func (fake *FakeConfig) SetEnvironmentReturns(result1 config.Config) {
-	fake.SetEnvironmentStub = nil
-	fake.setEnvironmentReturns = struct {
+func (fake *FakeConfig) AliasEnvironmentReturns(result1 config.Config, result2 error) {
+	fake.AliasEnvironmentStub = nil
+	fake.aliasEnvironmentReturns = struct {
 		result1 config.Config
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeConfig) CACert(url string) string {

--- a/cmd/config/fakes/fake_config2.go
+++ b/cmd/config/fakes/fake_config2.go
@@ -7,6 +7,8 @@ import (
 type FakeConfig2 struct {
 	Existing ConfigContents
 
+	AliasEnvironmentErr error
+
 	Saved   *ConfigContents
 	SaveErr error
 }
@@ -31,7 +33,7 @@ func (f *FakeConfig2) ResolveEnvironment(environmentOrName string) string {
 	return ""
 }
 
-func (f *FakeConfig2) SetEnvironment(environment, alias, caCert string) config.Config {
+func (f *FakeConfig2) AliasEnvironment(environment, alias, caCert string) (config.Config, error) {
 	f.Saved = &ConfigContents{}
 
 	return &FakeConfig2{
@@ -43,7 +45,7 @@ func (f *FakeConfig2) SetEnvironment(environment, alias, caCert string) config.C
 
 		Saved:   f.Saved,
 		SaveErr: f.SaveErr,
-	}
+	}, f.AliasEnvironmentErr
 }
 
 func (f *FakeConfig2) CACert(environment string) string {

--- a/cmd/config/fs_config.go
+++ b/cmd/config/fs_config.go
@@ -78,27 +78,23 @@ func (c FSConfig) ResolveEnvironment(urlOrAlias string) string {
 	return tg.URL
 }
 
-func (c FSConfig) SetEnvironment(urlOrAlias, alias, caCert string) Config {
-	config := c.deepCopy()
-
-	var url string
-
-	// If url is not provided, url might actually be an alias
-	if len(alias) == 0 {
-		url = c.ResolveEnvironment(urlOrAlias)
-	} else {
-		url = urlOrAlias
-
-		i, tg := config.findOrCreateEnvironment(url)
-		tg.Alias = alias
-		config.schema.Environments[i] = tg
+func (c FSConfig) AliasEnvironment(url, alias, caCert string) (Config, error) {
+	if len(url) == 0 {
+		return nil, bosherr.Error("Expected non-empty environment URL")
 	}
 
+	if len(alias) == 0 {
+		return nil, bosherr.Error("Expected non-empty environment alias")
+	}
+
+	config := c.deepCopy()
+
 	i, tg := config.findOrCreateEnvironment(url)
+	tg.Alias = alias
 	tg.CACert = c.readCACert(caCert)
 	config.schema.Environments[i] = tg
 
-	return config
+	return config, nil
 }
 
 func (c FSConfig) CACert(urlOrAlias string) string {

--- a/cmd/config/interfaces.go
+++ b/cmd/config/interfaces.go
@@ -5,7 +5,7 @@ package config
 type Config interface {
 	Environments() []Environment
 	ResolveEnvironment(urlOrAlias string) string
-	SetEnvironment(urlOrAlias, alias, caCert string) Config
+	AliasEnvironment(url, alias, caCert string) (Config, error)
 
 	CACert(url string) string
 

--- a/cmd/environment_test.go
+++ b/cmd/environment_test.go
@@ -7,9 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/bosh-cli/cmd"
-	cmdconf "github.com/cloudfoundry/bosh-cli/cmd/config"
-	fakecmdconf "github.com/cloudfoundry/bosh-cli/cmd/config/fakes"
-	fakecmd "github.com/cloudfoundry/bosh-cli/cmd/fakes"
 	boshdir "github.com/cloudfoundry/bosh-cli/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/director/fakes"
 	fakeui "github.com/cloudfoundry/bosh-cli/ui/fakes"
@@ -18,368 +15,59 @@ import (
 
 var _ = Describe("EnvironmentCmd", func() {
 	var (
-		sessions map[*fakecmdconf.FakeConfig2]*fakecmd.FakeSession
-		config   *fakecmdconf.FakeConfig2
 		ui       *fakeui.FakeUI
+		director *fakedir.FakeDirector
 		command  EnvironmentCmd
 	)
 
 	BeforeEach(func() {
-		sessions = map[*fakecmdconf.FakeConfig2]*fakecmd.FakeSession{}
-
-		sessionFactory := func(config cmdconf.Config) Session {
-			typedConfig, ok := config.(*fakecmdconf.FakeConfig2)
-			if !ok {
-				panic("Expected to find FakeConfig2")
-			}
-
-			for c, sess := range sessions {
-				if c.Existing == typedConfig.Existing {
-					return sess
-				}
-			}
-
-			panic("Expected to find fake session")
-		}
-
-		config = &fakecmdconf.FakeConfig2{
-			Existing: fakecmdconf.ConfigContents{
-				EnvironmentURL:    "curr-environment-url",
-				EnvironmentCACert: "curr-ca-cert",
-			},
-		}
-
 		ui = &fakeui.FakeUI{}
-
-		command = NewEnvironmentCmd(sessionFactory, config, ui)
+		director = &fakedir.FakeDirector{}
+		command = NewEnvironmentCmd(ui, director)
 	})
 
 	Describe("Run", func() {
-		var (
-			opts            EnvironmentOpts
-			updatedSession  *fakecmd.FakeSession
-			updatedConfig   *fakecmdconf.FakeConfig2
-			updatedDirector *fakedir.FakeDirector
-		)
+		act := func() error { return command.Run() }
 
-		BeforeEach(func() {
-			opts = EnvironmentOpts{}
+		It("shows director info if able to fetch it", func() {
+			info := boshdir.Info{
+				Name:    "director-name",
+				UUID:    "director-uuid",
+				Version: "director-version",
+			}
+			director.InfoReturns(info, nil)
+
+			err := act()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(ui.Table).To(Equal(boshtbl.Table{
+				Rows: [][]boshtbl.Value{
+					{
+						boshtbl.NewValueString("Name"),
+						boshtbl.NewValueString("director-name"),
+					},
+					{
+						boshtbl.NewValueString("UUID"),
+						boshtbl.NewValueString("director-uuid"),
+					},
+					{
+						boshtbl.NewValueString("Version"),
+						boshtbl.NewValueString("director-version"),
+					},
+					{
+						boshtbl.NewValueString("User"),
+						boshtbl.NewValueString("(not logged in)"),
+					},
+				},
+			}))
 		})
 
-		act := func() error { return command.Run(opts) }
+		It("returns error if director info cannot be fetched", func() {
+			director.InfoReturns(boshdir.Info{}, errors.New("fake-err"))
 
-		Context("when URL / name args are given without CA cert", func() {
-			BeforeEach(func() {
-				opts.Args.URL = "environment-url"
-				opts.Args.Alias = "environment-alias"
-
-				updatedConfig = &fakecmdconf.FakeConfig2{
-					Existing: fakecmdconf.ConfigContents{
-						EnvironmentURL:   "environment-url",
-						EnvironmentAlias: "environment-alias",
-					},
-				}
-
-				updatedDirector = &fakedir.FakeDirector{}
-
-				updatedSession = &fakecmd.FakeSession{}
-				updatedSession.DirectorReturns(updatedDirector, nil)
-				updatedSession.EnvironmentReturns("environment-url")
-
-				sessions[updatedConfig] = updatedSession
-			})
-
-			Context("when environment is reachable", func() {
-				BeforeEach(func() {
-					info := boshdir.Info{
-						Name:    "director-name",
-						UUID:    "director-uuid",
-						Version: "director-version",
-					}
-					updatedDirector.InfoReturns(info, nil)
-				})
-
-				It("sets and saves current environment", func() {
-					err := act()
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(config.Saved.EnvironmentURL).To(Equal("environment-url"))
-					Expect(config.Saved.EnvironmentAlias).To(Equal("environment-alias"))
-					Expect(config.Saved.EnvironmentCACert).To(Equal(""))
-				})
-
-				It("shows current environment and director info", func() {
-					err := act()
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(ui.Said).To(Equal([]string{"Environment set to 'environment-url'"}))
-
-					Expect(ui.Table).To(Equal(boshtbl.Table{
-						Rows: [][]boshtbl.Value{
-							{
-								boshtbl.NewValueString("Name"),
-								boshtbl.NewValueString("director-name"),
-							},
-							{
-								boshtbl.NewValueString("UUID"),
-								boshtbl.NewValueString("director-uuid"),
-							},
-							{
-								boshtbl.NewValueString("Version"),
-								boshtbl.NewValueString("director-version"),
-							},
-							{
-								boshtbl.NewValueString("User"),
-								boshtbl.NewValueString("(not logged in)"),
-							},
-						},
-					}))
-				})
-			})
-
-			Context("when environment is not reachable", func() {
-				var (
-					altUpdatedSession  *fakecmd.FakeSession
-					altUpdatedConfig   *fakecmdconf.FakeConfig2
-					altUpdatedDirector *fakedir.FakeDirector
-				)
-
-				BeforeEach(func() {
-					updatedDirector.InfoReturns(boshdir.Info{}, errors.New("fake-err"))
-
-					altUpdatedConfig = &fakecmdconf.FakeConfig2{
-						Existing: fakecmdconf.ConfigContents{
-							EnvironmentURL:    "environment-url",
-							EnvironmentAlias:  "environment-alias",
-							EnvironmentCACert: "curr-ca-cert",
-						},
-					}
-
-					altUpdatedDirector = &fakedir.FakeDirector{}
-
-					altUpdatedSession = &fakecmd.FakeSession{}
-					altUpdatedSession.DirectorReturns(altUpdatedDirector, nil)
-					altUpdatedSession.EnvironmentReturns("environment-url")
-
-					sessions[altUpdatedConfig] = altUpdatedSession
-				})
-
-				Context("when environment using existing certificate is reachable", func() {
-					BeforeEach(func() {
-						info := boshdir.Info{
-							Name:    "director-name",
-							UUID:    "director-uuid",
-							Version: "director-version",
-						}
-						altUpdatedDirector.InfoReturns(info, nil)
-					})
-
-					It("sets and saves current environment with existing certificate", func() {
-						err := act()
-						Expect(err).ToNot(HaveOccurred())
-
-						Expect(config.Saved.EnvironmentURL).To(Equal("environment-url"))
-						Expect(config.Saved.EnvironmentAlias).To(Equal("environment-alias"))
-						Expect(config.Saved.EnvironmentCACert).To(Equal("curr-ca-cert"))
-						Expect(config.Saved.Called).To(BeTrue())
-					})
-
-					It("shows current environment and director info", func() {
-						err := act()
-						Expect(err).ToNot(HaveOccurred())
-
-						Expect(ui.Said).To(Equal([]string{"Environment set to 'environment-url'"}))
-
-						Expect(ui.Table).To(Equal(boshtbl.Table{
-							Rows: [][]boshtbl.Value{
-								{
-									boshtbl.NewValueString("Name"),
-									boshtbl.NewValueString("director-name"),
-								},
-								{
-									boshtbl.NewValueString("UUID"),
-									boshtbl.NewValueString("director-uuid"),
-								},
-								{
-									boshtbl.NewValueString("Version"),
-									boshtbl.NewValueString("director-version"),
-								},
-								{
-									boshtbl.NewValueString("User"),
-									boshtbl.NewValueString("(not logged in)"),
-								},
-							},
-						}))
-					})
-				})
-
-				Context("when environment using existing certificate is not reachable", func() {
-					BeforeEach(func() {
-						altUpdatedDirector.InfoReturns(boshdir.Info{}, errors.New("fake-alt-err"))
-					})
-
-					It("returns an original error and does not save config", func() {
-						err := act()
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("fake-err"))
-
-						Expect(config.Saved.Called).To(BeFalse())
-					})
-				})
-			})
-		})
-
-		Context("when URL / name / CA cert args are given", func() {
-			BeforeEach(func() {
-				opts.Args.URL = "environment-url"
-				opts.Args.Alias = "environment-alias"
-				opts.CACert = "environment-ca-cert"
-
-				updatedConfig = &fakecmdconf.FakeConfig2{
-					Existing: fakecmdconf.ConfigContents{
-						EnvironmentURL:    "environment-url",
-						EnvironmentAlias:  "environment-alias",
-						EnvironmentCACert: "environment-ca-cert",
-					},
-				}
-
-				updatedDirector = &fakedir.FakeDirector{}
-
-				updatedSession = &fakecmd.FakeSession{}
-				updatedSession.DirectorReturns(updatedDirector, nil)
-				updatedSession.EnvironmentReturns("environment-url")
-
-				sessions[updatedConfig] = updatedSession
-			})
-
-			Context("when environment is reachable", func() {
-				BeforeEach(func() {
-					info := boshdir.Info{
-						Name:    "director-name",
-						UUID:    "director-uuid",
-						Version: "director-version",
-					}
-					updatedDirector.InfoReturns(info, nil)
-				})
-
-				It("sets and saves environment environment", func() {
-					err := act()
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(config.Saved.EnvironmentURL).To(Equal("environment-url"))
-					Expect(config.Saved.EnvironmentAlias).To(Equal("environment-alias"))
-					Expect(config.Saved.EnvironmentCACert).To(Equal("environment-ca-cert"))
-				})
-
-				It("shows current environment and director info", func() {
-					err := act()
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(ui.Said).To(Equal([]string{"Environment set to 'environment-url'"}))
-
-					Expect(ui.Table).To(Equal(boshtbl.Table{
-						Rows: [][]boshtbl.Value{
-							{
-								boshtbl.NewValueString("Name"),
-								boshtbl.NewValueString("director-name"),
-							},
-							{
-								boshtbl.NewValueString("UUID"),
-								boshtbl.NewValueString("director-uuid"),
-							},
-							{
-								boshtbl.NewValueString("Version"),
-								boshtbl.NewValueString("director-version"),
-							},
-							{
-								boshtbl.NewValueString("User"),
-								boshtbl.NewValueString("(not logged in)"),
-							},
-						},
-					}))
-				})
-			})
-
-			Context("when environment is not reachable", func() {
-				BeforeEach(func() {
-					updatedDirector.InfoReturns(boshdir.Info{}, errors.New("fake-err"))
-				})
-
-				It("returns an error and does not save config", func() {
-					err := act()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-err"))
-
-					Expect(config.Saved.Called).To(BeFalse())
-				})
-			})
-		})
-
-		Context("when no args are given", func() {
-			var (
-				director *fakedir.FakeDirector
-			)
-
-			BeforeEach(func() {
-				director = &fakedir.FakeDirector{}
-
-				initialSession := &fakecmd.FakeSession{}
-				initialSession.DirectorReturns(director, nil)
-				initialSession.EnvironmentReturns("environment-url")
-
-				sessions[config] = initialSession
-			})
-
-			It("shows current environment and director info", func() {
-				info := boshdir.Info{
-					Name:    "director-name",
-					UUID:    "director-uuid",
-					Version: "director-version",
-				}
-
-				director.InfoReturns(info, nil)
-
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(ui.Said).To(Equal([]string{"Current environment is 'environment-url'"}))
-
-				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Rows: [][]boshtbl.Value{
-						{
-							boshtbl.NewValueString("Name"),
-							boshtbl.NewValueString("director-name"),
-						},
-						{
-							boshtbl.NewValueString("UUID"),
-							boshtbl.NewValueString("director-uuid"),
-						},
-						{
-							boshtbl.NewValueString("Version"),
-							boshtbl.NewValueString("director-version"),
-						},
-						{
-							boshtbl.NewValueString("User"),
-							boshtbl.NewValueString("(not logged in)"),
-						},
-					},
-				}))
-			})
-
-			It("does not save config", func() {
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(config.Saved).To(BeNil())
-			})
-
-			It("returns error when cannot fetch director info", func() {
-				director.InfoReturns(boshdir.Info{}, errors.New("fake-err"))
-
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
+			err := act()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
 	})
 })

--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -39,7 +39,8 @@ func (f Factory) New(args []string) (Cmd, error) {
 			}
 		}
 
-		if opts, ok := command.(*EnvironmentOpts); ok {
+		if opts, ok := command.(*AliasEnvOpts); ok {
+			opts.URL = boshOpts.EnvironmentOpt
 			opts.CACert = boshOpts.CACertOpt
 		}
 

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -59,7 +59,8 @@ var _ = Describe("Factory", func() {
 			"deployment":            []string{},
 			"deployments":           []string{},
 			"disks":                 []string{},
-			"environment":           []string{"url", "alias"},
+			"alias-env":             []string{"alias"},
+			"environment":           []string{},
 			"environments":          []string{},
 			"errands":               []string{},
 			"events":                []string{},
@@ -167,12 +168,20 @@ var _ = Describe("Factory", func() {
 		})
 	})
 
-	Describe("environment command", func() {
-		It("is passed the global CA cert", func() {
-			cmd, err := factory.New([]string{"environment", "--ca-cert", "ca-cert"})
+	Describe("alias-env command", func() {
+		It("is passed global environment URL", func() {
+			cmd, err := factory.New([]string{"alias-env", "-e", "env", "alias"})
 			Expect(err).ToNot(HaveOccurred())
 
-			opts := cmd.Opts.(*EnvironmentOpts)
+			opts := cmd.Opts.(*AliasEnvOpts)
+			Expect(opts.URL).To(Equal("env"))
+		})
+
+		It("is passed the global CA cert", func() {
+			cmd, err := factory.New([]string{"alias-env", "--ca-cert", "ca-cert", "alias"})
+			Expect(err).ToNot(HaveOccurred())
+
+			opts := cmd.Opts.(*AliasEnvOpts)
 			Expect(opts.CACert).To(Equal("ca-cert"))
 		})
 	})

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -33,13 +33,12 @@ type BoshOpts struct {
 
 	// -----> Director management
 
-	// Original bosh-init
-	CreateEnv CreateEnvOpts `command:"create-env" description:"Create or update BOSH environment"`
-	DeleteEnv DeleteEnvOpts `command:"delete-env" description:"Delete BOSH environment"`
-
 	// Environments
-	Environment  EnvironmentOpts  `command:"environment"  alias:"env"  description:"Set or show current environment"`
+	Environment  EnvironmentOpts  `command:"environment"  alias:"env"  description:"Show environment"`
 	Environments EnvironmentsOpts `command:"environments" alias:"envs" description:"List environments"`
+	CreateEnv    CreateEnvOpts    `command:"create-env"                description:"Create or update BOSH environment"`
+	DeleteEnv    DeleteEnvOpts    `command:"delete-env"                description:"Delete BOSH environment"`
+	AliasEnv     AliasEnvOpts     `command:"alias-env"                 description:"Alias environment to save URL and CA certificate"`
 
 	// Authentication
 	LogIn  LogInOpts  `command:"log-in"  alias:"l" description:"Log in"`
@@ -64,7 +63,7 @@ type BoshOpts struct {
 	UpdateRuntimeConfig UpdateRuntimeConfigOpts `command:"update-runtime-config" alias:"urc" description:"Update current runtime config"`
 
 	// Deployments
-	Deployment       DeploymentOpts       `command:"deployment"        alias:"dep"             description:"Set or show current deployment"`
+	Deployment       DeploymentOpts       `command:"deployment"        alias:"dep"             description:"Show deployment"`
 	Deployments      DeploymentsOpts      `command:"deployments"       alias:"ds" alias:"deps" description:"List deployments"`
 	DeleteDeployment DeleteDeploymentOpts `command:"delete-deployment" alias:"deld"            description:"Delete deployment"`
 
@@ -163,20 +162,24 @@ type DeleteEnvArgs struct {
 
 // Environment
 type EnvironmentOpts struct {
-	Args EnvironmentArgs `positional-args:"true"`
+	cmd
+}
 
+type EnvironmentsOpts struct {
+	cmd
+}
+
+type AliasEnvOpts struct {
+	Args AliasEnvArgs `positional-args:"true" required:"true"`
+
+	URL    string
 	CACert string
 
 	cmd
 }
 
-type EnvironmentArgs struct {
-	URL   string `positional-arg-name:"URL"   description:"Director URL (e.g.: https://192.168.50.4:25555 or 192.168.50.4)"`
+type AliasEnvArgs struct {
 	Alias string `positional-arg-name:"ALIAS" description:"Environment alias"`
-}
-
-type EnvironmentsOpts struct {
-	cmd
 }
 
 type LogInOpts struct {

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Opts", func() {
 		Describe("Environment", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Environment", opts)).To(Equal(
-					`command:"environment" alias:"env" description:"Set or show current environment"`,
+					`command:"environment" alias:"env" description:"Show environment"`,
 				))
 			})
 		})
@@ -331,7 +331,7 @@ var _ = Describe("Opts", func() {
 		Describe("Deployment", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Deployment", opts)).To(Equal(
-					`command:"deployment" alias:"dep" description:"Set or show current deployment"`,
+					`command:"deployment" alias:"dep" description:"Show deployment"`,
 				))
 			})
 		})
@@ -741,33 +741,25 @@ var _ = Describe("Opts", func() {
 		})
 	})
 
-	Describe("EnvironmentOpts", func() {
-		var opts *EnvironmentOpts
+	Describe("AliasEnvOpts", func() {
+		var opts *AliasEnvOpts
 
 		BeforeEach(func() {
-			opts = &EnvironmentOpts{}
+			opts = &AliasEnvOpts{}
 		})
 
 		Describe("Args", func() {
 			It("contains desired values", func() {
-				Expect(getStructTagForName("Args", opts)).To(Equal(`positional-args:"true"`))
+				Expect(getStructTagForName("Args", opts)).To(Equal(`positional-args:"true" required:"true"`))
 			})
 		})
 	})
 
-	Describe("EnvironmentArgs", func() {
-		var args *EnvironmentArgs
+	Describe("AliasEnvArgs", func() {
+		var args *AliasEnvArgs
 
 		BeforeEach(func() {
-			args = &EnvironmentArgs{}
-		})
-
-		Describe("URL", func() {
-			It("contains desired values", func() {
-				Expect(getStructTagForName("URL", args)).To(Equal(
-					`positional-arg-name:"URL" description:"Director URL (e.g.: https://192.168.50.4:25555 or 192.168.50.4)"`,
-				))
-			})
+			args = &AliasEnvArgs{}
 		})
 
 		Describe("Alias", func() {


### PR DESCRIPTION
After chatting with tom then amit, flow goes something like this:

```
./pre-prod $ bosh create-env manifest.yml -l ...
./pre-prod $ bosh alias-env pre-prod -e https://my-ip --ca-cert ./ca.crt
./pre-prod $ bosh envs
./pre-prod $ bosh -e pre-prod upload-stemcell ...
...
```

Of course one does not have to `alias-env` and can provide `-e` and optionally `--ca-cert` (or set `BOSH_ENVIRONMENT` and `BOSH_CA_CERT`) to all commands.