### PR TITLE
Rename final_name -> name in config/final.yml

### DIFF
--- a/acceptance/assets/sample-release/config/final.yml
+++ b/acceptance/assets/sample-release/config/final.yml
@@ -1,2 +1,2 @@
 ---
-final_name: sample-release
+name: sample-release

--- a/releasedir/fs_config.go
+++ b/releasedir/fs_config.go
@@ -9,7 +9,7 @@ import (
 /*
 # final.yml
 ---
-final_name: cf
+name: cf
 min_cli_version: 1.5.0.pre.1001
 blobstore:
   provider: s3
@@ -29,7 +29,7 @@ type FSConfig struct {
 }
 
 type fsConfigPublicSchema struct {
-	FinalName string                   `yaml:"final_name"`
+	Name      string                   `yaml:"name"`
 	Blobstore fsConfigSchema_Blobstore `yaml:"blobstore,omitempty"`
 }
 
@@ -46,27 +46,27 @@ func NewFSConfig(publicPath, privatePath string, fs boshsys.FileSystem) FSConfig
 	return FSConfig{publicPath: publicPath, privatePath: privatePath, fs: fs}
 }
 
-func (c FSConfig) FinalName() (string, error) {
+func (c FSConfig) Name() (string, error) {
 	publicSchema, _, err := c.read()
 	if err != nil {
 		return "", err
 	}
 
-	if len(publicSchema.FinalName) == 0 {
+	if len(publicSchema.Name) == 0 {
 		return "", bosherr.Errorf(
-			"Expected non-empty 'final_name' in config '%s'", c.publicPath)
+			"Expected non-empty 'name' in config '%s'", c.publicPath)
 	}
 
-	return publicSchema.FinalName, nil
+	return publicSchema.Name, nil
 }
 
-func (c FSConfig) SaveFinalName(name string) error {
+func (c FSConfig) SaveName(name string) error {
 	publicSchema, _, err := c.read()
 	if err != nil {
 		return err
 	}
 
-	publicSchema.FinalName = name
+	publicSchema.Name = name
 
 	bytes, err := yaml.Marshal(publicSchema)
 	if err != nil {

--- a/releasedir/fs_config_test.go
+++ b/releasedir/fs_config_test.go
@@ -21,11 +21,11 @@ var _ = Describe("FSConfig", func() {
 		config = NewFSConfig("/dir/public.yml", "/dir/private.yml", fs)
 	})
 
-	Describe("FinalName", func() {
+	Describe("Name", func() {
 		It("returns final name from public config", func() {
-			fs.WriteFileString("/dir/public.yml", "final_name: name")
+			fs.WriteFileString("/dir/public.yml", "name: name")
 
-			name, err := config.FinalName()
+			name, err := config.Name()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(name).To(Equal("name"))
 		})
@@ -33,16 +33,16 @@ var _ = Describe("FSConfig", func() {
 		It("returns error if name is empty", func() {
 			fs.WriteFileString("/dir/public.yml", "")
 
-			_, err := config.FinalName()
+			_, err := config.Name()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Expected non-empty 'final_name' in config '/dir/public.yml'"))
+			Expect(err.Error()).To(Equal("Expected non-empty 'name' in config '/dir/public.yml'"))
 		})
 
 		It("returns error if cannot read public config", func() {
 			fs.WriteFileString("/dir/public.yml", "-")
 			fs.RegisterReadFileError("/dir/public.yml", errors.New("fake-err"))
 
-			_, err := config.FinalName()
+			_, err := config.Name()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
@@ -50,7 +50,7 @@ var _ = Describe("FSConfig", func() {
 		It("returns error if cannot unmarshal public config", func() {
 			fs.WriteFileString("/dir/public.yml", "-")
 
-			_, err := config.FinalName()
+			_, err := config.Name()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("line 1"))
 		})
@@ -59,7 +59,7 @@ var _ = Describe("FSConfig", func() {
 			fs.WriteFileString("/dir/private.yml", "-")
 			fs.RegisterReadFileError("/dir/private.yml", errors.New("fake-err"))
 
-			_, err := config.FinalName()
+			_, err := config.Name()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
@@ -67,7 +67,7 @@ var _ = Describe("FSConfig", func() {
 		It("returns error if cannot unmarshal private config", func() {
 			fs.WriteFileString("/dir/private.yml", "-")
 
-			_, err := config.FinalName()
+			_, err := config.Name()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("line 1"))
 		})
@@ -149,38 +149,38 @@ var _ = Describe("FSConfig", func() {
 		})
 	})
 
-	Describe("SaveFinalName", func() {
+	Describe("SaveName", func() {
 		It("writes new config with name if config does not exist", func() {
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(fs.ReadFileString("/dir/public.yml")).To(Equal("final_name: new-name\n"))
+			Expect(fs.ReadFileString("/dir/public.yml")).To(Equal("name: new-name\n"))
 		})
 
 		It("adds name to public config keeping other entries", func() {
-			fs.WriteFileString("/dir/public.yml", "final_name: name")
+			fs.WriteFileString("/dir/public.yml", "name: name")
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(fs.ReadFileString("/dir/public.yml")).To(Equal("final_name: new-name\n"))
+			Expect(fs.ReadFileString("/dir/public.yml")).To(Equal("name: new-name\n"))
 		})
 
 		It("overwrites existing name in public config keeping other entries", func() {
-			fs.WriteFileString("/dir/public.yml", "final_name: name\nblobstore: {provider: s3}")
+			fs.WriteFileString("/dir/public.yml", "name: name\nblobstore: {provider: s3}")
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(fs.ReadFileString("/dir/public.yml")).To(Equal(
-				"final_name: new-name\nblobstore:\n  provider: s3\n"))
+				"name: new-name\nblobstore:\n  provider: s3\n"))
 		})
 
 		It("returns error if cannot read public config", func() {
 			fs.WriteFileString("/dir/public.yml", "-")
 			fs.RegisterReadFileError("/dir/public.yml", errors.New("fake-err"))
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
@@ -188,7 +188,7 @@ var _ = Describe("FSConfig", func() {
 		It("returns error if cannot unmarshal public config", func() {
 			fs.WriteFileString("/dir/public.yml", "-")
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("line 1"))
 		})
@@ -197,7 +197,7 @@ var _ = Describe("FSConfig", func() {
 			fs.WriteFileString("/dir/private.yml", "-")
 			fs.RegisterReadFileError("/dir/private.yml", errors.New("fake-err"))
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
@@ -205,7 +205,7 @@ var _ = Describe("FSConfig", func() {
 		It("returns error if cannot unmarshal private config", func() {
 			fs.WriteFileString("/dir/private.yml", "-")
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("line 1"))
 		})
@@ -213,7 +213,7 @@ var _ = Describe("FSConfig", func() {
 		It("returns error if cannot write public config", func() {
 			fs.WriteFileError = errors.New("fake-err")
 
-			err := config.SaveFinalName("new-name")
+			err := config.SaveName("new-name")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})

--- a/releasedir/fs_generator_test.go
+++ b/releasedir/fs_generator_test.go
@@ -24,7 +24,7 @@ var _ = Describe("FSGenerator", func() {
 
 	Describe("GenerateJob", func() {
 		It("makes job directory", func() {
-			fs.WriteFileString("/dir/public.yml", "final_name: name")
+			fs.WriteFileString("/dir/public.yml", "name: name")
 
 			err := gen.GenerateJob("job1")
 			Expect(err).ToNot(HaveOccurred())
@@ -63,7 +63,7 @@ properties: {}
 
 	Describe("GeneratePackage", func() {
 		It("makes package directory", func() {
-			fs.WriteFileString("/dir/public.yml", "final_name: name")
+			fs.WriteFileString("/dir/public.yml", "name: name")
 
 			err := gen.GeneratePackage("pkg1")
 			Expect(err).ToNot(HaveOccurred())

--- a/releasedir/fs_release_dir.go
+++ b/releasedir/fs_release_dir.go
@@ -82,9 +82,9 @@ func (d FSReleaseDir) Init(git bool) error {
 		}
 	}
 
-	finalName := strings.TrimSuffix(gopath.Base(d.dirPath), "-release")
+	name := strings.TrimSuffix(gopath.Base(d.dirPath), "-release")
 
-	err := d.config.SaveFinalName(finalName)
+	err := d.config.SaveName(name)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (d FSReleaseDir) Reset() error {
 }
 
 func (d FSReleaseDir) DefaultName() (string, error) {
-	return d.config.FinalName()
+	return d.config.Name()
 }
 
 func (d FSReleaseDir) NextFinalVersion(name string) (semver.Version, error) {

--- a/releasedir/fs_release_dir_test.go
+++ b/releasedir/fs_release_dir_test.go
@@ -77,8 +77,8 @@ var _ = Describe("FSGenerator", func() {
 			err := releaseDir.Init(true)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(config.SaveFinalNameCallCount()).To(Equal(1))
-			Expect(config.SaveFinalNameArgsForCall(0)).To(Equal("dir"))
+			Expect(config.SaveNameCallCount()).To(Equal(1))
+			Expect(config.SaveNameArgsForCall(0)).To(Equal("dir"))
 		})
 
 		It("saves release name to directory base name stripping '-release' suffix from the name", func() {
@@ -88,12 +88,12 @@ var _ = Describe("FSGenerator", func() {
 			err := releaseDir.Init(true)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(config.SaveFinalNameCallCount()).To(Equal(1))
-			Expect(config.SaveFinalNameArgsForCall(0)).To(Equal("dir"))
+			Expect(config.SaveNameCallCount()).To(Equal(1))
+			Expect(config.SaveNameArgsForCall(0)).To(Equal("dir"))
 		})
 
 		It("returns error if saving final name fails", func() {
-			config.SaveFinalNameReturns(errors.New("fake-err"))
+			config.SaveNameReturns(errors.New("fake-err"))
 
 			err := releaseDir.Init(true)
 			Expect(err).To(HaveOccurred())
@@ -185,7 +185,7 @@ var _ = Describe("FSGenerator", func() {
 
 	Describe("DefaultName", func() {
 		It("delegates to config", func() {
-			config.FinalNameReturns("name", errors.New("fake-err"))
+			config.NameReturns("name", errors.New("fake-err"))
 
 			name, err := releaseDir.DefaultName()
 			Expect(name).To(Equal("name"))
@@ -349,7 +349,7 @@ var _ = Describe("FSGenerator", func() {
 		)
 
 		BeforeEach(func() {
-			config.FinalNameReturns("rel1", nil)
+			config.NameReturns("rel1", nil)
 
 			expectedRelease = &fakerel.FakeRelease{
 				NameStub: func() string { return "rel1" },
@@ -483,7 +483,7 @@ var _ = Describe("FSGenerator", func() {
 		})
 
 		It("retuns error if cannot determine final name", func() {
-			config.FinalNameReturns("", errors.New("fake-err"))
+			config.NameReturns("", errors.New("fake-err"))
 
 			_, err := releaseDir.LastRelease()
 			Expect(err).To(HaveOccurred())

--- a/releasedir/interfaces.go
+++ b/releasedir/interfaces.go
@@ -43,8 +43,8 @@ type ReleaseDir interface {
 //go:generate counterfeiter . Config
 
 type Config interface {
-	FinalName() (string, error)
-	SaveFinalName(string) error
+	Name() (string, error)
+	SaveName(string) error
 
 	Blobstore() (string, map[string]interface{}, error)
 }

--- a/releasedir/releasedirfakes/fake_config.go
+++ b/releasedir/releasedirfakes/fake_config.go
@@ -8,19 +8,19 @@ import (
 )
 
 type FakeConfig struct {
-	FinalNameStub        func() (string, error)
-	finalNameMutex       sync.RWMutex
-	finalNameArgsForCall []struct{}
-	finalNameReturns     struct {
+	NameStub        func() (string, error)
+	nameMutex       sync.RWMutex
+	nameArgsForCall []struct{}
+	nameReturns     struct {
 		result1 string
 		result2 error
 	}
-	SaveFinalNameStub        func(string) error
-	saveFinalNameMutex       sync.RWMutex
-	saveFinalNameArgsForCall []struct {
+	SaveNameStub        func(string) error
+	saveNameMutex       sync.RWMutex
+	saveNameArgsForCall []struct {
 		arg1 string
 	}
-	saveFinalNameReturns struct {
+	saveNameReturns struct {
 		result1 error
 	}
 	BlobstoreStub        func() (string, map[string]interface{}, error)
@@ -35,61 +35,61 @@ type FakeConfig struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeConfig) FinalName() (string, error) {
-	fake.finalNameMutex.Lock()
-	fake.finalNameArgsForCall = append(fake.finalNameArgsForCall, struct{}{})
-	fake.recordInvocation("FinalName", []interface{}{})
-	fake.finalNameMutex.Unlock()
-	if fake.FinalNameStub != nil {
-		return fake.FinalNameStub()
+func (fake *FakeConfig) Name() (string, error) {
+	fake.nameMutex.Lock()
+	fake.nameArgsForCall = append(fake.nameArgsForCall, struct{}{})
+	fake.recordInvocation("Name", []interface{}{})
+	fake.nameMutex.Unlock()
+	if fake.NameStub != nil {
+		return fake.NameStub()
 	} else {
-		return fake.finalNameReturns.result1, fake.finalNameReturns.result2
+		return fake.nameReturns.result1, fake.nameReturns.result2
 	}
 }
 
-func (fake *FakeConfig) FinalNameCallCount() int {
-	fake.finalNameMutex.RLock()
-	defer fake.finalNameMutex.RUnlock()
-	return len(fake.finalNameArgsForCall)
+func (fake *FakeConfig) NameCallCount() int {
+	fake.nameMutex.RLock()
+	defer fake.nameMutex.RUnlock()
+	return len(fake.nameArgsForCall)
 }
 
-func (fake *FakeConfig) FinalNameReturns(result1 string, result2 error) {
-	fake.FinalNameStub = nil
-	fake.finalNameReturns = struct {
+func (fake *FakeConfig) NameReturns(result1 string, result2 error) {
+	fake.NameStub = nil
+	fake.nameReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeConfig) SaveFinalName(arg1 string) error {
-	fake.saveFinalNameMutex.Lock()
-	fake.saveFinalNameArgsForCall = append(fake.saveFinalNameArgsForCall, struct {
+func (fake *FakeConfig) SaveName(arg1 string) error {
+	fake.saveNameMutex.Lock()
+	fake.saveNameArgsForCall = append(fake.saveNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	fake.recordInvocation("SaveFinalName", []interface{}{arg1})
-	fake.saveFinalNameMutex.Unlock()
-	if fake.SaveFinalNameStub != nil {
-		return fake.SaveFinalNameStub(arg1)
+	fake.recordInvocation("SaveName", []interface{}{arg1})
+	fake.saveNameMutex.Unlock()
+	if fake.SaveNameStub != nil {
+		return fake.SaveNameStub(arg1)
 	} else {
-		return fake.saveFinalNameReturns.result1
+		return fake.saveNameReturns.result1
 	}
 }
 
-func (fake *FakeConfig) SaveFinalNameCallCount() int {
-	fake.saveFinalNameMutex.RLock()
-	defer fake.saveFinalNameMutex.RUnlock()
-	return len(fake.saveFinalNameArgsForCall)
+func (fake *FakeConfig) SaveNameCallCount() int {
+	fake.saveNameMutex.RLock()
+	defer fake.saveNameMutex.RUnlock()
+	return len(fake.saveNameArgsForCall)
 }
 
-func (fake *FakeConfig) SaveFinalNameArgsForCall(i int) string {
-	fake.saveFinalNameMutex.RLock()
-	defer fake.saveFinalNameMutex.RUnlock()
-	return fake.saveFinalNameArgsForCall[i].arg1
+func (fake *FakeConfig) SaveNameArgsForCall(i int) string {
+	fake.saveNameMutex.RLock()
+	defer fake.saveNameMutex.RUnlock()
+	return fake.saveNameArgsForCall[i].arg1
 }
 
-func (fake *FakeConfig) SaveFinalNameReturns(result1 error) {
-	fake.SaveFinalNameStub = nil
-	fake.saveFinalNameReturns = struct {
+func (fake *FakeConfig) SaveNameReturns(result1 error) {
+	fake.SaveNameStub = nil
+	fake.saveNameReturns = struct {
 		result1 error
 	}{result1}
 }
@@ -124,10 +124,10 @@ func (fake *FakeConfig) BlobstoreReturns(result1 string, result2 map[string]inte
 func (fake *FakeConfig) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.finalNameMutex.RLock()
-	defer fake.finalNameMutex.RUnlock()
-	fake.saveFinalNameMutex.RLock()
-	defer fake.saveFinalNameMutex.RUnlock()
+	fake.nameMutex.RLock()
+	defer fake.nameMutex.RUnlock()
+	fake.saveNameMutex.RLock()
+	defer fake.saveNameMutex.RUnlock()
 	fake.blobstoreMutex.RLock()
 	defer fake.blobstoreMutex.RUnlock()
 	return fake.invocations


### PR DESCRIPTION
The field is already in a file named "final" and we no longer need to differentiate from a dev name.

Backwards incompatible.

Thoughts?