### PR TITLE
`bosh create-env` allows variable interpolation in middle of value

### DIFF
--- a/director/template/template.go
+++ b/director/template/template.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var templateFormatRegex = regexp.MustCompile(`^\(\((!?[-\w\p{L}]+)\)\)$`)
+var templateFormatRegex = regexp.MustCompile(`\(\((!?[-\w\p{L}]+)\)\)`)
 
 type Template struct {
 	bytes []byte
@@ -39,7 +39,10 @@ func (t Template) Evaluate(vars Variables, ops patch.Ops, opts EvaluateOpts) ([]
 
 	missingVars := map[string]struct{}{}
 
-	obj = t.interpolate(obj, vars, opts, missingVars)
+	obj, err = t.interpolate(obj, vars, opts, missingVars)
+	if err != nil {
+		return []byte{}, err
+	}
 
 	if len(missingVars) > 0 {
 		var missingVarKeys []string
@@ -61,54 +64,79 @@ func (t Template) Evaluate(vars Variables, ops patch.Ops, opts EvaluateOpts) ([]
 	return bytes, nil
 }
 
-func (t Template) interpolate(node interface{}, vars Variables, opts EvaluateOpts, missingVars map[string]struct{}) interface{} {
+func (t Template) interpolate(node interface{}, vars Variables, opts EvaluateOpts, missingVars map[string]struct{}) (interface{}, error) {
 	switch node.(type) {
 	case map[interface{}]interface{}:
 		nodeMap := node.(map[interface{}]interface{})
 
 		for k, v := range nodeMap {
-			evaluatedValue := t.interpolate(v, vars, opts, missingVars)
-
-			if keyAsString, ok := k.(string); ok {
-				if key, eval := t.needsEvaluation(keyAsString); eval {
-					if foundVarKey, exists := vars[key]; exists {
-						delete(nodeMap, k)
-						k = foundVarKey
-					} else if opts.ExpectAllKeys {
-						missingVars[key] = struct{}{}
-					}
-				}
+			evaluatedValue, err := t.interpolate(v, vars, opts, missingVars)
+			if err != nil {
+				return nil, err
 			}
 
-			nodeMap[k] = evaluatedValue
+			evaluatedKey, err := t.interpolate(k, vars, opts, missingVars)
+			if err != nil {
+				return nil, err
+			}
+			delete(nodeMap, k) // delete in case key has changed
+			nodeMap[evaluatedKey] = evaluatedValue
 		}
-
 	case []interface{}:
 		nodeArray := node.([]interface{})
 
 		for i, x := range nodeArray {
-			nodeArray[i] = t.interpolate(x, vars, opts, missingVars)
+			var err error
+			nodeArray[i], err = t.interpolate(x, vars, opts, missingVars)
+			if err != nil {
+				return nil, err
+			}
 		}
-
 	case string:
-		if key, found := t.needsEvaluation(node.(string)); found {
+		nodeString := node.(string)
+
+		for key, placeholders := range t.keysToPlaceholders(nodeString) {
 			if foundVar, exists := vars[key]; exists {
-				return foundVar
+				// ensure that value type is preserved when replacing the entire field
+				replaceEntireField := (nodeString == fmt.Sprintf("((%s))", key) || nodeString == fmt.Sprintf("((!%s))", key))
+				if replaceEntireField {
+					return foundVar, nil
+				}
+
+				for _, placeholder := range placeholders {
+					switch foundVar.(type) {
+					case string, int, int16, int32, int64, uint, uint16, uint32, uint64:
+						nodeString = strings.Replace(nodeString, placeholder, fmt.Sprintf("%v", foundVar), 1)
+					default:
+						return nil, fmt.Errorf("Invalid type '%T' for value '%v' and key '%s'. Supported types for interpolation within a string are integers and strings.", foundVar, foundVar, key)
+					}
+				}
 			} else if opts.ExpectAllKeys {
 				missingVars[key] = struct{}{}
 			}
 		}
+
+		return nodeString, nil
 	}
 
-	return node
+	return node, nil
 }
 
-func (t Template) needsEvaluation(value string) (string, bool) {
-	found := templateFormatRegex.FindAllSubmatch([]byte(value), 1)
+func (t Template) keysToPlaceholders(value string) map[string][]string {
+	matches := templateFormatRegex.FindAllSubmatch([]byte(value), -1)
 
-	if len(found) != 0 && len(found[0]) != 0 {
-		return strings.TrimPrefix(string(found[0][1]), "!"), true
+	keysToPlaceholders := map[string][]string{}
+	if matches == nil {
+		return keysToPlaceholders
 	}
 
-	return "", false
+	for _, match := range matches {
+		capture := match[1]
+		key := strings.TrimPrefix(string(capture), "!")
+		if len(key) > 0 {
+			keysToPlaceholders[key] = append(keysToPlaceholders[key], fmt.Sprintf("((%s))", capture))
+		}
+	}
+
+	return keysToPlaceholders
 }


### PR DESCRIPTION
- the `agent.mbus` property is a good example of the usefulness of this
feature

```yaml
properties:
  agent:
    # final value = nats://nats:nats-password@10.0.0.6:4222
    mbus: "nats://nats:((nats_password))@((private_ip)):4222"
```

[#134030589](https://www.pivotaltracker.com/story/show/134030589)

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>