### PR TITLE
Include logical name and sha1 when uploading blobs

### DIFF
--- a/releasedir/index/fs_index.go
+++ b/releasedir/index/fs_index.go
@@ -146,7 +146,7 @@ func (i FSIndex) Add(name, fingerprint, path, sha1 string) (string, string, erro
 
 	i.reporter.IndexEntryStartedAdding(i.name, desc)
 
-	blobID, blobPath, err := i.blobs.Add(path, sha1)
+	blobID, blobPath, err := i.blobs.Add(desc, path, sha1)
 	if err != nil {
 		i.reporter.IndexEntryFinishedAdding(i.name, desc, err)
 		return "", "", err

--- a/releasedir/index/fs_index_blobs.go
+++ b/releasedir/index/fs_index_blobs.go
@@ -92,7 +92,7 @@ func (c FSIndexBlobs) Get(name string, blobID string, sha1 string) (string, erro
 
 // Add adds file to cache and blobstore but does not guarantee
 // that file have expected SHA1 when retrieved later.
-func (c FSIndexBlobs) Add(path, sha1 string) (string, string, error) {
+func (c FSIndexBlobs) Add(name, path, sha1 string) (string, string, error) {
 	dstPath, err := c.blobPath(sha1)
 	if err != nil {
 		return "", "", err
@@ -106,17 +106,17 @@ func (c FSIndexBlobs) Add(path, sha1 string) (string, string, error) {
 	}
 
 	if c.blobstore != nil {
-		desc := path
+		desc := fmt.Sprintf("sha1=%s", sha1)
 
-		c.reporter.IndexEntryUploadStarted("", desc)
+		c.reporter.IndexEntryUploadStarted(name, desc)
 
 		blobID, _, err := c.blobstore.Create(path)
 		if err != nil {
-			c.reporter.IndexEntryUploadFinished("", desc, err)
+			c.reporter.IndexEntryUploadFinished(name, desc, err)
 			return "", "", bosherr.WrapErrorf(err, "Creating blob for path '%s'", path)
 		}
 
-		c.reporter.IndexEntryUploadFinished("", desc, nil)
+		c.reporter.IndexEntryUploadFinished(name, desc, nil)
 
 		return blobID, dstPath, nil
 	}

--- a/releasedir/index/fs_index_blobs_test.go
+++ b/releasedir/index/fs_index_blobs_test.go
@@ -269,7 +269,7 @@ var _ = Describe("FSIndexBlobs", func() {
 
 		itCopiesFileIntoDir := func() {
 			It("copies file into cache dir", func() {
-				blobID, path, err := blobs.Add("/tmp/sha1", "sha1")
+				blobID, path, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(blobID).To(Equal(""))
 				Expect(path).To(Equal("/dir/sub-dir/sha1"))
@@ -280,7 +280,7 @@ var _ = Describe("FSIndexBlobs", func() {
 			It("keeps existing file in the cache directory if it's already there", func() {
 				fs.WriteFileString("/dir/sub-dir/sha1", "other")
 
-				blobID, path, err := blobs.Add("/tmp/sha1", "sha1")
+				blobID, path, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(blobID).To(Equal(""))
 				Expect(path).To(Equal("/dir/sub-dir/sha1"))
@@ -292,7 +292,7 @@ var _ = Describe("FSIndexBlobs", func() {
 				fs.ExpandPathExpanded = "/full-dir"
 				fs.WriteFileString("/full-dir/sha1", "file")
 
-				_, _, err := blobs.Add("/tmp/sha1", "sha1")
+				_, _, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(fs.ExpandPathPath).To(Equal("/dir/sub-dir"))
@@ -301,7 +301,7 @@ var _ = Describe("FSIndexBlobs", func() {
 			It("returns error if expanding directory path fails", func() {
 				fs.ExpandPathErr = errors.New("fake-err")
 
-				_, _, err := blobs.Add("/tmp/sha1", "sha1")
+				_, _, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-err"))
 			})
@@ -309,7 +309,7 @@ var _ = Describe("FSIndexBlobs", func() {
 			It("returns error if creating directory fails", func() {
 				fs.MkdirAllError = errors.New("fake-err")
 
-				_, _, err := blobs.Add("/tmp/sha1", "sha1")
+				_, _, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-err"))
 			})
@@ -334,7 +334,7 @@ var _ = Describe("FSIndexBlobs", func() {
 			It("uploads blob and returns blob id", func() {
 				blobstore.CreateBlobID = "blob-id"
 
-				blobID, path, err := blobs.Add("/tmp/sha1", "sha1")
+				blobID, path, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(blobID).To(Equal("blob-id"))
 				Expect(path).To(Equal("/dir/sub-dir/sha1"))
@@ -345,19 +345,19 @@ var _ = Describe("FSIndexBlobs", func() {
 				Expect(reporter.IndexEntryUploadFinishedCallCount()).To(Equal(1))
 
 				kind, desc := reporter.IndexEntryUploadStartedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("/tmp/sha1"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 
 				kind, desc, err = reporter.IndexEntryUploadFinishedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("/tmp/sha1"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 				Expect(err).To(BeNil())
 			})
 
 			It("returns error if uploading blob fails", func() {
 				blobstore.CreateErr = errors.New("fake-err")
 
-				_, _, err := blobs.Add("/tmp/sha1", "sha1")
+				_, _, err := blobs.Add("name", "/tmp/sha1", "sha1")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-err"))
 				Expect(err.Error()).To(ContainSubstring("Creating blob for path '/tmp/sha1'"))
@@ -366,12 +366,12 @@ var _ = Describe("FSIndexBlobs", func() {
 				Expect(reporter.IndexEntryUploadFinishedCallCount()).To(Equal(1))
 
 				kind, desc := reporter.IndexEntryUploadStartedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("/tmp/sha1"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 
 				kind, desc, err = reporter.IndexEntryUploadFinishedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("/tmp/sha1"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 				Expect(err).ToNot(BeNil())
 			})
 		})

--- a/releasedir/index/fs_index_test.go
+++ b/releasedir/index/fs_index_test.go
@@ -145,7 +145,8 @@ format-version: "2"`)
 
 	Describe("Add", func() {
 		It("adds new entry when no index file exists", func() {
-			blobs.AddStub = func(path, sha1 string) (string, string, error) {
+			blobs.AddStub = func(name, path, sha1 string) (string, string, error) {
+				Expect(name).To(Equal("name/fp"))
 				Expect(path).To(Equal("path"))
 				Expect(sha1).To(Equal("sha1"))
 				return "blob-id", "blob-path", nil

--- a/releasedir/index/indexfakes/fake_index_blobs.go
+++ b/releasedir/index/indexfakes/fake_index_blobs.go
@@ -8,7 +8,7 @@ import (
 )
 
 type FakeIndexBlobs struct {
-	GetStub        func(name string, blobID string, sha1 string) (string, error)
+	GetStub        func(name, blobID, sha1 string) (string, error)
 	getMutex       sync.RWMutex
 	getArgsForCall []struct {
 		name   string
@@ -19,9 +19,10 @@ type FakeIndexBlobs struct {
 		result1 string
 		result2 error
 	}
-	AddStub        func(path, sha1 string) (string, string, error)
+	AddStub        func(name, path, sha1 string) (string, string, error)
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
+		name string
 		path string
 		sha1 string
 	}
@@ -70,16 +71,17 @@ func (fake *FakeIndexBlobs) GetReturns(result1 string, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *FakeIndexBlobs) Add(path string, sha1 string) (string, string, error) {
+func (fake *FakeIndexBlobs) Add(name string, path string, sha1 string) (string, string, error) {
 	fake.addMutex.Lock()
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
+		name string
 		path string
 		sha1 string
-	}{path, sha1})
-	fake.recordInvocation("Add", []interface{}{path, sha1})
+	}{name, path, sha1})
+	fake.recordInvocation("Add", []interface{}{name, path, sha1})
 	fake.addMutex.Unlock()
 	if fake.AddStub != nil {
-		return fake.AddStub(path, sha1)
+		return fake.AddStub(name, path, sha1)
 	} else {
 		return fake.addReturns.result1, fake.addReturns.result2, fake.addReturns.result3
 	}
@@ -91,10 +93,10 @@ func (fake *FakeIndexBlobs) AddCallCount() int {
 	return len(fake.addArgsForCall)
 }
 
-func (fake *FakeIndexBlobs) AddArgsForCall(i int) (string, string) {
+func (fake *FakeIndexBlobs) AddArgsForCall(i int) (string, string, string) {
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
-	return fake.addArgsForCall[i].path, fake.addArgsForCall[i].sha1
+	return fake.addArgsForCall[i].name, fake.addArgsForCall[i].path, fake.addArgsForCall[i].sha1
 }
 
 func (fake *FakeIndexBlobs) AddReturns(result1 string, result2 string, result3 error) {

--- a/releasedir/index/interfaces.go
+++ b/releasedir/index/interfaces.go
@@ -10,8 +10,8 @@ type Index interface {
 //go:generate counterfeiter . IndexBlobs
 
 type IndexBlobs interface {
-	Get(name string, blobID string, sha1 string) (string, error)
-	Add(path, sha1 string) (string, string, error)
+	Get(name, blobID, sha1 string) (string, error)
+	Add(name, path, sha1 string) (string, string, error)
 }
 
 //go:generate counterfeiter . Reporter


### PR DESCRIPTION
Upload messages include empty quotes and a meaningless cache path.

Instead of this...

    Adding job 'mysql-backup/7340294eb37ba38d18475fd7e2473150ed82e8d4'...
    -- Started uploading '' (~/.bosh/cache/c17dc313bbaa37eb0f08b836b91d9e2fdb6541ee)
    2016/11/13 22:50:02 Successfully uploaded file to https://s3/bucket/f1d38b03-91bf-4eb5-7711-582de487433f
    -- Finished uploading '' (~/.bosh/cache/c17dc313bbaa37eb0f08b836b91d9e2fdb6541ee)
    Added job 'mysql-backup/7340294eb37ba38d18475fd7e2473150ed82e8d4'

Show this...

    Adding job 'mysql-backup/7340294eb37ba38d18475fd7e2473150ed82e8d4'...
    -- Started uploading 'mysql-backup/7340294eb37ba38d18475fd7e2473150ed82e8d4' (sha1=c17dc313bbaa37eb0f08b836b91d9e2fdb6541ee)
    2016/11/13 22:56:41 Successfully uploaded file to https://s3/bucket/00465c4a-64d7-4ee1-560b-375d3b74320c
    -- Finished uploading 'mysql-backup/7340294eb37ba38d18475fd7e2473150ed82e8d4' (sha1=c17dc313bbaa37eb0f08b836b91d9e2fdb6541ee)
    Added job 'mysql-backup/7340294eb37ba38d18475fd7e2473150ed82e8d4'
