### PR TITLE
read CA cert only once so that it can be read from a pipe

### DIFF
--- a/cmd/alias_env.go
+++ b/cmd/alias_env.go
@@ -21,7 +21,7 @@ func NewAliasEnvCmd(
 }
 
 func (c AliasEnvCmd) Run(opts AliasEnvOpts) error {
-	updatedConfig, err := c.config.AliasEnvironment(opts.URL, opts.Args.Alias, opts.CACert)
+	updatedConfig, err := c.config.AliasEnvironment(opts.URL, opts.Args.Alias, opts.CACert.Content)
 	if err != nil {
 		return err
 	}

--- a/cmd/alias_env_test.go
+++ b/cmd/alias_env_test.go
@@ -67,7 +67,7 @@ var _ = Describe("AliasEnvCmd", func() {
 
 			opts.URL = "environment-url"
 			opts.Args.Alias = "environment-alias"
-			opts.CACert = "environment-ca-cert"
+			opts.CACert = CACertArg{Content: "environment-ca-cert"}
 
 			updatedConfig = &fakecmdconf.FakeConfig2{
 				Existing: fakecmdconf.ConfigContents{

--- a/cmd/ca_cert_arg.go
+++ b/cmd/ca_cert_arg.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"strings"
+
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
+)
+
+type CACertArg struct {
+	FS boshsys.FileSystem
+
+	Content string
+}
+
+func (a *CACertArg) UnmarshalFlag(data string) error {
+	if len(data) == 0 {
+		return bosherr.Errorf("Expected CA cert to be non-empty")
+	}
+
+	if strings.Contains(data, "BEGIN") {
+		(*a).Content = data
+		return nil
+	}
+
+	absPath, err := a.FS.ExpandPath(data)
+	if err != nil {
+		return bosherr.WrapErrorf(err, "Getting absolute path '%s'", data)
+	}
+
+	content, err := a.FS.ReadFileString(absPath)
+	if err != nil {
+		return err
+	}
+
+	(*a).Content = content
+
+	return nil
+}

--- a/cmd/ca_cert_arg_test.go
+++ b/cmd/ca_cert_arg_test.go
@@ -1,0 +1,62 @@
+package cmd_test
+
+import (
+	"errors"
+
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-cli/cmd"
+)
+
+var _ = Describe("CACertArg", func() {
+	Describe("UnmarshalFlag", func() {
+		var (
+			fs  *fakesys.FakeFileSystem
+			arg CACertArg
+		)
+
+		BeforeEach(func() {
+			fs = fakesys.NewFakeFileSystem()
+			arg = CACertArg{FS: fs}
+		})
+
+		It("sets bytes from value if value is a PEM certificate (contains BEGIN)", func() {
+			err := (&arg).UnmarshalFlag("BEGIN ...")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arg.Content).To(Equal("BEGIN ..."))
+		})
+
+		It("sets bytes from file contents if value is not a PEM certificate", func() {
+			fs.WriteFileString("/some/path", "content")
+
+			err := (&arg).UnmarshalFlag("/some/path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arg.Content).To(Equal("content"))
+		})
+
+		It("returns an error if expanding path fails", func() {
+			fs.ExpandPathErr = errors.New("fake-err")
+
+			err := (&arg).UnmarshalFlag("/some/path")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
+		})
+
+		It("returns an error if reading file fails", func() {
+			fs.WriteFileString("/some/path", "content")
+			fs.ReadFileError = errors.New("fake-err")
+
+			err := (&arg).UnmarshalFlag("/some/path")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
+		})
+
+		It("returns an error when it's empty", func() {
+			err := (&arg).UnmarshalFlag("")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Expected CA cert to be non-empty"))
+		})
+	})
+})

--- a/cmd/config/fs_config.go
+++ b/cmd/config/fs_config.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"strings"
-
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 	"gopkg.in/yaml.v2"
@@ -91,7 +89,7 @@ func (c FSConfig) AliasEnvironment(url, alias, caCert string) (Config, error) {
 
 	i, tg := config.findOrCreateEnvironment(url)
 	tg.Alias = alias
-	tg.CACert = c.readCACert(caCert)
+	tg.CACert = caCert
 	config.schema.Environments[i] = tg
 
 	return config, nil
@@ -100,20 +98,7 @@ func (c FSConfig) AliasEnvironment(url, alias, caCert string) (Config, error) {
 func (c FSConfig) CACert(urlOrAlias string) string {
 	_, tg := c.findOrCreateEnvironment(urlOrAlias)
 
-	return c.readCACert(tg.CACert)
-}
-
-func (c FSConfig) readCACert(caCert string) string {
-	if strings.Contains(caCert, "BEGIN") {
-		return caCert
-	}
-
-	readCACert, err := c.fs.ReadFileString(caCert)
-	if err != nil {
-		return ""
-	}
-
-	return readCACert
+	return tg.CACert
 }
 
 func (c FSConfig) Credentials(urlOrAlias string) Creds {

--- a/cmd/config/fs_config_test.go
+++ b/cmd/config/fs_config_test.go
@@ -173,21 +173,18 @@ var _ = Describe("FSConfig", func() {
 			Expect(reloadedConfig.CACert("url")).To(Equal(""))
 		})
 
-		// Valid from pov of FSConfig
-		validCACert := "BEGIN\nca-cert"
-
 		It("saves non-empty CA certificate and then unsets it", func() {
-			updatedConfig, err := config.AliasEnvironment("url", "alias", validCACert)
+			updatedConfig, err := config.AliasEnvironment("url", "alias", "ca-cert")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(updatedConfig.ResolveEnvironment("url")).To(Equal("url"))
-			Expect(updatedConfig.CACert("url")).To(Equal(validCACert))
+			Expect(updatedConfig.CACert("url")).To(Equal("ca-cert"))
 
 			err = updatedConfig.Save()
 			Expect(err).ToNot(HaveOccurred())
 
 			reloadedConfig := readConfig()
-			Expect(reloadedConfig.CACert("url")).To(Equal(validCACert))
+			Expect(reloadedConfig.CACert("url")).To(Equal("ca-cert"))
 
 			updatedConfig, err = reloadedConfig.AliasEnvironment("url", "alias", "")
 			Expect(err).ToNot(HaveOccurred())
@@ -202,36 +199,18 @@ var _ = Describe("FSConfig", func() {
 			Expect(reloadedConfig.CACert("url")).To(Equal(""))
 		})
 
-		It("saves CA cert via file path and does not need file system later", func() {
-			fs.WriteFileString("/ca-cert", validCACert)
-
-			updatedConfig, err := config.AliasEnvironment("url", "alias", "/ca-cert")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(updatedConfig.CACert("url")).To(Equal(validCACert))
-
-			err = updatedConfig.Save()
-			Expect(err).ToNot(HaveOccurred())
-
-			err = fs.RemoveAll("/ca-cert")
-			Expect(err).ToNot(HaveOccurred())
-
-			reloadedConfig := readConfig()
-			Expect(reloadedConfig.CACert("url")).To(Equal(validCACert))
-		})
-
 		It("returns CA cert for alias", func() {
-			updatedConfig, err := config.AliasEnvironment("url", "alias", validCACert)
+			updatedConfig, err := config.AliasEnvironment("url", "alias", "ca-cert")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(updatedConfig.ResolveEnvironment("url")).To(Equal("url"))
-			Expect(updatedConfig.CACert("alias")).To(Equal(validCACert))
+			Expect(updatedConfig.CACert("alias")).To(Equal("ca-cert"))
 
 			err = updatedConfig.Save()
 			Expect(err).ToNot(HaveOccurred())
 
 			reloadedConfig := readConfig()
-			Expect(reloadedConfig.CACert("alias")).To(Equal(validCACert))
+			Expect(reloadedConfig.CACert("alias")).To(Equal("ca-cert"))
 
 			updatedConfig, err = reloadedConfig.AliasEnvironment("url", "alias", "")
 			Expect(err).ToNot(HaveOccurred())

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -218,11 +218,12 @@ var _ = Describe("Factory", func() {
 		})
 
 		It("is passed the global CA cert", func() {
-			cmd, err := factory.New([]string{"alias-env", "--ca-cert", "ca-cert", "alias"})
+			cmd, err := factory.New([]string{"alias-env", "--ca-cert", "BEGIN ca-cert", "alias"})
 			Expect(err).ToNot(HaveOccurred())
 
 			opts := cmd.Opts.(*AliasEnvOpts)
-			Expect(opts.CACert).To(Equal("ca-cert"))
+			opts.CACert.FS = nil
+			Expect(opts.CACert).To(Equal(CACertArg{Content: "BEGIN ca-cert"}))
 		})
 	})
 
@@ -302,7 +303,8 @@ var _ = Describe("Factory", func() {
 
 	Describe("global options", func() {
 		clearNonGlobalOpts := func(boshOpts BoshOpts) BoshOpts {
-			boshOpts.VersionOpt = nil // can't compare functions
+			boshOpts.VersionOpt = nil   // can't compare functions
+			boshOpts.CACertOpt.FS = nil // fs is populated by factory.New
 			boshOpts.UploadRelease = UploadReleaseOpts{}
 			boshOpts.ExportRelease = ExportReleaseOpts{}
 			boshOpts.RunErrand = RunErrandOpts{}
@@ -336,7 +338,7 @@ var _ = Describe("Factory", func() {
 			opts := []string{
 				"--config", "config",
 				"--environment", "env",
-				"--ca-cert", "ca-cert",
+				"--ca-cert", "BEGIN ca-cert",
 				"--user", "user",
 				"--password", "password",
 				"--uaa-client", "uaa-client",
@@ -355,7 +357,7 @@ var _ = Describe("Factory", func() {
 			Expect(clearNonGlobalOpts(cmd.BoshOpts)).To(Equal(BoshOpts{
 				ConfigPathOpt:      "config",
 				EnvironmentOpt:     "env",
-				CACertOpt:          "ca-cert",
+				CACertOpt:          CACertArg{Content: "BEGIN ca-cert"},
 				UsernameOpt:        "user",
 				PasswordOpt:        "password",
 				UAAClientOpt:       "uaa-client",

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -14,8 +14,8 @@ type BoshOpts struct {
 
 	ConfigPathOpt string `long:"config" description:"Config file path" env:"BOSH_CONFIG" default:"~/.bosh/config"`
 
-	EnvironmentOpt string `long:"environment" short:"e" description:"Director environment name or URL" env:"BOSH_ENVIRONMENT"`
-	CACertOpt      string `long:"ca-cert"               description:"Director CA certificate path or value" env:"BOSH_CA_CERT"`
+	EnvironmentOpt string    `long:"environment" short:"e" description:"Director environment name or URL" env:"BOSH_ENVIRONMENT"`
+	CACertOpt      CACertArg `long:"ca-cert"               description:"Director CA certificate path or value" env:"BOSH_CA_CERT"`
 
 	// Specify basic credentaials
 	UsernameOpt string `long:"user"     description:"Override username" env:"BOSH_USER"`
@@ -190,7 +190,7 @@ type AliasEnvOpts struct {
 	Args AliasEnvArgs `positional-args:"true" required:"true"`
 
 	URL    string
-	CACert string
+	CACert CACertArg
 
 	cmd
 }

--- a/cmd/session_context.go
+++ b/cmd/session_context.go
@@ -46,19 +46,8 @@ func (c SessionContextImpl) Credentials() cmdconf.Creds {
 }
 
 func (c SessionContextImpl) CACert() string {
-	caCert := c.opts.CACertOpt
-
-	if len(caCert) > 0 {
-		if c.isFilePath(caCert) {
-			readCACert, err := c.fs.ReadFileString(caCert)
-			if err != nil {
-				return ""
-			}
-
-			return readCACert
-		}
-
-		return caCert
+	if len(c.opts.CACertOpt.Content) > 0 {
+		return c.opts.CACertOpt.Content
 	}
 
 	return c.config.CACert(c.Environment())
@@ -66,13 +55,4 @@ func (c SessionContextImpl) CACert() string {
 
 func (c SessionContextImpl) Deployment() string {
 	return c.opts.DeploymentOpt
-}
-
-func (c SessionContextImpl) isFilePath(path string) bool {
-	fullPath, err := c.fs.ExpandPath(path)
-	if err != nil {
-		return false
-	}
-
-	return c.fs.FileExists(fullPath)
 }

--- a/cmd/session_context_test.go
+++ b/cmd/session_context_test.go
@@ -1,8 +1,6 @@
 package cmd_test
 
 import (
-	"errors"
-
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -111,36 +109,19 @@ var _ = Describe("SessionContextImpl", func() {
 			opts.EnvironmentOpt = "opt-url"
 		})
 
-		It("returns global option if provided as non-file-path", func() {
+		It("returns global option if provided", func() {
 			config.CACertReturns("config-cert")
-
-			opts.CACertOpt = "opt-cert"
-
+			opts.CACertOpt = CACertArg{Content: "opt-cert"}
 			Expect(build().CACert()).To(Equal("opt-cert"))
 		})
 
-		It("returns global option as value if provided as file path", func() {
-			fs.WriteFileString("/cert", "file-cert")
-
+		It("returns config value if global option is not set", func() {
 			config.CACertReturns("config-cert")
-
-			opts.CACertOpt = "/cert"
-
-			Expect(build().CACert()).To(Equal("file-cert"))
+			opts.CACertOpt = CACertArg{}
+			Expect(build().CACert()).To(Equal("config-cert"))
 		})
 
-		It("returns empty value if provided file path cannot be read", func() {
-			fs.WriteFileString("/cert", "file-cert")
-			fs.ReadFileError = errors.New("fake-err")
-
-			config.CACertReturns("config-cert")
-
-			opts.CACertOpt = "/cert"
-
-			Expect(build().CACert()).To(Equal(""))
-		})
-
-		It("returns empty string if global option is not set", func() {
+		It("returns empty string if global option or config value is not set", func() {
 			Expect(build().CACert()).To(Equal(""))
 		})
 	})


### PR DESCRIPTION
```
$ bosh alias-env my-bosh -e my-bosh.com --ca-cert <(bosh bm ~/workspace/my-bosh/manifest-creds.yml --path /director_ssl/ca)
```