### PR TITLE
Accept and ignore empty responses.

### DIFF
--- a/cmd/uaa_login_strategy.go
+++ b/cmd/uaa_login_strategy.go
@@ -103,9 +103,10 @@ func (c UAALoginStrategy) tryUserOnce(environment string, prompts []boshuaa.Prom
 			return false, err
 		}
 
-		answer := boshuaa.PromptAnswer{Key: prompt.Key, Value: value}
-
-		answers = append(answers, answer)
+		if value != "" {
+			answer := boshuaa.PromptAnswer{Key: prompt.Key, Value: value}
+			answers = append(answers, answer)
+		}
 	}
 
 	accessToken, err := uaa.OwnerPasswordCredentialsGrant(answers)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -101,7 +101,7 @@ func (ui *WriterUI) PrintTable(table Table) {
 func (ui *WriterUI) AskForText(label string) (string, error) {
 	var text string
 
-	err := interact.NewInteraction(label).Resolve(interact.Required(&text))
+	err := interact.NewInteraction(label).Resolve(&text)
 	if err != nil {
 		return "", bosherr.WrapError(err, "Asking for text")
 	}
@@ -129,7 +129,7 @@ func (ui *WriterUI) AskForChoice(label string, options []string) (int, error) {
 func (ui *WriterUI) AskForPassword(label string) (string, error) {
 	var password interact.Password
 
-	err := interact.NewInteraction(label).Resolve(interact.Required(&password))
+	err := interact.NewInteraction(label).Resolve(&password)
 	if err != nil {
 		return "", bosherr.WrapError(err, "Asking for password")
 	}


### PR DESCRIPTION
Note: this feels like a hack, but it does restore parity with the ruby cli.

This patch makes bosh-cli behave like the ruby cli, in that empty
responses are accepted during login but not passed to the identity
provider. This is currently necessary to log in using a local account
when saml is enabled, since uaa prmopts for a login, password, and otp,
but only wants values for the login and password.

[Resolves #59]

@cppforlife @sharms