### PR TITLE
Add support for scoped vars files

### DIFF
--- a/director/template/vars_file_arg_test.go
+++ b/director/template/vars_file_arg_test.go
@@ -33,6 +33,19 @@ var _ = Describe("VarsFileArg", func() {
 			}))
 		})
 
+		It("sets scoped vars", func() {
+			fs.WriteFileString("/some/path", "name1: var1\nname2: var2")
+
+			err := (&arg).UnmarshalFlag("scope=/some/path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(arg.Vars).To(Equal(StaticVariables{
+				"scope": map[interface{}]interface{}{
+					"name1": "var1",
+					"name2": "var2",
+				},
+			}))
+		})
+
 		It("returns objects", func() {
 			fs.WriteFileString("/some/path", "name1: \n  key: value")
 


### PR DESCRIPTION
It would be helpful to allow scoping variables to avoid collisions. It allows `--vars-file` to have an `=` delimiter for this support, but certainly open to suggestions.

When a `aws.yml` vars file has...

    subnet_id: subnet-a1b2c3d4

And a manifest has...

    cloud_properties:
      subnet: ((iaas.subnet_id))

It could be interpolated with...

    bosh interpolate --vars-file iaas=aws.yml

For a result of...

    cloud_properties:
      subnet: subnet-a1b2c3d4

Thoughts?