### PR TITLE
Fix ssh when there is no public key given by director

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -11,14 +11,14 @@ import (
 )
 
 type SessionImpl struct {
-	connOpts ConnectionOpts
-	sessOpts SessionImplOpts
-	result   boshdir.SSHResult
+	connOpts       ConnectionOpts
+	sessOpts       SessionImplOpts
+	result         boshdir.SSHResult
 
 	privKeyFile    boshsys.File
 	knownHostsFile boshsys.File
 
-	fs boshsys.FileSystem
+	fs             boshsys.FileSystem
 }
 
 type SessionImplOpts struct {
@@ -26,10 +26,10 @@ type SessionImplOpts struct {
 }
 
 func NewSessionImpl(
-	connOpts ConnectionOpts,
-	sessOpts SessionImplOpts,
-	result boshdir.SSHResult,
-	fs boshsys.FileSystem,
+connOpts ConnectionOpts,
+sessOpts SessionImplOpts,
+result boshdir.SSHResult,
+fs boshsys.FileSystem,
 ) *SessionImpl {
 	return &SessionImpl{connOpts: connOpts, sessOpts: sessOpts, result: result, fs: fs}
 }
@@ -62,9 +62,13 @@ func (r *SessionImpl) Start() ([]string, error) {
 		"-o", "IdentitiesOnly=yes",
 		"-o", "IdentityFile=" + r.privKeyFile.Name(),
 		"-o", "StrictHostKeyChecking=yes",
-		"-o", "UserKnownHostsFile=" + r.knownHostsFile.Name(),
 	}...)
-
+	statHostFile, _ := r.knownHostsFile.Stat()
+	if statHostFile.Size() != 0 {
+		cmdOpts = append(cmdOpts, []string{
+			"-o", "UserKnownHostsFile=" + r.knownHostsFile.Name(),
+		}...)
+	}
 	gwUsername, gwHost, gwPrivKeyPath := r.gwOpts(r.connOpts, r.result)
 
 	if len(gwHost) > 0 {
@@ -84,7 +88,7 @@ func (r *SessionImpl) Start() ([]string, error) {
 				gwCmdOpts,
 				"-o", "PasswordAuthentication=no",
 				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile="+gwPrivKeyPath,
+				"-o", "IdentityFile=" + gwPrivKeyPath,
 			)
 		}
 


### PR DESCRIPTION
If a bosh director doesn't give a public key when requesting bosh-cli respond with this error:

```
No RSA host key is known for 10.244.52.2 and you have requested strict checking.
Host key verification failed.
```

Indeed, the bosh-cli call this command to do the ssh:

`ssh -tt -o ServerAliveInterval=30 -o ForwardAgent=no -o PasswordAuthentication=no -o IdentitiesOnly=yes -o IdentityFile=/var/.../ssh-priv-key485211751 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=/var/.../ssh-known-hosts485211751 10.244.52.2 -l bosh_3e32d12a96b04095 echo toto`

but when no public key is given the file `ssh-known-hosts485211751` is empty. 
It seems that the actual bosh-cli handle this error by removing the argument `-o UserKnownHostsFile=/var/.../ssh-known-hosts485211751` as we can see here: https://github.com/cloudfoundry/bosh/blob/master/bosh_cli/lib/cli/ssh_session.rb#L20-L25

This pull request do the same behavior as the current cli does, if the file is empty it removes this argument. This change fix the issue.

To recreate this issue, simply install a bosh-lite and just try to do a ssh on an deployment.