### PR TITLE
Support Context Id in SDK

### DIFF
--- a/director/client.go
+++ b/director/client.go
@@ -23,3 +23,12 @@ func NewClient(
 	taskClientRequest := NewTaskClientRequest(clientRequest, taskReporter, 500*time.Millisecond)
 	return Client{clientRequest, taskClientRequest}
 }
+
+func (c Client) WithContext(contextId string) Client {
+	clientRequest := c.clientRequest.WithContext(contextId)
+
+	taskClientRequest := c.taskClientRequest
+	taskClientRequest.clientRequest = clientRequest
+
+	return Client{clientRequest, taskClientRequest}
+}

--- a/director/deployment_test.go
+++ b/director/deployment_test.go
@@ -935,4 +935,37 @@ var _ = Describe("Deployment", func() {
 			Expect(err.Error()).Should(ContainSubstring("Error fetching variables for deployment 'dep'"))
 		})
 	})
+
+	Describe("using a director with context", func() {
+		contextId := "example-context-id"
+
+		BeforeEach(func() {
+			var err error
+			directorWithContextId := director.WithContext(contextId)
+
+			deployment, err = directorWithContextId.FindDeployment("dep")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("adds context to request headers", func() {
+			ConfigureTaskResult(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/deployments", ""),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.VerifyHeader(http.Header{
+						"Content-Type":      []string{"text/yaml"},
+						"X-Bosh-Context-Id": []string{contextId},
+					}),
+					ghttp.VerifyBody([]byte("manifest")),
+				),
+				``,
+				server,
+			)
+
+			err := deployment.Update([]byte("manifest"), UpdateOpts{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+	})
+
 })

--- a/director/director.go
+++ b/director/director.go
@@ -13,6 +13,10 @@ type DirectorImpl struct {
 	client Client
 }
 
+func (d DirectorImpl) WithContext(id string) Director {
+	return DirectorImpl{client: d.client.WithContext(id)}
+}
+
 func (d DirectorImpl) EnableResurrection(enabled bool) error {
 	return d.client.EnableResurrectionAll(enabled)
 }

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -145,4 +145,23 @@ var _ = Describe("Director", func() {
 			Expect(err.Error()).To(ContainSubstring("Downloading resource 'blob-id'"))
 		})
 	})
+
+	Describe("With Context", func() {
+		It("Adds the context id to requests", func() {
+			buf := bytes.NewBufferString("")
+			contextId := "example-context-id"
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/resources/blob-id"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.VerifyHeaderKV("X-Bosh-Context-Id", contextId),
+					ghttp.RespondWith(http.StatusOK, contextId),
+				),
+			)
+
+			director = director.WithContext(contextId)
+			err := director.DownloadResourceUnchecked("blob-id", buf)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/director/directorfakes/fake_director.go
+++ b/director/directorfakes/fake_director.go
@@ -16,6 +16,14 @@ type FakeDirector struct {
 		result1 bool
 		result2 error
 	}
+	WithContextStub        func(id string) director.Director
+	withContextMutex       sync.RWMutex
+	withContextArgsForCall []struct {
+		id string
+	}
+	withContextReturns struct {
+		result1 director.Director
+	}
 	InfoStub        func() (director.Info, error)
 	infoMutex       sync.RWMutex
 	infoArgsForCall []struct{}
@@ -317,6 +325,39 @@ func (fake *FakeDirector) IsAuthenticatedReturns(result1 bool, result2 error) {
 		result1 bool
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeDirector) WithContext(id string) director.Director {
+	fake.withContextMutex.Lock()
+	fake.withContextArgsForCall = append(fake.withContextArgsForCall, struct {
+		id string
+	}{id})
+	fake.recordInvocation("WithContext", []interface{}{id})
+	fake.withContextMutex.Unlock()
+	if fake.WithContextStub != nil {
+		return fake.WithContextStub(id)
+	} else {
+		return fake.withContextReturns.result1
+	}
+}
+
+func (fake *FakeDirector) WithContextCallCount() int {
+	fake.withContextMutex.RLock()
+	defer fake.withContextMutex.RUnlock()
+	return len(fake.withContextArgsForCall)
+}
+
+func (fake *FakeDirector) WithContextArgsForCall(i int) string {
+	fake.withContextMutex.RLock()
+	defer fake.withContextMutex.RUnlock()
+	return fake.withContextArgsForCall[i].id
+}
+
+func (fake *FakeDirector) WithContextReturns(result1 director.Director) {
+	fake.WithContextStub = nil
+	fake.withContextReturns = struct {
+		result1 director.Director
+	}{result1}
 }
 
 func (fake *FakeDirector) Info() (director.Info, error) {
@@ -1358,6 +1399,8 @@ func (fake *FakeDirector) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.isAuthenticatedMutex.RLock()
 	defer fake.isAuthenticatedMutex.RUnlock()
+	fake.withContextMutex.RLock()
+	defer fake.withContextMutex.RUnlock()
 	fake.infoMutex.RLock()
 	defer fake.infoMutex.RUnlock()
 	fake.locksMutex.RLock()

--- a/director/directorfakes/fake_director.go
+++ b/director/directorfakes/fake_director.go
@@ -58,6 +58,15 @@ type FakeDirector struct {
 		result1 director.Task
 		result2 error
 	}
+	FindTasksByContextIdStub        func(string) ([]director.Task, error)
+	findTasksByContextIdMutex       sync.RWMutex
+	findTasksByContextIdArgsForCall []struct {
+		arg1 string
+	}
+	findTasksByContextIdReturns struct {
+		result1 []director.Task
+		result2 error
+	}
 	EventsStub        func(director.EventsFilter) ([]director.Event, error)
 	eventsMutex       sync.RWMutex
 	eventsArgsForCall []struct {
@@ -461,6 +470,40 @@ func (fake *FakeDirector) FindTaskReturns(result1 director.Task, result2 error) 
 	fake.FindTaskStub = nil
 	fake.findTaskReturns = struct {
 		result1 director.Task
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDirector) FindTasksByContextId(arg1 string) ([]director.Task, error) {
+	fake.findTasksByContextIdMutex.Lock()
+	fake.findTasksByContextIdArgsForCall = append(fake.findTasksByContextIdArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("FindTasksByContextId", []interface{}{arg1})
+	fake.findTasksByContextIdMutex.Unlock()
+	if fake.FindTasksByContextIdStub != nil {
+		return fake.FindTasksByContextIdStub(arg1)
+	} else {
+		return fake.findTasksByContextIdReturns.result1, fake.findTasksByContextIdReturns.result2
+	}
+}
+
+func (fake *FakeDirector) FindTasksByContextIdCallCount() int {
+	fake.findTasksByContextIdMutex.RLock()
+	defer fake.findTasksByContextIdMutex.RUnlock()
+	return len(fake.findTasksByContextIdArgsForCall)
+}
+
+func (fake *FakeDirector) FindTasksByContextIdArgsForCall(i int) string {
+	fake.findTasksByContextIdMutex.RLock()
+	defer fake.findTasksByContextIdMutex.RUnlock()
+	return fake.findTasksByContextIdArgsForCall[i].arg1
+}
+
+func (fake *FakeDirector) FindTasksByContextIdReturns(result1 []director.Task, result2 error) {
+	fake.FindTasksByContextIdStub = nil
+	fake.findTasksByContextIdReturns = struct {
+		result1 []director.Task
 		result2 error
 	}{result1, result2}
 }
@@ -1325,6 +1368,8 @@ func (fake *FakeDirector) Invocations() map[string][][]interface{} {
 	defer fake.recentTasksMutex.RUnlock()
 	fake.findTaskMutex.RLock()
 	defer fake.findTaskMutex.RUnlock()
+	fake.findTasksByContextIdMutex.RLock()
+	defer fake.findTasksByContextIdMutex.RUnlock()
 	fake.eventsMutex.RLock()
 	defer fake.eventsMutex.RUnlock()
 	fake.deploymentsMutex.RLock()

--- a/director/directorfakes/fake_task.go
+++ b/director/directorfakes/fake_task.go
@@ -51,6 +51,12 @@ type FakeTask struct {
 	deploymentNameReturns     struct {
 		result1 string
 	}
+	ContextIDStub        func() string
+	contextIDMutex       sync.RWMutex
+	contextIDArgsForCall []struct{}
+	contextIDReturns     struct {
+		result1 string
+	}
 	DescriptionStub        func() string
 	descriptionMutex       sync.RWMutex
 	descriptionArgsForCall []struct{}
@@ -280,6 +286,31 @@ func (fake *FakeTask) DeploymentNameReturns(result1 string) {
 	}{result1}
 }
 
+func (fake *FakeTask) ContextID() string {
+	fake.contextIDMutex.Lock()
+	fake.contextIDArgsForCall = append(fake.contextIDArgsForCall, struct{}{})
+	fake.recordInvocation("ContextID", []interface{}{})
+	fake.contextIDMutex.Unlock()
+	if fake.ContextIDStub != nil {
+		return fake.ContextIDStub()
+	} else {
+		return fake.contextIDReturns.result1
+	}
+}
+
+func (fake *FakeTask) ContextIDCallCount() int {
+	fake.contextIDMutex.RLock()
+	defer fake.contextIDMutex.RUnlock()
+	return len(fake.contextIDArgsForCall)
+}
+
+func (fake *FakeTask) ContextIDReturns(result1 string) {
+	fake.ContextIDStub = nil
+	fake.contextIDReturns = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeTask) Description() string {
 	fake.descriptionMutex.Lock()
 	fake.descriptionArgsForCall = append(fake.descriptionArgsForCall, struct{}{})
@@ -504,6 +535,8 @@ func (fake *FakeTask) Invocations() map[string][][]interface{} {
 	defer fake.userMutex.RUnlock()
 	fake.deploymentNameMutex.RLock()
 	defer fake.deploymentNameMutex.RUnlock()
+	fake.contextIDMutex.RLock()
+	defer fake.contextIDMutex.RUnlock()
 	fake.descriptionMutex.RLock()
 	defer fake.descriptionMutex.RUnlock()
 	fake.resultMutex.RLock()

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -19,6 +19,7 @@ type Director interface {
 	CurrentTasks(TasksFilter) ([]Task, error)
 	RecentTasks(int, TasksFilter) ([]Task, error)
 	FindTask(int) (Task, error)
+	FindTasksByContextId(string) ([]Task, error)
 
 	Events(EventsFilter) ([]Event, error)
 
@@ -221,6 +222,7 @@ type Task interface {
 	IsError() bool
 	User() string
 	DeploymentName() string
+	ContextID() string
 
 	Description() string
 	Result() string

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -12,6 +12,7 @@ import (
 
 type Director interface {
 	IsAuthenticated() (bool, error)
+	WithContext(id string) Director
 	Info() (Info, error)
 
 	Locks() ([]Lock, error)


### PR DESCRIPTION
CF BOSH Tracker story [#134702861](https://www.pivotaltracker.com/n/projects/956238/stories/134702861)

## Why

As a bosh user
I can assign a context to bosh deployments and errands
So that I can query a group of bosh tasks

## What

This PR extends the BOSH Go SDK to support using the new [`X-Bosh-Context-Id'](https://github.com/cloudfoundry/bosh/pull/1531). This change is not exposed in the CLI, only in the Go Library, so the UX is unchanged.

- Director interface extended with  a `WithContext(string)` function that returns a Director whose subsquent requests will include the `X-Bosh-Context-Id` header.
- Currently limited to GET/POST/PUT (see below)
- Header added at http client request level so no interface changes to operations.
- Director interface extended with a `FindTasksByContextId(string) ([]Task, error)`
- Task now has a `contextId` property

**Missing Delete support**
The Bosh-Utils HttpClient package only supports customising requests for Get/Post/Put but not Delete. [This PR](https://github.com/cloudfoundry/bosh-utils/pull/7) has been submitted to add the functionality to DELETE. 

However, since the vendored `18e54c` sha, the head of Bosh-Utils has breaking changes to other areas of the Bosh CLI, e.g. [Blobstore interface changes](https://github.com/cloudfoundry/bosh-utils/commit/ed39ea3a92b20becbfb16a2b02cf52e58aad5c26#diff-e76fb5507231062ad745b68e69863a3d). So even when that PR gets merged there will be additional work to integrate with head. @cppforlife / @avade thoughts?

Sam