### PR TITLE
Show IEC (1024) byte values instead of SI (1000)

### DIFF
--- a/ui/table/values.go
+++ b/ui/table/values.go
@@ -69,7 +69,7 @@ func (t ValueInt) Compare(other Value) int {
 func NewValueBytes(i uint64) ValueBytes     { return ValueBytes{I: i} }
 func NewValueMegaBytes(i uint64) ValueBytes { return ValueBytes{I: i * 1024 * 1024} }
 
-func (t ValueBytes) String() string { return humanize.Bytes(t.I) }
+func (t ValueBytes) String() string { return humanize.IBytes(t.I) }
 func (t ValueBytes) Value() Value   { return t }
 
 func (t ValueBytes) Compare(other Value) int {

--- a/ui/table/values_test.go
+++ b/ui/table/values_test.go
@@ -66,8 +66,12 @@ var _ = Describe("ValueBytes", func() {
 		Expect(ValueBytes{1}.String()).To(Equal("1 B"))
 	})
 
-	It("returns formatted megabytes", func() {
-		Expect(NewValueMegaBytes(1).String()).To(Equal("1.0 MB"))
+	It("returns formatted mebibytes", func() {
+		Expect(NewValueMegaBytes(1).String()).To(Equal("1.0 MiB"))
+	})
+
+	It("returns formatted gibibytes", func() {
+		Expect(NewValueMegaBytes(131072).String()).To(Equal("128 GiB"))
 	})
 
 	It("returns itself", func() {


### PR DESCRIPTION
When showing byte values, use [IEC format](http://physics.nist.gov/cuu/Units/binary.html) instead of SI. Particularly since [`NewValueMegaBytes`](https://github.com/cloudfoundry/bosh-cli/blob/8c9abad8a9a38cfc29873c2897381bb0279344e6/ui/table/values.go#L70) is using a 1024 base. Otherwise the rendered value confuses me.

Given...

    [ { "size": 131072,
        "disk_cid": "vol-c539194c",
        ...snip... } ]

Before...

    Disk CID      Size     Deployment  Instance                                   AZ  Orphaned At                   
    vol-c539194c  137 GB   deployme    five/533a814e-c558-4554-8b66-a0db5fd1e60b  z0  Tue Dec 27 04:00:59 UTC 2016  

After...

    vol-c539194c  128 GiB  deployme    five/533a814e-c558-4554-8b66-a0db5fd1e60b  z0  Tue Dec 27 04:00:59 UTC 2016  

Technically, `NewValueMegaBytes` should probably be changed to `NewValueMebiBytes`, too... but that seems more interface-y and I'd like confirmation before doing that. I'd be happy to amend the PR if that change is desirable.

    $ grep -snr NewValueMegaBytes .
    ./cmd/disks.go:39:			boshtbl.NewValueMegaBytes(d.Size()),
    ./cmd/disks_test.go:81:							boshtbl.NewValueMegaBytes(100),
    ./ui/table/values.go:70:func NewValueMegaBytes(i uint64) ValueBytes { return ValueBytes{I: i * 1024 * 1024} }
    ./ui/table/values_test.go:70:		Expect(NewValueMegaBytes(1).String()).To(Equal("1.0 MiB"))
    ./ui/table/values_test.go:74:		Expect(NewValueMegaBytes(131072).String()).To(Equal("128 GiB"))