### PR TITLE
ping the agent after attach/detach_disk because cpi could reboote/recreate vm

### DIFF
--- a/deployment/vm/manager.go
+++ b/deployment/vm/manager.go
@@ -12,6 +12,7 @@ import (
 	biproperty "github.com/cloudfoundry/bosh-utils/property"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
+	"github.com/pivotal-golang/clock"
 )
 
 type Manager interface {
@@ -72,6 +73,7 @@ func (m *manager) FindCurrent() (VM, bool, error) {
 		m.diskDeployer,
 		m.agentClient,
 		m.cloud,
+		clock.NewClock(),
 		m.fs,
 		m.logger,
 	)
@@ -125,6 +127,7 @@ func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest b
 		m.diskDeployer,
 		m.agentClient,
 		m.cloud,
+		clock.NewClock(),
 		m.fs,
 		m.logger,
 	)

--- a/deployment/vm/manager_test.go
+++ b/deployment/vm/manager_test.go
@@ -18,6 +18,7 @@ import (
 	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-golang/clock"
 )
 
 var _ = Describe("Manager", func() {
@@ -123,6 +124,7 @@ var _ = Describe("Manager", func() {
 				fakeDiskDeployer,
 				fakeAgentClient,
 				fakeCloud,
+				clock.NewClock(),
 				fs,
 				logger,
 			)

--- a/integration/create_env_test.go
+++ b/integration/create_env_test.go
@@ -458,6 +458,7 @@ cloud_provider:
 
 				mockCloud.EXPECT().CreateDisk(diskSize, diskCloudProperties, vmCID).Return(diskCID, nil),
 				mockCloud.EXPECT().AttachDisk(vmCID, diskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(diskCID),
 
 				mockAgentClient.EXPECT().Apply(applySpec),
@@ -498,12 +499,15 @@ cloud_provider:
 
 				// attach both disks and migrate
 				mockCloud.EXPECT().AttachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(oldDiskCID),
 				mockCloud.EXPECT().CreateDisk(newDiskSize, diskCloudProperties, newVMCID).Return(newDiskCID, nil),
 				mockCloud.EXPECT().AttachDisk(newVMCID, newDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(newDiskCID),
 				mockAgentClient.EXPECT().MigrateDisk(),
 				mockCloud.EXPECT().DetachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockCloud.EXPECT().DeleteDisk(oldDiskCID),
 
 				// start jobs & wait for running
@@ -541,12 +545,15 @@ cloud_provider:
 
 				// attach both disks and migrate
 				mockCloud.EXPECT().AttachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(oldDiskCID),
 				mockCloud.EXPECT().CreateDisk(newDiskSize, diskCloudProperties, newVMCID).Return(newDiskCID, nil),
 				mockCloud.EXPECT().AttachDisk(newVMCID, newDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(newDiskCID),
 				mockAgentClient.EXPECT().MigrateDisk(),
 				mockCloud.EXPECT().DetachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockCloud.EXPECT().DeleteDisk(oldDiskCID),
 
 				// start jobs & wait for running
@@ -617,9 +624,11 @@ cloud_provider:
 
 				// attach both disks and migrate (with error)
 				mockCloud.EXPECT().AttachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(oldDiskCID),
 				mockCloud.EXPECT().CreateDisk(newDiskSize, diskCloudProperties, newVMCID).Return(newDiskCID, nil),
 				mockCloud.EXPECT().AttachDisk(newVMCID, newDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(newDiskCID),
 				mockAgentClient.EXPECT().MigrateDisk().Return(
 					bosherr.Error("fake-migration-error"),
@@ -652,12 +661,15 @@ cloud_provider:
 
 				// attach both disks and migrate
 				mockCloud.EXPECT().AttachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(oldDiskCID),
 				mockCloud.EXPECT().CreateDisk(newDiskSize, diskCloudProperties, newVMCID).Return(newDiskCID, nil),
 				mockCloud.EXPECT().AttachDisk(newVMCID, newDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockAgentClient.EXPECT().MountDisk(newDiskCID),
 				mockAgentClient.EXPECT().MigrateDisk(),
 				mockCloud.EXPECT().DetachDisk(newVMCID, oldDiskCID),
+				mockAgentClient.EXPECT().Ping().Return("any-state", nil),
 				mockCloud.EXPECT().DeleteDisk(oldDiskCID),
 
 				// start jobs & wait for running


### PR DESCRIPTION
attach/disk disk CPI methods may reboot/recreate the machine to attach/detach a disk. need to wait for the agent to become responsive before proceeding to avoid flakiness

cc @loewenstein @sykesm
