### PR TITLE
add %i so that bosh scp can download files into instance namespaced directories

### DIFF
--- a/ssh/scp_args.go
+++ b/ssh/scp_args.go
@@ -47,6 +47,11 @@ func (a SCPArgs) ForHost(host boshdir.Host) []string {
 			pieces[0] = fmt.Sprintf("%s@%s", host.Username, host.Host)
 		}
 
+		for i, _ := range pieces {
+			// Replace special identifier '%i' with specific instance
+			pieces[i] = strings.Replace(pieces[i], "%i", host.IndexOrID, -1)
+		}
+
 		args = append(args, strings.Join(pieces, ":"))
 	}
 

--- a/ssh/scp_args_test.go
+++ b/ssh/scp_args_test.go
@@ -14,7 +14,7 @@ var _ = Describe("SCPArgs", func() {
 	)
 
 	BeforeEach(func() {
-		host = boshdir.Host{Username: "user", Host: "127.0.0.1"}
+		host = boshdir.Host{Username: "user", Host: "127.0.0.1", IndexOrID: "id"}
 	})
 
 	Describe("AllOrInstanceGroupOrInstanceSlug", func() {
@@ -62,7 +62,7 @@ var _ = Describe("SCPArgs", func() {
 			Expect(scpArgs.ForHost(host)).To(Equal([]string{"user@127.0.0.1:arg1", "user@127.0.0.1:arg2"}))
 		})
 
-		It("replaces named host keeping remaining :s", func() {
+		It("replaces named host keeping remaining colons", func() {
 			scpArgs := NewSCPArgs([]string{"host:some:file"}, false)
 			Expect(scpArgs.ForHost(host)).To(Equal([]string{"user@127.0.0.1:some:file"}))
 		})
@@ -70,6 +70,12 @@ var _ = Describe("SCPArgs", func() {
 		It("returns as is if no host info is included", func() {
 			scpArgs := NewSCPArgs([]string{"arg1", "arg2"}, false)
 			Expect(scpArgs.ForHost(host)).To(Equal([]string{"arg1", "arg2"}))
+		})
+
+		It("replaces '%i' with instance host id", func() {
+			scpArgs := NewSCPArgs([]string{"host:some:file-%i", "host:file-%i", "file-%i"}, false)
+			Expect(scpArgs.ForHost(host)).To(Equal([]string{
+				"user@127.0.0.1:some:file-id", "user@127.0.0.1:file-id", "file-id"}))
 		})
 
 		It("returns empty when it's empty", func() {


### PR DESCRIPTION
was trying to download persistent data for all instances in a deployment. ended doing quick change so that `bosh scp :/var/vcap/store /tmp/inst-%i` makes scp create directory per instance and put content there.

cc @dpb587 