### PR TITLE
Add bash completion support to homebrew formula

### DIFF
--- a/ci/tasks/update-homebrew-formula.sh
+++ b/ci/tasks/update-homebrew-formula.sh
@@ -19,6 +19,19 @@ class BoshCli < Formula
 
   def install
     bin.install "bosh-cli-#{version}-darwin-amd64" => "gosh"
+    (bash_completion/"bosh-cli").write <<-completion
+      _gosh() {
+          # All arguments except the first one
+          args=("\${COMP_WORDS[@]:1:\$COMP_CWORD}")
+          # Only split on newlines
+          local IFS=$'\n'
+          # Call completion (note that the first element of COMP_WORDS is
+          # the executable itself)
+          COMPREPLY=(\$(GO_FLAGS_COMPLETION=1 \${COMP_WORDS[0]} "\${args[@]}"))
+          return 0
+      }
+      complete -F _gosh gosh
+    completion
   end
 
   test do


### PR DESCRIPTION
See https://github.com/jessevdk/go-flags/blob/cebccf636b1a2b89786298229c6cdc938e75f359/flags.go#L235-L248 to see how this is built in to go-flags and https://github.com/Homebrew/brew/blob/44f1c9752a1f55f09475cab79ab85fdaf39cef84/Library/Homebrew/formula.rb#L833-L839 to see how this is supported by homebrew