### PR TITLE
Don't stop the sshTunnel

### DIFF
--- a/deployment/instance/instance.go
+++ b/deployment/instance/instance.go
@@ -99,11 +99,6 @@ func (i *instance) WaitUntilReady(
 			}
 			sshTunnel := i.sshTunnelFactory.NewSSHTunnel(sshTunnelOptions)
 			go sshTunnel.Start(sshReadyErrCh, sshErrCh)
-			defer func() {
-				if err := sshTunnel.Stop(); err != nil {
-					i.logger.Warn(i.logTag, "Failed to stop ssh tunnel: %s", err.Error())
-				}
-			}()
 
 			err := <-sshReadyErrCh
 			if err != nil {

--- a/deployment/instance/instance_test.go
+++ b/deployment/instance/instance_test.go
@@ -483,7 +483,6 @@ var _ = Describe("Instance", func() {
 					RemoteForwardPort: 125,
 				}))
 				Expect(fakeSSHTunnel.Started).To(BeTrue())
-				Expect(fakeSSHTunnel.Stopped).To(BeTrue())
 			})
 
 			It("waits for the vm", func() {

--- a/deployment/instance/manager_test.go
+++ b/deployment/instance/manager_test.go
@@ -338,7 +338,6 @@ var _ = Describe("Manager", func() {
 					RemoteForwardPort: 124,
 				}))
 				Expect(fakeSSHTunnel.Started).To(BeTrue())
-				Expect(fakeSSHTunnel.Stopped).To(BeTrue())
 			})
 
 			Context("when starting the ssh tunnel fails", func() {
@@ -373,7 +372,6 @@ var _ = Describe("Manager", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeSSHTunnel.Started).To(BeFalse())
-				Expect(fakeSSHTunnel.Stopped).To(BeFalse())
 			})
 		})
 

--- a/deployment/sshtunnel/fakes/fake_ssh_tunnel.go
+++ b/deployment/sshtunnel/fakes/fake_ssh_tunnel.go
@@ -3,7 +3,6 @@ package fakes
 type FakeTunnel struct {
 	startOutput *startOutput
 	Started     bool
-	Stopped     bool
 }
 
 type startOutput struct {
@@ -22,11 +21,6 @@ func (s *FakeTunnel) Start(readyErrCh chan<- error, errCh chan<- error) {
 		readyErrCh <- s.startOutput.ReadyErrChOutput
 		errCh <- s.startOutput.ErrChOutput
 	}
-}
-
-func (s *FakeTunnel) Stop() error {
-	s.Stopped = true
-	return nil
 }
 
 func (s *FakeTunnel) SetStartBehavior(readyErrChOutput error, errChOutput error) {

--- a/deployment/sshtunnel/ssh_tunnel.go
+++ b/deployment/sshtunnel/ssh_tunnel.go
@@ -13,7 +13,6 @@ import (
 
 type SSHTunnel interface {
 	Start(chan<- error, chan<- error)
-	Stop() error
 }
 
 type sshTunnel struct {
@@ -98,11 +97,4 @@ func (s *sshTunnel) Start(readyErrCh chan<- error, errCh chan<- error) {
 			}
 		}()
 	}
-}
-
-func (s *sshTunnel) Stop() error {
-	if s.remoteListener != nil {
-		return s.remoteListener.Close()
-	}
-	return nil
 }


### PR DESCRIPTION
- there was a race condition, where the tunnel closed
  too early: Fixes #110
- remove the stop method as it is not used anymore

[#138795111](https://www.pivotaltracker.com/story/show/138795111)

Signed-off-by: Mauro Morales <mamorales@suse.com>