### PR TITLE
Windows doesn't allow renaming files that are open

### DIFF
--- a/installation/tarball/provider.go
+++ b/installation/tarball/provider.go
@@ -157,6 +157,8 @@ func (p *provider) downloadRetryable(source Source) boshretry.Retryable {
 			return true, bosherr.Errorf("SHA1 of downloaded file '%s' does not match expected SHA1 '%s'", downloadedSha1, source.GetSHA1())
 		}
 
+		downloadedFile.Close()
+
 		err = p.cache.Save(downloadedFile.Name(), source)
 		if err != nil {
 			return true, bosherr.WrapError(err, "Saving downloaded file in cache")


### PR DESCRIPTION
This change causes the unit tests to fail in Linux and Windows, but this function works on Windows with this change:

    Provider Get when URL starts with http(s):// when tarball is not present in cache when downloading succeds when saving to cache fails [It] returns an error 
    /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-cli/installation/tarball/provider_test.go:161

      Expected
          <string>: Failed to download from 'http://fake-url': Saving downloaded bits to temporary file: write /tmp/temp-download-file428754441: bad file descriptor
      to contain substring
          <string>: fake-mkdir-error

      /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-cli/installation/tarball/provider_test.go:160

      Full Stack Trace
        /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-cli/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x1ed
      github.com/cloudfoundry/bosh-cli/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).To(0xc4203b3440, 0x8ec1c0, 0xc4203bb380, 0x0, 0x0, 0x0, 0xc4203bb380)
        /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-cli/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:35 +0xae
      github.com/cloudfoundry/bosh-cli/installation/tarball_test.glob..func2.2.2.3.3.5.2()
        /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-cli/installation/tarball/provider_test.go:160 +0x230
      github.com/cloudfoundry/bosh-cli/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc420203860, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /tmp/build/1944c6a2/gopath/src/github.com/cloudfoundry/bosh-cli/installation/tarball/suite_test.go:11 +0x64
      testing.tRunner(0xc42008a480, 0x7a0928)
        /usr/local/go/src/testing/testing.go:610 +0x81
      created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:646 +0x2ec

Moving the close [line 150][1] causes the test on [line 134][2] to fail with the same error. Why does the test fail?

I didn't check the close for error, as the current code doesn't close the file.

[1]: https://github.com/Fydon/bosh-cli/blob/302f6853c761112391558cf34457142b0be3126c/installation/tarball/provider.go#L150
[2]: https://github.com/Fydon/bosh-cli/blob/302f6853c761112391558cf34457142b0be3126c/installation/tarball/provider_test.go#L134