### PR TITLE
update-dep script enhancement

### DIFF
--- a/update-dep
+++ b/update-dep
@@ -17,7 +17,7 @@ package_path=$(echo ${package_name} | sed 's/\.\.\.$//')
 rm -rf vendor/${package_path}
 mkdir -p vendor/${package_path}
 
-cp -r $GOPATH/src/${package_path}/ vendor/${package_path}
+cp -RP $GOPATH/src/${package_path}/ vendor/${package_path}
 
 pushd $GOPATH/src/${package_path}
 set +e


### PR DESCRIPTION
Hey, all.

Right now, `./update-dep` script can fail if you fetch a package with circular symbolic links. For instance, if you'll run `./update-dep` with `github.com/cloudfoundry/bosh-cli` you'll get the following error:

```
 → ./update-dep github.com/cloudfoundry/bosh-cli
+ '[' 1 -ne 1 ']'
+ package_name=github.com/cloudfoundry/bosh-cli
+ go get -d github.com/cloudfoundry/bosh-cli
++ echo github.com/cloudfoundry/bosh-cli
++ sed 's/\.\.\.$//'
+ package_path=github.com/cloudfoundry/bosh-cli
+ rm -rf vendor/github.com/cloudfoundry/bosh-cli
+ mkdir -p vendor/github.com/cloudfoundry/bosh-cli
+ cp -r /Users/allomov/work/altoros/vmware/cf-audit/go/src/github.com/cloudfoundry/bosh-cli/ vendor/github.com/cloudfoundry/bosh-cli
cp: /Users/allomov/work/altoros/vmware/cf-audit/go/src/github.com/cloudfoundry/bosh-cli//vendor/github.com/bmatcuk/doublestar/test/abc/working-symlink: Too many levels of symbolic links
cp: /Users/allomov/work/altoros/vmware/cf-audit/go/src/github.com/cloudfoundry/bosh-cli//vendor/github.com/bmatcuk/doublestar/test/broken-symlink: No such file or directory
```
To fix it you just need to change `cp` opts from `-r` to `-PR` not to follow the links.

The script can be used by other projects or people, so I've decided to place fix here.

Both Mac OS and Linux support `cp -RP` options.
