### PR TITLE
Remove file url from manifest when using 'version: create'

### DIFF
--- a/cmd/release_manager.go
+++ b/cmd/release_manager.go
@@ -103,7 +103,16 @@ func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (pat
 			Value: release.Version(),
 		}
 
-		ops = append(ops, replaceOp)
+		removeUrlOp := patch.RemoveOp{
+			Path: patch.NewPointer([]patch.Token{
+				patch.RootToken{},
+				patch.KeyToken{Key: "releases"},
+				patch.MatchingIndexToken{Key: "name", Value: rel.Name},
+				patch.KeyToken{Key: "url"},
+			}),
+		}
+
+		ops = append(ops, replaceOp, removeUrlOp)
 	}
 
 	return ops, m.uploadReleaseCmd.Run(uploadOpts)

--- a/cmd/release_manager_test.go
+++ b/cmd/release_manager_test.go
@@ -125,12 +125,10 @@ releases:
 
 			Expect(bytes).To(Equal([]byte(`releases:
 - name: capi
-  url: file:///capi-dir
   version: capi-created-ver
 - name: rel-without-upload
   version: 1+rel
 - name: consul
-  url: /consul-dir
   version: consul-created-ver
 `)))
 		})


### PR DESCRIPTION
See this issue: https://github.com/cloudfoundry/bosh-cli/issues/133