### PR TITLE
Add IPs to Instance struct

### DIFF
--- a/director/instances.go
+++ b/director/instances.go
@@ -15,6 +15,8 @@ type Instance struct {
 
 	AZ        string `json:"az"`
 	ExpectsVM bool   `json:"expects_vm"`
+
+	IPs []string `json:"ips"`
 }
 
 func (d DeploymentImpl) InstanceInfos() ([]VMInfo, error) {

--- a/director/instances_test.go
+++ b/director/instances_test.go
@@ -183,7 +183,8 @@ var _ = Describe("Instances", func() {
         "index": 1,
         "id": "instance-id",
         "az": "my-az",
-        "expects_vm": true
+        "expects_vm": true,
+        "ips": [ "ip" ]
     }
 ]`, "\n", "", -1)),
 			),
@@ -200,6 +201,7 @@ var _ = Describe("Instances", func() {
 				AZ:        "my-az",
 				VMID:      "vm-cid",
 				ExpectsVM: true,
+				IPs:       []string{"ip"},
 			}))
 		})
 	})


### PR DESCRIPTION
The director API endpoint `/deployments/:name/instances` returns also the [instance IP addresses](https://github.com/cloudfoundry/bosh/blob/master/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb#L500),
so expose them at the `Instance` struct.