### PR TITLE
Support custom VM metadata for bosh-init manifests

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -35,12 +35,7 @@ type cloud struct {
 	logTag       string
 }
 
-type VMMetadata struct {
-	Director   string `json:"director"`
-	Deployment string `json:"deployment"`
-	Job        string `json:"job"`
-	Index      string `json:"index"`
-}
+type VMMetadata map[string]string
 
 func NewCloud(
 	cpiCmdRunner CPICmdRunner,

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -296,10 +296,10 @@ var _ = Describe("Cloud", func() {
 		It("calls the set_vm_metadata CPI method", func() {
 			vmCID := "fake-vm-cid"
 			metadata := VMMetadata{
-				Director:   "bosh-init",
-				Deployment: "some-deployment",
-				Job:        "some-job",
-				Index:      "0",
+				"director":   "bosh-init",
+				"deployment": "some-deployment",
+				"job":        "some-job",
+				"index":      "0",
 			}
 			err := cloud.SetVMMetadata(vmCID, metadata)
 			Expect(err).ToNot(HaveOccurred())
@@ -319,10 +319,10 @@ var _ = Describe("Cloud", func() {
 			fakeCPICmdRunner.RunErr = errors.New("fake-run-error")
 			vmCID := "fake-vm-cid"
 			metadata := VMMetadata{
-				Director:   "bosh-init",
-				Deployment: "some-deployment",
-				Job:        "some-job",
-				Index:      "0",
+				"director":   "bosh-init",
+				"deployment": "some-deployment",
+				"job":        "some-job",
+				"index":      "0",
 			}
 
 			err := cloud.SetVMMetadata(vmCID, metadata)
@@ -333,10 +333,10 @@ var _ = Describe("Cloud", func() {
 		itHandlesCPIErrors("set_vm_metadata", func() error {
 			vmCID := "fake-vm-cid"
 			metadata := VMMetadata{
-				Director:   "bosh-init",
-				Deployment: "some-deployment",
-				Job:        "some-job",
-				Index:      "0",
+				"director":   "bosh-init",
+				"deployment": "some-deployment",
+				"job":        "some-job",
+				"index":      "0",
 			}
 			return cloud.SetVMMetadata(vmCID, metadata)
 		})

--- a/deployment/manifest/manifest.go
+++ b/deployment/manifest/manifest.go
@@ -13,6 +13,7 @@ type Manifest struct {
 	DiskPools     []DiskPool
 	ResourcePools []ResourcePool
 	Update        Update
+	Tags          map[string]string
 }
 
 type Update struct {

--- a/deployment/manifest/manifest_test.go
+++ b/deployment/manifest/manifest_test.go
@@ -368,4 +368,16 @@ var _ = Describe("Manifest", func() {
 			})
 		})
 	})
+
+	Describe("Tags", func() {
+		It("can be referenced", func() {
+			deploymentManifest = Manifest{
+				Tags: map[string]string{
+					"custom-tag": "custom-value",
+				},
+			}
+
+			Expect(deploymentManifest.Tags["custom-tag"]).To(Equal("custom-value"))
+		})
+	})
 })

--- a/deployment/manifest/parser.go
+++ b/deployment/manifest/parser.go
@@ -29,6 +29,7 @@ type manifest struct {
 	Jobs           []job
 	InstanceGroups []job `yaml:"instance_groups"`
 	Properties     map[interface{}]interface{}
+	Tags           map[string]string
 }
 
 type UpdateSpec struct {
@@ -140,6 +141,7 @@ func (p *parser) Parse(interpolatedTemplate bidepltpl.InterpolatedTemplate, path
 func (p *parser) parseDeploymentManifest(depManifest manifest, path string) (Manifest, error) {
 	deployment := boshDeploymentDefaults
 	deployment.Name = depManifest.Name
+	deployment.Tags = depManifest.Tags
 
 	networks, err := p.parseNetworkManifests(depManifest.Networks)
 	if err != nil {

--- a/deployment/manifest/parser_test.go
+++ b/deployment/manifest/parser_test.go
@@ -34,6 +34,8 @@ var _ = Describe("Parser", func() {
 			contents := `
 ---
 name: fake-deployment-name
+tags:
+  tag1: tagval1
 update:
   update_watch_time: 2000-7000
 resource_pools:
@@ -178,6 +180,9 @@ properties:
 					"foo": biproperty.Map{
 						"bar": "baz",
 					},
+				},
+				Tags: map[string]string{
+					"tag1": "tagval1",
 				},
 			}))
 		})

--- a/deployment/vm/manager.go
+++ b/deployment/vm/manager.go
@@ -110,6 +110,11 @@ func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest b
 		"index":      "0",
 		"director":   "bosh-init",
 	}
+
+	for tagKey, tagValue := range deploymentManifest.Tags {
+		metadata[tagKey] = tagValue
+	}
+
 	err = m.cloud.SetVMMetadata(cid, metadata)
 	if err != nil {
 		cloudErr, ok := err.(bicloud.Error)

--- a/deployment/vm/manager.go
+++ b/deployment/vm/manager.go
@@ -105,10 +105,10 @@ func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest b
 	}
 
 	metadata := bicloud.VMMetadata{
-		Deployment: deploymentManifest.Name,
-		Job:        deploymentManifest.JobName(),
-		Index:      "0",
-		Director:   "bosh-init",
+		"deployment": deploymentManifest.Name,
+		"job":        deploymentManifest.JobName(),
+		"index":      "0",
+		"director":   "bosh-init",
 	}
 	err = m.cloud.SetVMMetadata(cid, metadata)
 	if err != nil {

--- a/deployment/vm/manager_test.go
+++ b/deployment/vm/manager_test.go
@@ -154,6 +154,48 @@ var _ = Describe("Manager", func() {
 			}))
 		})
 
+		Context("deployment-configured tags", func() {
+			It("sets additional tags on vms", func() {
+				deploymentManifest.Tags = map[string]string{
+					"empty1": "",
+					"key1":   "value1",
+				}
+
+				_, err := manager.Create(stemcell, deploymentManifest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeCloud.SetVMMetadataMetadata).To(Equal(cloud.VMMetadata{
+					"deployment": "fake-deployment",
+					"job":        "fake-job",
+					"index":      "0",
+					"director":   "bosh-init",
+					"empty1":     "",
+					"key1":       "value1",
+				}))
+			})
+
+			Context("overriding built-in metadata", func() {
+				It("gives precedence to deployment tags", func() {
+					deploymentManifest.Tags = map[string]string{
+						"deployment": "manifest-deployment",
+						"job":        "manifest-job",
+						"index":      "7",
+						"director":   "manifest-director",
+					}
+
+					_, err := manager.Create(stemcell, deploymentManifest)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeCloud.SetVMMetadataMetadata).To(Equal(cloud.VMMetadata{
+						"deployment": "manifest-deployment",
+						"job":        "manifest-job",
+						"index":      "7",
+						"director":   "manifest-director",
+					}))
+				})
+			})
+		})
+
 		It("updates the current vm record", func() {
 			_, err := manager.Create(stemcell, deploymentManifest)
 			Expect(err).ToNot(HaveOccurred())

--- a/deployment/vm/manager_test.go
+++ b/deployment/vm/manager_test.go
@@ -147,10 +147,10 @@ var _ = Describe("Manager", func() {
 
 			Expect(fakeCloud.SetVMMetadataCid).To(Equal("fake-vm-cid"))
 			Expect(fakeCloud.SetVMMetadataMetadata).To(Equal(cloud.VMMetadata{
-				Deployment: "fake-deployment",
-				Job:        "fake-job",
-				Index:      "0",
-				Director:   "bosh-init",
+				"deployment": "fake-deployment",
+				"job":        "fake-job",
+				"index":      "0",
+				"director":   "bosh-init",
 			}))
 		})
 


### PR DESCRIPTION
Similar to https://github.com/cloudfoundry/bosh/issues/936, but for bosh-init manifests. Note, that manifest tags can intentionally override init-generated ones (which is a bit [different](https://github.com/cloudfoundry/bosh/blob/c6c419f9eff844c35c8c7307e977427f05a23a51/src/bosh-director/lib/bosh/director/vm_metadata_updater.rb) than director behavior).

```
name: bosh
tags:
  director: *director
properties:
  director:
    name: &director my-prod-bosh
```

Thoughts?