### PR TITLE
WIP: follow symlinks on create-release

### DIFF
--- a/release/resource/fingerprint.go
+++ b/release/resource/fingerprint.go
@@ -75,30 +75,28 @@ func (f FingerprinterImpl) fingerprintPath(file File) (string, error) {
 		result += file.RelativePath
 	}
 
+	targetFilePath := file.Path
+
 	fileInfo, err := f.fs.Lstat(file.Path)
 	if err != nil {
 		return "", err
 	}
 
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		symlinkTarget, err := f.fs.Readlink(file.Path)
+		var err error
+		targetFilePath, err = f.fs.ReadAndFollowLink(file.Path)
 		if err != nil {
 			return "", err
 		}
-
-		//generation of digest string
-		sha1 := f.digestCalculator.CalculateString(symlinkTarget)
-
-		result += sha1
-	} else {
-		//generation of digest string
-		sha1, err := f.digestCalculator.Calculate(file.Path)
-		if err != nil {
-			return "", err
-		}
-
-		result += sha1
 	}
+
+	//generation of digest string
+	sha1, err := f.digestCalculator.Calculate(targetFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	result += sha1
 
 	if !file.ExcludeMode {
 		// Git doesn't really track file permissions, it just looks at executable
@@ -111,8 +109,6 @@ func (f FingerprinterImpl) fingerprintPath(file File) (string, error) {
 
 		if fileInfo.IsDir() {
 			modeStr = "40755"
-		} else if fileInfo.Mode()&os.ModeSymlink != 0 {
-			modeStr = "symlink"
 		} else if fileInfo.Mode()&0111 != 0 {
 			modeStr = "100755"
 		} else {


### PR DESCRIPTION
- capi-release and others make use of symlinks to share templates
  between multiple jobs, e.g. https://github.com/cloudfoundry/cloud_controller_ng/blob/3db08e602ef4f7156c681a8799bc53a2c6e65848/bosh/shared_job_templates/setup_local_blobstore.sh.erb
- While some of our shared templates could be moved into packages or
  links, there are some files that don't fit this pattern like scripts that
  require ERB interpolation
- TODO: add tests