### PR TITLE
Add deploy --var-errs

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -29,7 +29,11 @@ func NewDeployCmd(
 func (c DeployCmd) Run(opts DeployOpts) error {
 	tpl := boshtpl.NewTemplate(opts.Args.Manifest.Bytes)
 
-	bytes, err := tpl.Evaluate(opts.VarFlags.AsVariables(), opts.OpsFlags.AsOp(), boshtpl.EvaluateOpts{})
+	evalOpts := boshtpl.EvaluateOpts{
+		ExpectAllKeys:     opts.VarErrors,
+		ExpectAllVarsUsed: opts.VarErrorsUnused,
+	}
+	bytes, err := tpl.Evaluate(opts.VarFlags.AsVariables(), opts.OpsFlags.AsOp(), evalOpts)
 	if err != nil {
 		return bosherr.WrapErrorf(err, "Evaluating manifest")
 	}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -253,5 +253,37 @@ releases:
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("fake-err"))
 		})
+
+		It("returns error if variables are not found in templated manifest if var-errs flag is set", func() {
+			opts.Args.Manifest = FileBytesArg{
+				Bytes: []byte("name1: ((name1))\nname2: ((name2))"),
+			}
+
+			opts.VarKVs = []boshtpl.VarKV{
+				{Name: "name1", Value: "val1-from-kv"},
+			}
+
+			opts.VarErrors = true
+
+			err := act()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Expected to find variables: name2"))
+		})
+
+		It("returns error if variables are not used in templated manifest if var-errs-unused flag is set", func() {
+			opts.Args.Manifest = FileBytesArg{
+				Bytes: []byte("name1: ((name1))\nname2: ((name2))"),
+			}
+
+			opts.VarKVs = []boshtpl.VarKV{
+				{Name: "name3", Value: "val3-from-kv"},
+			}
+
+			opts.VarErrorsUnused = true
+
+			err := act()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Expected to use variables: name3"))
+		})
 	})
 })

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -361,6 +361,9 @@ type DeployOpts struct {
 	VarFlags
 	OpsFlags
 
+	VarErrors       bool `long:"var-errs"                  description:"Expect all variables to be found, otherwise error"`
+	VarErrorsUnused bool `long:"var-errs-unused"           description:"Expect all variables to be used, otherwise error"`
+
 	NoRedact bool `long:"no-redact" description:"Show non-redacted manifest diff"`
 
 	Recreate  bool                `long:"recreate"                          description:"Recreate all VMs in deployment"`


### PR DESCRIPTION
`int --var-errs` is a helpful thing (though perhaps could be the default #177) but just discovered it's missing from `deploy`.

I think `deploy --var-errs` is important to ensure variables aren't missing. If its not the default, can it at least be added to `deploy` too please?

Update: PR attached