### PR TITLE
Show cloud config diff before updating

### DIFF
--- a/cmd/update_cloud_config_test.go
+++ b/cmd/update_cloud_config_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/bosh-cli/cmd"
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/director/directorfakes"
 	boshtpl "github.com/cloudfoundry/bosh-cli/director/template"
 	fakeui "github.com/cloudfoundry/bosh-cli/ui/fakes"
@@ -80,6 +81,30 @@ var _ = Describe("UpdateCloudConfigCmd", func() {
 
 			bytes := director.UpdateCloudConfigArgsForCall(0)
 			Expect(bytes).To(Equal([]byte("name1: val1-from-kv\nname2: val2-from-file\nxyz: val\n")))
+		})
+
+		It("returns an error if diffing failed", func() {
+			director.DiffCloudConfigReturns(boshdir.CloudConfigDiff{}, errors.New("Fetching diff result"))
+
+			err := act()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("gets the diff from the deployment", func() {
+			diff := [][]interface{}{
+				[]interface{}{"some line that stayed", nil},
+				[]interface{}{"some line that was added", "added"},
+				[]interface{}{"some line that was removed", "removed"},
+			}
+
+			expectedDiff := boshdir.NewCloudConfigDiff(diff)
+			director.DiffCloudConfigReturns(expectedDiff, nil)
+			err := act()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(director.DiffCloudConfigCallCount()).To(Equal(1))
+			Expect(ui.Said).To(ContainElement("  some line that stayed\n"))
+			Expect(ui.Said).To(ContainElement("+ some line that was added\n"))
+			Expect(ui.Said).To(ContainElement("- some line that was removed\n"))
 		})
 
 		It("does not stop if confirmation is rejected", func() {

--- a/director/cloud_configs_test.go
+++ b/director/cloud_configs_test.go
@@ -106,4 +106,59 @@ var _ = Describe("Director", func() {
 				"Updating cloud config: Director responded with non-successful status code"))
 		})
 	})
+
+	Describe("DiffCloudConfig", func() {
+		var expectedDiffResponse CloudConfigDiff
+
+		expectedDiffResponse = CloudConfigDiff{
+			Diff: [][]interface{}{
+				[]interface{}{"azs:", nil},
+				[]interface{}{"- name: az2", "removed"},
+				[]interface{}{"  cloud_properties: {}", "removed"},
+			},
+		}
+
+		It("diffs cloud config", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/cloud_configs/diff"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.VerifyHeader(http.Header{
+						"Content-Type": []string{"text/yaml"},
+					}),
+					ghttp.RespondWith(http.StatusOK, `{"diff":[["azs:",null],["- name: az2","removed"],["  cloud_properties: {}","removed"]]}`),
+				),
+			)
+
+			diff, err := director.DiffCloudConfig([]byte("config"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diff).To(Equal(expectedDiffResponse))
+		})
+
+		It("returns error if info response in non-200", func() {
+			AppendBadRequest(ghttp.VerifyRequest("POST", "/cloud_configs/diff"), server)
+
+			_, err := director.DiffCloudConfig(nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				"Fetching diff result: Director responded with non-successful status code"))
+		})
+
+		It("is backwards compatible with directors without the `/diff` endpoint", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/cloud_configs/diff"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.VerifyHeader(http.Header{
+						"Content-Type": []string{"text/yaml"},
+					}),
+					ghttp.RespondWith(http.StatusNotFound, ""),
+				),
+			)
+
+			diff, err := director.DiffCloudConfig([]byte("config"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diff).To(Equal(CloudConfigDiff{}))
+		})
+	})
 })

--- a/director/directorfakes/fake_director.go
+++ b/director/directorfakes/fake_director.go
@@ -16,6 +16,10 @@ type FakeDirector struct {
 		result1 bool
 		result2 error
 	}
+	isAuthenticatedReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	WithContextStub        func(id string) director.Director
 	withContextMutex       sync.RWMutex
 	withContextArgsForCall []struct {
@@ -24,10 +28,17 @@ type FakeDirector struct {
 	withContextReturns struct {
 		result1 director.Director
 	}
+	withContextReturnsOnCall map[int]struct {
+		result1 director.Director
+	}
 	InfoStub        func() (director.Info, error)
 	infoMutex       sync.RWMutex
 	infoArgsForCall []struct{}
 	infoReturns     struct {
+		result1 director.Info
+		result2 error
+	}
+	infoReturnsOnCall map[int]struct {
 		result1 director.Info
 		result2 error
 	}
@@ -38,12 +49,20 @@ type FakeDirector struct {
 		result1 []director.Lock
 		result2 error
 	}
+	locksReturnsOnCall map[int]struct {
+		result1 []director.Lock
+		result2 error
+	}
 	CurrentTasksStub        func(director.TasksFilter) ([]director.Task, error)
 	currentTasksMutex       sync.RWMutex
 	currentTasksArgsForCall []struct {
 		arg1 director.TasksFilter
 	}
 	currentTasksReturns struct {
+		result1 []director.Task
+		result2 error
+	}
+	currentTasksReturnsOnCall map[int]struct {
 		result1 []director.Task
 		result2 error
 	}
@@ -57,12 +76,20 @@ type FakeDirector struct {
 		result1 []director.Task
 		result2 error
 	}
+	recentTasksReturnsOnCall map[int]struct {
+		result1 []director.Task
+		result2 error
+	}
 	FindTaskStub        func(int) (director.Task, error)
 	findTaskMutex       sync.RWMutex
 	findTaskArgsForCall []struct {
 		arg1 int
 	}
 	findTaskReturns struct {
+		result1 director.Task
+		result2 error
+	}
+	findTaskReturnsOnCall map[int]struct {
 		result1 director.Task
 		result2 error
 	}
@@ -75,12 +102,20 @@ type FakeDirector struct {
 		result1 []director.Task
 		result2 error
 	}
+	findTasksByContextIdReturnsOnCall map[int]struct {
+		result1 []director.Task
+		result2 error
+	}
 	EventsStub        func(director.EventsFilter) ([]director.Event, error)
 	eventsMutex       sync.RWMutex
 	eventsArgsForCall []struct {
 		arg1 director.EventsFilter
 	}
 	eventsReturns struct {
+		result1 []director.Event
+		result2 error
+	}
+	eventsReturnsOnCall map[int]struct {
 		result1 []director.Event
 		result2 error
 	}
@@ -93,10 +128,18 @@ type FakeDirector struct {
 		result1 director.Event
 		result2 error
 	}
+	eventReturnsOnCall map[int]struct {
+		result1 director.Event
+		result2 error
+	}
 	DeploymentsStub        func() ([]director.Deployment, error)
 	deploymentsMutex       sync.RWMutex
 	deploymentsArgsForCall []struct{}
 	deploymentsReturns     struct {
+		result1 []director.Deployment
+		result2 error
+	}
+	deploymentsReturnsOnCall map[int]struct {
 		result1 []director.Deployment
 		result2 error
 	}
@@ -109,10 +152,18 @@ type FakeDirector struct {
 		result1 director.Deployment
 		result2 error
 	}
+	findDeploymentReturnsOnCall map[int]struct {
+		result1 director.Deployment
+		result2 error
+	}
 	ReleasesStub        func() ([]director.Release, error)
 	releasesMutex       sync.RWMutex
 	releasesArgsForCall []struct{}
 	releasesReturns     struct {
+		result1 []director.Release
+		result2 error
+	}
+	releasesReturnsOnCall map[int]struct {
 		result1 []director.Release
 		result2 error
 	}
@@ -126,6 +177,10 @@ type FakeDirector struct {
 		result1 bool
 		result2 error
 	}
+	hasReleaseReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	FindReleaseStub        func(director.ReleaseSlug) (director.Release, error)
 	findReleaseMutex       sync.RWMutex
 	findReleaseArgsForCall []struct {
@@ -135,12 +190,20 @@ type FakeDirector struct {
 		result1 director.Release
 		result2 error
 	}
+	findReleaseReturnsOnCall map[int]struct {
+		result1 director.Release
+		result2 error
+	}
 	FindReleaseSeriesStub        func(director.ReleaseSeriesSlug) (director.ReleaseSeries, error)
 	findReleaseSeriesMutex       sync.RWMutex
 	findReleaseSeriesArgsForCall []struct {
 		arg1 director.ReleaseSeriesSlug
 	}
 	findReleaseSeriesReturns struct {
+		result1 director.ReleaseSeries
+		result2 error
+	}
+	findReleaseSeriesReturnsOnCall map[int]struct {
 		result1 director.ReleaseSeries
 		result2 error
 	}
@@ -155,6 +218,9 @@ type FakeDirector struct {
 	uploadReleaseURLReturns struct {
 		result1 error
 	}
+	uploadReleaseURLReturnsOnCall map[int]struct {
+		result1 error
+	}
 	UploadReleaseFileStub        func(file director.UploadFile, rebase, fix bool) error
 	uploadReleaseFileMutex       sync.RWMutex
 	uploadReleaseFileArgsForCall []struct {
@@ -163,6 +229,9 @@ type FakeDirector struct {
 		fix    bool
 	}
 	uploadReleaseFileReturns struct {
+		result1 error
+	}
+	uploadReleaseFileReturnsOnCall map[int]struct {
 		result1 error
 	}
 	MatchPackagesStub        func(manifest interface{}, compiled bool) ([]string, error)
@@ -175,10 +244,18 @@ type FakeDirector struct {
 		result1 []string
 		result2 error
 	}
+	matchPackagesReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	StemcellsStub        func() ([]director.Stemcell, error)
 	stemcellsMutex       sync.RWMutex
 	stemcellsArgsForCall []struct{}
 	stemcellsReturns     struct {
+		result1 []director.Stemcell
+		result2 error
+	}
+	stemcellsReturnsOnCall map[int]struct {
 		result1 []director.Stemcell
 		result2 error
 	}
@@ -192,12 +269,20 @@ type FakeDirector struct {
 		result1 bool
 		result2 error
 	}
+	hasStemcellReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	FindStemcellStub        func(director.StemcellSlug) (director.Stemcell, error)
 	findStemcellMutex       sync.RWMutex
 	findStemcellArgsForCall []struct {
 		arg1 director.StemcellSlug
 	}
 	findStemcellReturns struct {
+		result1 director.Stemcell
+		result2 error
+	}
+	findStemcellReturnsOnCall map[int]struct {
 		result1 director.Stemcell
 		result2 error
 	}
@@ -211,6 +296,9 @@ type FakeDirector struct {
 	uploadStemcellURLReturns struct {
 		result1 error
 	}
+	uploadStemcellURLReturnsOnCall map[int]struct {
+		result1 error
+	}
 	UploadStemcellFileStub        func(file director.UploadFile, fix bool) error
 	uploadStemcellFileMutex       sync.RWMutex
 	uploadStemcellFileArgsForCall []struct {
@@ -220,10 +308,17 @@ type FakeDirector struct {
 	uploadStemcellFileReturns struct {
 		result1 error
 	}
+	uploadStemcellFileReturnsOnCall map[int]struct {
+		result1 error
+	}
 	LatestCloudConfigStub        func() (director.CloudConfig, error)
 	latestCloudConfigMutex       sync.RWMutex
 	latestCloudConfigArgsForCall []struct{}
 	latestCloudConfigReturns     struct {
+		result1 director.CloudConfig
+		result2 error
+	}
+	latestCloudConfigReturnsOnCall map[int]struct {
 		result1 director.CloudConfig
 		result2 error
 	}
@@ -235,10 +330,30 @@ type FakeDirector struct {
 	updateCloudConfigReturns struct {
 		result1 error
 	}
+	updateCloudConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DiffCloudConfigStub        func(manifest []byte) (director.CloudConfigDiff, error)
+	diffCloudConfigMutex       sync.RWMutex
+	diffCloudConfigArgsForCall []struct {
+		manifest []byte
+	}
+	diffCloudConfigReturns struct {
+		result1 director.CloudConfigDiff
+		result2 error
+	}
+	diffCloudConfigReturnsOnCall map[int]struct {
+		result1 director.CloudConfigDiff
+		result2 error
+	}
 	LatestCPIConfigStub        func() (director.CPIConfig, error)
 	latestCPIConfigMutex       sync.RWMutex
 	latestCPIConfigArgsForCall []struct{}
 	latestCPIConfigReturns     struct {
+		result1 director.CPIConfig
+		result2 error
+	}
+	latestCPIConfigReturnsOnCall map[int]struct {
 		result1 director.CPIConfig
 		result2 error
 	}
@@ -250,12 +365,19 @@ type FakeDirector struct {
 	updateCPIConfigReturns struct {
 		result1 error
 	}
+	updateCPIConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
 	LatestRuntimeConfigStub        func(name string) (director.RuntimeConfig, error)
 	latestRuntimeConfigMutex       sync.RWMutex
 	latestRuntimeConfigArgsForCall []struct {
 		name string
 	}
 	latestRuntimeConfigReturns struct {
+		result1 director.RuntimeConfig
+		result2 error
+	}
+	latestRuntimeConfigReturnsOnCall map[int]struct {
 		result1 director.RuntimeConfig
 		result2 error
 	}
@@ -268,6 +390,9 @@ type FakeDirector struct {
 	updateRuntimeConfigReturns struct {
 		result1 error
 	}
+	updateRuntimeConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
 	FindOrphanedDiskStub        func(string) (director.OrphanedDisk, error)
 	findOrphanedDiskMutex       sync.RWMutex
 	findOrphanedDiskArgsForCall []struct {
@@ -277,10 +402,18 @@ type FakeDirector struct {
 		result1 director.OrphanedDisk
 		result2 error
 	}
+	findOrphanedDiskReturnsOnCall map[int]struct {
+		result1 director.OrphanedDisk
+		result2 error
+	}
 	OrphanedDisksStub        func() ([]director.OrphanedDisk, error)
 	orphanedDisksMutex       sync.RWMutex
 	orphanedDisksArgsForCall []struct{}
 	orphanedDisksReturns     struct {
+		result1 []director.OrphanedDisk
+		result2 error
+	}
+	orphanedDisksReturnsOnCall map[int]struct {
 		result1 []director.OrphanedDisk
 		result2 error
 	}
@@ -292,12 +425,18 @@ type FakeDirector struct {
 	enableResurrectionReturns struct {
 		result1 error
 	}
+	enableResurrectionReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CleanUpStub        func(bool) error
 	cleanUpMutex       sync.RWMutex
 	cleanUpArgsForCall []struct {
 		arg1 bool
 	}
 	cleanUpReturns struct {
+		result1 error
+	}
+	cleanUpReturnsOnCall map[int]struct {
 		result1 error
 	}
 	DownloadResourceUncheckedStub        func(blobstoreID string, out io.Writer) error
@@ -309,20 +448,26 @@ type FakeDirector struct {
 	downloadResourceUncheckedReturns struct {
 		result1 error
 	}
+	downloadResourceUncheckedReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
 func (fake *FakeDirector) IsAuthenticated() (bool, error) {
 	fake.isAuthenticatedMutex.Lock()
+	ret, specificReturn := fake.isAuthenticatedReturnsOnCall[len(fake.isAuthenticatedArgsForCall)]
 	fake.isAuthenticatedArgsForCall = append(fake.isAuthenticatedArgsForCall, struct{}{})
 	fake.recordInvocation("IsAuthenticated", []interface{}{})
 	fake.isAuthenticatedMutex.Unlock()
 	if fake.IsAuthenticatedStub != nil {
 		return fake.IsAuthenticatedStub()
-	} else {
-		return fake.isAuthenticatedReturns.result1, fake.isAuthenticatedReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.isAuthenticatedReturns.result1, fake.isAuthenticatedReturns.result2
 }
 
 func (fake *FakeDirector) IsAuthenticatedCallCount() int {
@@ -339,8 +484,23 @@ func (fake *FakeDirector) IsAuthenticatedReturns(result1 bool, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) IsAuthenticatedReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.IsAuthenticatedStub = nil
+	if fake.isAuthenticatedReturnsOnCall == nil {
+		fake.isAuthenticatedReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isAuthenticatedReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) WithContext(id string) director.Director {
 	fake.withContextMutex.Lock()
+	ret, specificReturn := fake.withContextReturnsOnCall[len(fake.withContextArgsForCall)]
 	fake.withContextArgsForCall = append(fake.withContextArgsForCall, struct {
 		id string
 	}{id})
@@ -348,9 +508,11 @@ func (fake *FakeDirector) WithContext(id string) director.Director {
 	fake.withContextMutex.Unlock()
 	if fake.WithContextStub != nil {
 		return fake.WithContextStub(id)
-	} else {
-		return fake.withContextReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.withContextReturns.result1
 }
 
 func (fake *FakeDirector) WithContextCallCount() int {
@@ -372,16 +534,31 @@ func (fake *FakeDirector) WithContextReturns(result1 director.Director) {
 	}{result1}
 }
 
+func (fake *FakeDirector) WithContextReturnsOnCall(i int, result1 director.Director) {
+	fake.WithContextStub = nil
+	if fake.withContextReturnsOnCall == nil {
+		fake.withContextReturnsOnCall = make(map[int]struct {
+			result1 director.Director
+		})
+	}
+	fake.withContextReturnsOnCall[i] = struct {
+		result1 director.Director
+	}{result1}
+}
+
 func (fake *FakeDirector) Info() (director.Info, error) {
 	fake.infoMutex.Lock()
+	ret, specificReturn := fake.infoReturnsOnCall[len(fake.infoArgsForCall)]
 	fake.infoArgsForCall = append(fake.infoArgsForCall, struct{}{})
 	fake.recordInvocation("Info", []interface{}{})
 	fake.infoMutex.Unlock()
 	if fake.InfoStub != nil {
 		return fake.InfoStub()
-	} else {
-		return fake.infoReturns.result1, fake.infoReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.infoReturns.result1, fake.infoReturns.result2
 }
 
 func (fake *FakeDirector) InfoCallCount() int {
@@ -398,16 +575,33 @@ func (fake *FakeDirector) InfoReturns(result1 director.Info, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) InfoReturnsOnCall(i int, result1 director.Info, result2 error) {
+	fake.InfoStub = nil
+	if fake.infoReturnsOnCall == nil {
+		fake.infoReturnsOnCall = make(map[int]struct {
+			result1 director.Info
+			result2 error
+		})
+	}
+	fake.infoReturnsOnCall[i] = struct {
+		result1 director.Info
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Locks() ([]director.Lock, error) {
 	fake.locksMutex.Lock()
+	ret, specificReturn := fake.locksReturnsOnCall[len(fake.locksArgsForCall)]
 	fake.locksArgsForCall = append(fake.locksArgsForCall, struct{}{})
 	fake.recordInvocation("Locks", []interface{}{})
 	fake.locksMutex.Unlock()
 	if fake.LocksStub != nil {
 		return fake.LocksStub()
-	} else {
-		return fake.locksReturns.result1, fake.locksReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.locksReturns.result1, fake.locksReturns.result2
 }
 
 func (fake *FakeDirector) LocksCallCount() int {
@@ -424,8 +618,23 @@ func (fake *FakeDirector) LocksReturns(result1 []director.Lock, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) LocksReturnsOnCall(i int, result1 []director.Lock, result2 error) {
+	fake.LocksStub = nil
+	if fake.locksReturnsOnCall == nil {
+		fake.locksReturnsOnCall = make(map[int]struct {
+			result1 []director.Lock
+			result2 error
+		})
+	}
+	fake.locksReturnsOnCall[i] = struct {
+		result1 []director.Lock
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) CurrentTasks(arg1 director.TasksFilter) ([]director.Task, error) {
 	fake.currentTasksMutex.Lock()
+	ret, specificReturn := fake.currentTasksReturnsOnCall[len(fake.currentTasksArgsForCall)]
 	fake.currentTasksArgsForCall = append(fake.currentTasksArgsForCall, struct {
 		arg1 director.TasksFilter
 	}{arg1})
@@ -433,9 +642,11 @@ func (fake *FakeDirector) CurrentTasks(arg1 director.TasksFilter) ([]director.Ta
 	fake.currentTasksMutex.Unlock()
 	if fake.CurrentTasksStub != nil {
 		return fake.CurrentTasksStub(arg1)
-	} else {
-		return fake.currentTasksReturns.result1, fake.currentTasksReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.currentTasksReturns.result1, fake.currentTasksReturns.result2
 }
 
 func (fake *FakeDirector) CurrentTasksCallCount() int {
@@ -458,8 +669,23 @@ func (fake *FakeDirector) CurrentTasksReturns(result1 []director.Task, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) CurrentTasksReturnsOnCall(i int, result1 []director.Task, result2 error) {
+	fake.CurrentTasksStub = nil
+	if fake.currentTasksReturnsOnCall == nil {
+		fake.currentTasksReturnsOnCall = make(map[int]struct {
+			result1 []director.Task
+			result2 error
+		})
+	}
+	fake.currentTasksReturnsOnCall[i] = struct {
+		result1 []director.Task
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) RecentTasks(arg1 int, arg2 director.TasksFilter) ([]director.Task, error) {
 	fake.recentTasksMutex.Lock()
+	ret, specificReturn := fake.recentTasksReturnsOnCall[len(fake.recentTasksArgsForCall)]
 	fake.recentTasksArgsForCall = append(fake.recentTasksArgsForCall, struct {
 		arg1 int
 		arg2 director.TasksFilter
@@ -468,9 +694,11 @@ func (fake *FakeDirector) RecentTasks(arg1 int, arg2 director.TasksFilter) ([]di
 	fake.recentTasksMutex.Unlock()
 	if fake.RecentTasksStub != nil {
 		return fake.RecentTasksStub(arg1, arg2)
-	} else {
-		return fake.recentTasksReturns.result1, fake.recentTasksReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.recentTasksReturns.result1, fake.recentTasksReturns.result2
 }
 
 func (fake *FakeDirector) RecentTasksCallCount() int {
@@ -493,8 +721,23 @@ func (fake *FakeDirector) RecentTasksReturns(result1 []director.Task, result2 er
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) RecentTasksReturnsOnCall(i int, result1 []director.Task, result2 error) {
+	fake.RecentTasksStub = nil
+	if fake.recentTasksReturnsOnCall == nil {
+		fake.recentTasksReturnsOnCall = make(map[int]struct {
+			result1 []director.Task
+			result2 error
+		})
+	}
+	fake.recentTasksReturnsOnCall[i] = struct {
+		result1 []director.Task
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) FindTask(arg1 int) (director.Task, error) {
 	fake.findTaskMutex.Lock()
+	ret, specificReturn := fake.findTaskReturnsOnCall[len(fake.findTaskArgsForCall)]
 	fake.findTaskArgsForCall = append(fake.findTaskArgsForCall, struct {
 		arg1 int
 	}{arg1})
@@ -502,9 +745,11 @@ func (fake *FakeDirector) FindTask(arg1 int) (director.Task, error) {
 	fake.findTaskMutex.Unlock()
 	if fake.FindTaskStub != nil {
 		return fake.FindTaskStub(arg1)
-	} else {
-		return fake.findTaskReturns.result1, fake.findTaskReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findTaskReturns.result1, fake.findTaskReturns.result2
 }
 
 func (fake *FakeDirector) FindTaskCallCount() int {
@@ -527,8 +772,23 @@ func (fake *FakeDirector) FindTaskReturns(result1 director.Task, result2 error) 
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindTaskReturnsOnCall(i int, result1 director.Task, result2 error) {
+	fake.FindTaskStub = nil
+	if fake.findTaskReturnsOnCall == nil {
+		fake.findTaskReturnsOnCall = make(map[int]struct {
+			result1 director.Task
+			result2 error
+		})
+	}
+	fake.findTaskReturnsOnCall[i] = struct {
+		result1 director.Task
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) FindTasksByContextId(arg1 string) ([]director.Task, error) {
 	fake.findTasksByContextIdMutex.Lock()
+	ret, specificReturn := fake.findTasksByContextIdReturnsOnCall[len(fake.findTasksByContextIdArgsForCall)]
 	fake.findTasksByContextIdArgsForCall = append(fake.findTasksByContextIdArgsForCall, struct {
 		arg1 string
 	}{arg1})
@@ -536,9 +796,11 @@ func (fake *FakeDirector) FindTasksByContextId(arg1 string) ([]director.Task, er
 	fake.findTasksByContextIdMutex.Unlock()
 	if fake.FindTasksByContextIdStub != nil {
 		return fake.FindTasksByContextIdStub(arg1)
-	} else {
-		return fake.findTasksByContextIdReturns.result1, fake.findTasksByContextIdReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findTasksByContextIdReturns.result1, fake.findTasksByContextIdReturns.result2
 }
 
 func (fake *FakeDirector) FindTasksByContextIdCallCount() int {
@@ -561,8 +823,23 @@ func (fake *FakeDirector) FindTasksByContextIdReturns(result1 []director.Task, r
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindTasksByContextIdReturnsOnCall(i int, result1 []director.Task, result2 error) {
+	fake.FindTasksByContextIdStub = nil
+	if fake.findTasksByContextIdReturnsOnCall == nil {
+		fake.findTasksByContextIdReturnsOnCall = make(map[int]struct {
+			result1 []director.Task
+			result2 error
+		})
+	}
+	fake.findTasksByContextIdReturnsOnCall[i] = struct {
+		result1 []director.Task
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Events(arg1 director.EventsFilter) ([]director.Event, error) {
 	fake.eventsMutex.Lock()
+	ret, specificReturn := fake.eventsReturnsOnCall[len(fake.eventsArgsForCall)]
 	fake.eventsArgsForCall = append(fake.eventsArgsForCall, struct {
 		arg1 director.EventsFilter
 	}{arg1})
@@ -570,9 +847,11 @@ func (fake *FakeDirector) Events(arg1 director.EventsFilter) ([]director.Event, 
 	fake.eventsMutex.Unlock()
 	if fake.EventsStub != nil {
 		return fake.EventsStub(arg1)
-	} else {
-		return fake.eventsReturns.result1, fake.eventsReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.eventsReturns.result1, fake.eventsReturns.result2
 }
 
 func (fake *FakeDirector) EventsCallCount() int {
@@ -595,8 +874,23 @@ func (fake *FakeDirector) EventsReturns(result1 []director.Event, result2 error)
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) EventsReturnsOnCall(i int, result1 []director.Event, result2 error) {
+	fake.EventsStub = nil
+	if fake.eventsReturnsOnCall == nil {
+		fake.eventsReturnsOnCall = make(map[int]struct {
+			result1 []director.Event
+			result2 error
+		})
+	}
+	fake.eventsReturnsOnCall[i] = struct {
+		result1 []director.Event
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Event(arg1 string) (director.Event, error) {
 	fake.eventMutex.Lock()
+	ret, specificReturn := fake.eventReturnsOnCall[len(fake.eventArgsForCall)]
 	fake.eventArgsForCall = append(fake.eventArgsForCall, struct {
 		arg1 string
 	}{arg1})
@@ -604,9 +898,11 @@ func (fake *FakeDirector) Event(arg1 string) (director.Event, error) {
 	fake.eventMutex.Unlock()
 	if fake.EventStub != nil {
 		return fake.EventStub(arg1)
-	} else {
-		return fake.eventReturns.result1, fake.eventReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.eventReturns.result1, fake.eventReturns.result2
 }
 
 func (fake *FakeDirector) EventCallCount() int {
@@ -629,16 +925,33 @@ func (fake *FakeDirector) EventReturns(result1 director.Event, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) EventReturnsOnCall(i int, result1 director.Event, result2 error) {
+	fake.EventStub = nil
+	if fake.eventReturnsOnCall == nil {
+		fake.eventReturnsOnCall = make(map[int]struct {
+			result1 director.Event
+			result2 error
+		})
+	}
+	fake.eventReturnsOnCall[i] = struct {
+		result1 director.Event
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Deployments() ([]director.Deployment, error) {
 	fake.deploymentsMutex.Lock()
+	ret, specificReturn := fake.deploymentsReturnsOnCall[len(fake.deploymentsArgsForCall)]
 	fake.deploymentsArgsForCall = append(fake.deploymentsArgsForCall, struct{}{})
 	fake.recordInvocation("Deployments", []interface{}{})
 	fake.deploymentsMutex.Unlock()
 	if fake.DeploymentsStub != nil {
 		return fake.DeploymentsStub()
-	} else {
-		return fake.deploymentsReturns.result1, fake.deploymentsReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.deploymentsReturns.result1, fake.deploymentsReturns.result2
 }
 
 func (fake *FakeDirector) DeploymentsCallCount() int {
@@ -655,8 +968,23 @@ func (fake *FakeDirector) DeploymentsReturns(result1 []director.Deployment, resu
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) DeploymentsReturnsOnCall(i int, result1 []director.Deployment, result2 error) {
+	fake.DeploymentsStub = nil
+	if fake.deploymentsReturnsOnCall == nil {
+		fake.deploymentsReturnsOnCall = make(map[int]struct {
+			result1 []director.Deployment
+			result2 error
+		})
+	}
+	fake.deploymentsReturnsOnCall[i] = struct {
+		result1 []director.Deployment
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) FindDeployment(arg1 string) (director.Deployment, error) {
 	fake.findDeploymentMutex.Lock()
+	ret, specificReturn := fake.findDeploymentReturnsOnCall[len(fake.findDeploymentArgsForCall)]
 	fake.findDeploymentArgsForCall = append(fake.findDeploymentArgsForCall, struct {
 		arg1 string
 	}{arg1})
@@ -664,9 +992,11 @@ func (fake *FakeDirector) FindDeployment(arg1 string) (director.Deployment, erro
 	fake.findDeploymentMutex.Unlock()
 	if fake.FindDeploymentStub != nil {
 		return fake.FindDeploymentStub(arg1)
-	} else {
-		return fake.findDeploymentReturns.result1, fake.findDeploymentReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findDeploymentReturns.result1, fake.findDeploymentReturns.result2
 }
 
 func (fake *FakeDirector) FindDeploymentCallCount() int {
@@ -689,16 +1019,33 @@ func (fake *FakeDirector) FindDeploymentReturns(result1 director.Deployment, res
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindDeploymentReturnsOnCall(i int, result1 director.Deployment, result2 error) {
+	fake.FindDeploymentStub = nil
+	if fake.findDeploymentReturnsOnCall == nil {
+		fake.findDeploymentReturnsOnCall = make(map[int]struct {
+			result1 director.Deployment
+			result2 error
+		})
+	}
+	fake.findDeploymentReturnsOnCall[i] = struct {
+		result1 director.Deployment
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Releases() ([]director.Release, error) {
 	fake.releasesMutex.Lock()
+	ret, specificReturn := fake.releasesReturnsOnCall[len(fake.releasesArgsForCall)]
 	fake.releasesArgsForCall = append(fake.releasesArgsForCall, struct{}{})
 	fake.recordInvocation("Releases", []interface{}{})
 	fake.releasesMutex.Unlock()
 	if fake.ReleasesStub != nil {
 		return fake.ReleasesStub()
-	} else {
-		return fake.releasesReturns.result1, fake.releasesReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.releasesReturns.result1, fake.releasesReturns.result2
 }
 
 func (fake *FakeDirector) ReleasesCallCount() int {
@@ -715,8 +1062,23 @@ func (fake *FakeDirector) ReleasesReturns(result1 []director.Release, result2 er
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) ReleasesReturnsOnCall(i int, result1 []director.Release, result2 error) {
+	fake.ReleasesStub = nil
+	if fake.releasesReturnsOnCall == nil {
+		fake.releasesReturnsOnCall = make(map[int]struct {
+			result1 []director.Release
+			result2 error
+		})
+	}
+	fake.releasesReturnsOnCall[i] = struct {
+		result1 []director.Release
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) HasRelease(name string, version string) (bool, error) {
 	fake.hasReleaseMutex.Lock()
+	ret, specificReturn := fake.hasReleaseReturnsOnCall[len(fake.hasReleaseArgsForCall)]
 	fake.hasReleaseArgsForCall = append(fake.hasReleaseArgsForCall, struct {
 		name    string
 		version string
@@ -725,9 +1087,11 @@ func (fake *FakeDirector) HasRelease(name string, version string) (bool, error) 
 	fake.hasReleaseMutex.Unlock()
 	if fake.HasReleaseStub != nil {
 		return fake.HasReleaseStub(name, version)
-	} else {
-		return fake.hasReleaseReturns.result1, fake.hasReleaseReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.hasReleaseReturns.result1, fake.hasReleaseReturns.result2
 }
 
 func (fake *FakeDirector) HasReleaseCallCount() int {
@@ -750,8 +1114,23 @@ func (fake *FakeDirector) HasReleaseReturns(result1 bool, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) HasReleaseReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.HasReleaseStub = nil
+	if fake.hasReleaseReturnsOnCall == nil {
+		fake.hasReleaseReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.hasReleaseReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) FindRelease(arg1 director.ReleaseSlug) (director.Release, error) {
 	fake.findReleaseMutex.Lock()
+	ret, specificReturn := fake.findReleaseReturnsOnCall[len(fake.findReleaseArgsForCall)]
 	fake.findReleaseArgsForCall = append(fake.findReleaseArgsForCall, struct {
 		arg1 director.ReleaseSlug
 	}{arg1})
@@ -759,9 +1138,11 @@ func (fake *FakeDirector) FindRelease(arg1 director.ReleaseSlug) (director.Relea
 	fake.findReleaseMutex.Unlock()
 	if fake.FindReleaseStub != nil {
 		return fake.FindReleaseStub(arg1)
-	} else {
-		return fake.findReleaseReturns.result1, fake.findReleaseReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findReleaseReturns.result1, fake.findReleaseReturns.result2
 }
 
 func (fake *FakeDirector) FindReleaseCallCount() int {
@@ -784,8 +1165,23 @@ func (fake *FakeDirector) FindReleaseReturns(result1 director.Release, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindReleaseReturnsOnCall(i int, result1 director.Release, result2 error) {
+	fake.FindReleaseStub = nil
+	if fake.findReleaseReturnsOnCall == nil {
+		fake.findReleaseReturnsOnCall = make(map[int]struct {
+			result1 director.Release
+			result2 error
+		})
+	}
+	fake.findReleaseReturnsOnCall[i] = struct {
+		result1 director.Release
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) FindReleaseSeries(arg1 director.ReleaseSeriesSlug) (director.ReleaseSeries, error) {
 	fake.findReleaseSeriesMutex.Lock()
+	ret, specificReturn := fake.findReleaseSeriesReturnsOnCall[len(fake.findReleaseSeriesArgsForCall)]
 	fake.findReleaseSeriesArgsForCall = append(fake.findReleaseSeriesArgsForCall, struct {
 		arg1 director.ReleaseSeriesSlug
 	}{arg1})
@@ -793,9 +1189,11 @@ func (fake *FakeDirector) FindReleaseSeries(arg1 director.ReleaseSeriesSlug) (di
 	fake.findReleaseSeriesMutex.Unlock()
 	if fake.FindReleaseSeriesStub != nil {
 		return fake.FindReleaseSeriesStub(arg1)
-	} else {
-		return fake.findReleaseSeriesReturns.result1, fake.findReleaseSeriesReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findReleaseSeriesReturns.result1, fake.findReleaseSeriesReturns.result2
 }
 
 func (fake *FakeDirector) FindReleaseSeriesCallCount() int {
@@ -818,8 +1216,23 @@ func (fake *FakeDirector) FindReleaseSeriesReturns(result1 director.ReleaseSerie
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindReleaseSeriesReturnsOnCall(i int, result1 director.ReleaseSeries, result2 error) {
+	fake.FindReleaseSeriesStub = nil
+	if fake.findReleaseSeriesReturnsOnCall == nil {
+		fake.findReleaseSeriesReturnsOnCall = make(map[int]struct {
+			result1 director.ReleaseSeries
+			result2 error
+		})
+	}
+	fake.findReleaseSeriesReturnsOnCall[i] = struct {
+		result1 director.ReleaseSeries
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) UploadReleaseURL(url string, sha1 string, rebase bool, fix bool) error {
 	fake.uploadReleaseURLMutex.Lock()
+	ret, specificReturn := fake.uploadReleaseURLReturnsOnCall[len(fake.uploadReleaseURLArgsForCall)]
 	fake.uploadReleaseURLArgsForCall = append(fake.uploadReleaseURLArgsForCall, struct {
 		url    string
 		sha1   string
@@ -830,9 +1243,11 @@ func (fake *FakeDirector) UploadReleaseURL(url string, sha1 string, rebase bool,
 	fake.uploadReleaseURLMutex.Unlock()
 	if fake.UploadReleaseURLStub != nil {
 		return fake.UploadReleaseURLStub(url, sha1, rebase, fix)
-	} else {
-		return fake.uploadReleaseURLReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.uploadReleaseURLReturns.result1
 }
 
 func (fake *FakeDirector) UploadReleaseURLCallCount() int {
@@ -854,8 +1269,21 @@ func (fake *FakeDirector) UploadReleaseURLReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UploadReleaseURLReturnsOnCall(i int, result1 error) {
+	fake.UploadReleaseURLStub = nil
+	if fake.uploadReleaseURLReturnsOnCall == nil {
+		fake.uploadReleaseURLReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.uploadReleaseURLReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) UploadReleaseFile(file director.UploadFile, rebase bool, fix bool) error {
 	fake.uploadReleaseFileMutex.Lock()
+	ret, specificReturn := fake.uploadReleaseFileReturnsOnCall[len(fake.uploadReleaseFileArgsForCall)]
 	fake.uploadReleaseFileArgsForCall = append(fake.uploadReleaseFileArgsForCall, struct {
 		file   director.UploadFile
 		rebase bool
@@ -865,9 +1293,11 @@ func (fake *FakeDirector) UploadReleaseFile(file director.UploadFile, rebase boo
 	fake.uploadReleaseFileMutex.Unlock()
 	if fake.UploadReleaseFileStub != nil {
 		return fake.UploadReleaseFileStub(file, rebase, fix)
-	} else {
-		return fake.uploadReleaseFileReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.uploadReleaseFileReturns.result1
 }
 
 func (fake *FakeDirector) UploadReleaseFileCallCount() int {
@@ -889,8 +1319,21 @@ func (fake *FakeDirector) UploadReleaseFileReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UploadReleaseFileReturnsOnCall(i int, result1 error) {
+	fake.UploadReleaseFileStub = nil
+	if fake.uploadReleaseFileReturnsOnCall == nil {
+		fake.uploadReleaseFileReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.uploadReleaseFileReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) MatchPackages(manifest interface{}, compiled bool) ([]string, error) {
 	fake.matchPackagesMutex.Lock()
+	ret, specificReturn := fake.matchPackagesReturnsOnCall[len(fake.matchPackagesArgsForCall)]
 	fake.matchPackagesArgsForCall = append(fake.matchPackagesArgsForCall, struct {
 		manifest interface{}
 		compiled bool
@@ -899,9 +1342,11 @@ func (fake *FakeDirector) MatchPackages(manifest interface{}, compiled bool) ([]
 	fake.matchPackagesMutex.Unlock()
 	if fake.MatchPackagesStub != nil {
 		return fake.MatchPackagesStub(manifest, compiled)
-	} else {
-		return fake.matchPackagesReturns.result1, fake.matchPackagesReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.matchPackagesReturns.result1, fake.matchPackagesReturns.result2
 }
 
 func (fake *FakeDirector) MatchPackagesCallCount() int {
@@ -924,16 +1369,33 @@ func (fake *FakeDirector) MatchPackagesReturns(result1 []string, result2 error) 
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) MatchPackagesReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.MatchPackagesStub = nil
+	if fake.matchPackagesReturnsOnCall == nil {
+		fake.matchPackagesReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.matchPackagesReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Stemcells() ([]director.Stemcell, error) {
 	fake.stemcellsMutex.Lock()
+	ret, specificReturn := fake.stemcellsReturnsOnCall[len(fake.stemcellsArgsForCall)]
 	fake.stemcellsArgsForCall = append(fake.stemcellsArgsForCall, struct{}{})
 	fake.recordInvocation("Stemcells", []interface{}{})
 	fake.stemcellsMutex.Unlock()
 	if fake.StemcellsStub != nil {
 		return fake.StemcellsStub()
-	} else {
-		return fake.stemcellsReturns.result1, fake.stemcellsReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.stemcellsReturns.result1, fake.stemcellsReturns.result2
 }
 
 func (fake *FakeDirector) StemcellsCallCount() int {
@@ -950,8 +1412,23 @@ func (fake *FakeDirector) StemcellsReturns(result1 []director.Stemcell, result2 
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) StemcellsReturnsOnCall(i int, result1 []director.Stemcell, result2 error) {
+	fake.StemcellsStub = nil
+	if fake.stemcellsReturnsOnCall == nil {
+		fake.stemcellsReturnsOnCall = make(map[int]struct {
+			result1 []director.Stemcell
+			result2 error
+		})
+	}
+	fake.stemcellsReturnsOnCall[i] = struct {
+		result1 []director.Stemcell
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) HasStemcell(name string, version string) (bool, error) {
 	fake.hasStemcellMutex.Lock()
+	ret, specificReturn := fake.hasStemcellReturnsOnCall[len(fake.hasStemcellArgsForCall)]
 	fake.hasStemcellArgsForCall = append(fake.hasStemcellArgsForCall, struct {
 		name    string
 		version string
@@ -960,9 +1437,11 @@ func (fake *FakeDirector) HasStemcell(name string, version string) (bool, error)
 	fake.hasStemcellMutex.Unlock()
 	if fake.HasStemcellStub != nil {
 		return fake.HasStemcellStub(name, version)
-	} else {
-		return fake.hasStemcellReturns.result1, fake.hasStemcellReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.hasStemcellReturns.result1, fake.hasStemcellReturns.result2
 }
 
 func (fake *FakeDirector) HasStemcellCallCount() int {
@@ -985,8 +1464,23 @@ func (fake *FakeDirector) HasStemcellReturns(result1 bool, result2 error) {
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) HasStemcellReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.HasStemcellStub = nil
+	if fake.hasStemcellReturnsOnCall == nil {
+		fake.hasStemcellReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.hasStemcellReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) FindStemcell(arg1 director.StemcellSlug) (director.Stemcell, error) {
 	fake.findStemcellMutex.Lock()
+	ret, specificReturn := fake.findStemcellReturnsOnCall[len(fake.findStemcellArgsForCall)]
 	fake.findStemcellArgsForCall = append(fake.findStemcellArgsForCall, struct {
 		arg1 director.StemcellSlug
 	}{arg1})
@@ -994,9 +1488,11 @@ func (fake *FakeDirector) FindStemcell(arg1 director.StemcellSlug) (director.Ste
 	fake.findStemcellMutex.Unlock()
 	if fake.FindStemcellStub != nil {
 		return fake.FindStemcellStub(arg1)
-	} else {
-		return fake.findStemcellReturns.result1, fake.findStemcellReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findStemcellReturns.result1, fake.findStemcellReturns.result2
 }
 
 func (fake *FakeDirector) FindStemcellCallCount() int {
@@ -1019,8 +1515,23 @@ func (fake *FakeDirector) FindStemcellReturns(result1 director.Stemcell, result2
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindStemcellReturnsOnCall(i int, result1 director.Stemcell, result2 error) {
+	fake.FindStemcellStub = nil
+	if fake.findStemcellReturnsOnCall == nil {
+		fake.findStemcellReturnsOnCall = make(map[int]struct {
+			result1 director.Stemcell
+			result2 error
+		})
+	}
+	fake.findStemcellReturnsOnCall[i] = struct {
+		result1 director.Stemcell
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) UploadStemcellURL(url string, sha1 string, fix bool) error {
 	fake.uploadStemcellURLMutex.Lock()
+	ret, specificReturn := fake.uploadStemcellURLReturnsOnCall[len(fake.uploadStemcellURLArgsForCall)]
 	fake.uploadStemcellURLArgsForCall = append(fake.uploadStemcellURLArgsForCall, struct {
 		url  string
 		sha1 string
@@ -1030,9 +1541,11 @@ func (fake *FakeDirector) UploadStemcellURL(url string, sha1 string, fix bool) e
 	fake.uploadStemcellURLMutex.Unlock()
 	if fake.UploadStemcellURLStub != nil {
 		return fake.UploadStemcellURLStub(url, sha1, fix)
-	} else {
-		return fake.uploadStemcellURLReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.uploadStemcellURLReturns.result1
 }
 
 func (fake *FakeDirector) UploadStemcellURLCallCount() int {
@@ -1054,8 +1567,21 @@ func (fake *FakeDirector) UploadStemcellURLReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UploadStemcellURLReturnsOnCall(i int, result1 error) {
+	fake.UploadStemcellURLStub = nil
+	if fake.uploadStemcellURLReturnsOnCall == nil {
+		fake.uploadStemcellURLReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.uploadStemcellURLReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) UploadStemcellFile(file director.UploadFile, fix bool) error {
 	fake.uploadStemcellFileMutex.Lock()
+	ret, specificReturn := fake.uploadStemcellFileReturnsOnCall[len(fake.uploadStemcellFileArgsForCall)]
 	fake.uploadStemcellFileArgsForCall = append(fake.uploadStemcellFileArgsForCall, struct {
 		file director.UploadFile
 		fix  bool
@@ -1064,9 +1590,11 @@ func (fake *FakeDirector) UploadStemcellFile(file director.UploadFile, fix bool)
 	fake.uploadStemcellFileMutex.Unlock()
 	if fake.UploadStemcellFileStub != nil {
 		return fake.UploadStemcellFileStub(file, fix)
-	} else {
-		return fake.uploadStemcellFileReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.uploadStemcellFileReturns.result1
 }
 
 func (fake *FakeDirector) UploadStemcellFileCallCount() int {
@@ -1088,16 +1616,31 @@ func (fake *FakeDirector) UploadStemcellFileReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UploadStemcellFileReturnsOnCall(i int, result1 error) {
+	fake.UploadStemcellFileStub = nil
+	if fake.uploadStemcellFileReturnsOnCall == nil {
+		fake.uploadStemcellFileReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.uploadStemcellFileReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) LatestCloudConfig() (director.CloudConfig, error) {
 	fake.latestCloudConfigMutex.Lock()
+	ret, specificReturn := fake.latestCloudConfigReturnsOnCall[len(fake.latestCloudConfigArgsForCall)]
 	fake.latestCloudConfigArgsForCall = append(fake.latestCloudConfigArgsForCall, struct{}{})
 	fake.recordInvocation("LatestCloudConfig", []interface{}{})
 	fake.latestCloudConfigMutex.Unlock()
 	if fake.LatestCloudConfigStub != nil {
 		return fake.LatestCloudConfigStub()
-	} else {
-		return fake.latestCloudConfigReturns.result1, fake.latestCloudConfigReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.latestCloudConfigReturns.result1, fake.latestCloudConfigReturns.result2
 }
 
 func (fake *FakeDirector) LatestCloudConfigCallCount() int {
@@ -1114,6 +1657,20 @@ func (fake *FakeDirector) LatestCloudConfigReturns(result1 director.CloudConfig,
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) LatestCloudConfigReturnsOnCall(i int, result1 director.CloudConfig, result2 error) {
+	fake.LatestCloudConfigStub = nil
+	if fake.latestCloudConfigReturnsOnCall == nil {
+		fake.latestCloudConfigReturnsOnCall = make(map[int]struct {
+			result1 director.CloudConfig
+			result2 error
+		})
+	}
+	fake.latestCloudConfigReturnsOnCall[i] = struct {
+		result1 director.CloudConfig
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) UpdateCloudConfig(arg1 []byte) error {
 	var arg1Copy []byte
 	if arg1 != nil {
@@ -1121,6 +1678,7 @@ func (fake *FakeDirector) UpdateCloudConfig(arg1 []byte) error {
 		copy(arg1Copy, arg1)
 	}
 	fake.updateCloudConfigMutex.Lock()
+	ret, specificReturn := fake.updateCloudConfigReturnsOnCall[len(fake.updateCloudConfigArgsForCall)]
 	fake.updateCloudConfigArgsForCall = append(fake.updateCloudConfigArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
@@ -1128,9 +1686,11 @@ func (fake *FakeDirector) UpdateCloudConfig(arg1 []byte) error {
 	fake.updateCloudConfigMutex.Unlock()
 	if fake.UpdateCloudConfigStub != nil {
 		return fake.UpdateCloudConfigStub(arg1)
-	} else {
-		return fake.updateCloudConfigReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.updateCloudConfigReturns.result1
 }
 
 func (fake *FakeDirector) UpdateCloudConfigCallCount() int {
@@ -1152,16 +1712,87 @@ func (fake *FakeDirector) UpdateCloudConfigReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UpdateCloudConfigReturnsOnCall(i int, result1 error) {
+	fake.UpdateCloudConfigStub = nil
+	if fake.updateCloudConfigReturnsOnCall == nil {
+		fake.updateCloudConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateCloudConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeDirector) DiffCloudConfig(manifest []byte) (director.CloudConfigDiff, error) {
+	var manifestCopy []byte
+	if manifest != nil {
+		manifestCopy = make([]byte, len(manifest))
+		copy(manifestCopy, manifest)
+	}
+	fake.diffCloudConfigMutex.Lock()
+	ret, specificReturn := fake.diffCloudConfigReturnsOnCall[len(fake.diffCloudConfigArgsForCall)]
+	fake.diffCloudConfigArgsForCall = append(fake.diffCloudConfigArgsForCall, struct {
+		manifest []byte
+	}{manifestCopy})
+	fake.recordInvocation("DiffCloudConfig", []interface{}{manifestCopy})
+	fake.diffCloudConfigMutex.Unlock()
+	if fake.DiffCloudConfigStub != nil {
+		return fake.DiffCloudConfigStub(manifest)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.diffCloudConfigReturns.result1, fake.diffCloudConfigReturns.result2
+}
+
+func (fake *FakeDirector) DiffCloudConfigCallCount() int {
+	fake.diffCloudConfigMutex.RLock()
+	defer fake.diffCloudConfigMutex.RUnlock()
+	return len(fake.diffCloudConfigArgsForCall)
+}
+
+func (fake *FakeDirector) DiffCloudConfigArgsForCall(i int) []byte {
+	fake.diffCloudConfigMutex.RLock()
+	defer fake.diffCloudConfigMutex.RUnlock()
+	return fake.diffCloudConfigArgsForCall[i].manifest
+}
+
+func (fake *FakeDirector) DiffCloudConfigReturns(result1 director.CloudConfigDiff, result2 error) {
+	fake.DiffCloudConfigStub = nil
+	fake.diffCloudConfigReturns = struct {
+		result1 director.CloudConfigDiff
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDirector) DiffCloudConfigReturnsOnCall(i int, result1 director.CloudConfigDiff, result2 error) {
+	fake.DiffCloudConfigStub = nil
+	if fake.diffCloudConfigReturnsOnCall == nil {
+		fake.diffCloudConfigReturnsOnCall = make(map[int]struct {
+			result1 director.CloudConfigDiff
+			result2 error
+		})
+	}
+	fake.diffCloudConfigReturnsOnCall[i] = struct {
+		result1 director.CloudConfigDiff
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) LatestCPIConfig() (director.CPIConfig, error) {
 	fake.latestCPIConfigMutex.Lock()
+	ret, specificReturn := fake.latestCPIConfigReturnsOnCall[len(fake.latestCPIConfigArgsForCall)]
 	fake.latestCPIConfigArgsForCall = append(fake.latestCPIConfigArgsForCall, struct{}{})
 	fake.recordInvocation("LatestCPIConfig", []interface{}{})
 	fake.latestCPIConfigMutex.Unlock()
 	if fake.LatestCPIConfigStub != nil {
 		return fake.LatestCPIConfigStub()
-	} else {
-		return fake.latestCPIConfigReturns.result1, fake.latestCPIConfigReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.latestCPIConfigReturns.result1, fake.latestCPIConfigReturns.result2
 }
 
 func (fake *FakeDirector) LatestCPIConfigCallCount() int {
@@ -1178,6 +1809,20 @@ func (fake *FakeDirector) LatestCPIConfigReturns(result1 director.CPIConfig, res
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) LatestCPIConfigReturnsOnCall(i int, result1 director.CPIConfig, result2 error) {
+	fake.LatestCPIConfigStub = nil
+	if fake.latestCPIConfigReturnsOnCall == nil {
+		fake.latestCPIConfigReturnsOnCall = make(map[int]struct {
+			result1 director.CPIConfig
+			result2 error
+		})
+	}
+	fake.latestCPIConfigReturnsOnCall[i] = struct {
+		result1 director.CPIConfig
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) UpdateCPIConfig(arg1 []byte) error {
 	var arg1Copy []byte
 	if arg1 != nil {
@@ -1185,6 +1830,7 @@ func (fake *FakeDirector) UpdateCPIConfig(arg1 []byte) error {
 		copy(arg1Copy, arg1)
 	}
 	fake.updateCPIConfigMutex.Lock()
+	ret, specificReturn := fake.updateCPIConfigReturnsOnCall[len(fake.updateCPIConfigArgsForCall)]
 	fake.updateCPIConfigArgsForCall = append(fake.updateCPIConfigArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
@@ -1192,9 +1838,11 @@ func (fake *FakeDirector) UpdateCPIConfig(arg1 []byte) error {
 	fake.updateCPIConfigMutex.Unlock()
 	if fake.UpdateCPIConfigStub != nil {
 		return fake.UpdateCPIConfigStub(arg1)
-	} else {
-		return fake.updateCPIConfigReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.updateCPIConfigReturns.result1
 }
 
 func (fake *FakeDirector) UpdateCPIConfigCallCount() int {
@@ -1216,8 +1864,21 @@ func (fake *FakeDirector) UpdateCPIConfigReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UpdateCPIConfigReturnsOnCall(i int, result1 error) {
+	fake.UpdateCPIConfigStub = nil
+	if fake.updateCPIConfigReturnsOnCall == nil {
+		fake.updateCPIConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateCPIConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) LatestRuntimeConfig(name string) (director.RuntimeConfig, error) {
 	fake.latestRuntimeConfigMutex.Lock()
+	ret, specificReturn := fake.latestRuntimeConfigReturnsOnCall[len(fake.latestRuntimeConfigArgsForCall)]
 	fake.latestRuntimeConfigArgsForCall = append(fake.latestRuntimeConfigArgsForCall, struct {
 		name string
 	}{name})
@@ -1225,9 +1886,11 @@ func (fake *FakeDirector) LatestRuntimeConfig(name string) (director.RuntimeConf
 	fake.latestRuntimeConfigMutex.Unlock()
 	if fake.LatestRuntimeConfigStub != nil {
 		return fake.LatestRuntimeConfigStub(name)
-	} else {
-		return fake.latestRuntimeConfigReturns.result1, fake.latestRuntimeConfigReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.latestRuntimeConfigReturns.result1, fake.latestRuntimeConfigReturns.result2
 }
 
 func (fake *FakeDirector) LatestRuntimeConfigCallCount() int {
@@ -1250,6 +1913,20 @@ func (fake *FakeDirector) LatestRuntimeConfigReturns(result1 director.RuntimeCon
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) LatestRuntimeConfigReturnsOnCall(i int, result1 director.RuntimeConfig, result2 error) {
+	fake.LatestRuntimeConfigStub = nil
+	if fake.latestRuntimeConfigReturnsOnCall == nil {
+		fake.latestRuntimeConfigReturnsOnCall = make(map[int]struct {
+			result1 director.RuntimeConfig
+			result2 error
+		})
+	}
+	fake.latestRuntimeConfigReturnsOnCall[i] = struct {
+		result1 director.RuntimeConfig
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) UpdateRuntimeConfig(name string, manifest []byte) error {
 	var manifestCopy []byte
 	if manifest != nil {
@@ -1257,6 +1934,7 @@ func (fake *FakeDirector) UpdateRuntimeConfig(name string, manifest []byte) erro
 		copy(manifestCopy, manifest)
 	}
 	fake.updateRuntimeConfigMutex.Lock()
+	ret, specificReturn := fake.updateRuntimeConfigReturnsOnCall[len(fake.updateRuntimeConfigArgsForCall)]
 	fake.updateRuntimeConfigArgsForCall = append(fake.updateRuntimeConfigArgsForCall, struct {
 		name     string
 		manifest []byte
@@ -1265,9 +1943,11 @@ func (fake *FakeDirector) UpdateRuntimeConfig(name string, manifest []byte) erro
 	fake.updateRuntimeConfigMutex.Unlock()
 	if fake.UpdateRuntimeConfigStub != nil {
 		return fake.UpdateRuntimeConfigStub(name, manifest)
-	} else {
-		return fake.updateRuntimeConfigReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.updateRuntimeConfigReturns.result1
 }
 
 func (fake *FakeDirector) UpdateRuntimeConfigCallCount() int {
@@ -1289,8 +1969,21 @@ func (fake *FakeDirector) UpdateRuntimeConfigReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) UpdateRuntimeConfigReturnsOnCall(i int, result1 error) {
+	fake.UpdateRuntimeConfigStub = nil
+	if fake.updateRuntimeConfigReturnsOnCall == nil {
+		fake.updateRuntimeConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateRuntimeConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) FindOrphanedDisk(arg1 string) (director.OrphanedDisk, error) {
 	fake.findOrphanedDiskMutex.Lock()
+	ret, specificReturn := fake.findOrphanedDiskReturnsOnCall[len(fake.findOrphanedDiskArgsForCall)]
 	fake.findOrphanedDiskArgsForCall = append(fake.findOrphanedDiskArgsForCall, struct {
 		arg1 string
 	}{arg1})
@@ -1298,9 +1991,11 @@ func (fake *FakeDirector) FindOrphanedDisk(arg1 string) (director.OrphanedDisk, 
 	fake.findOrphanedDiskMutex.Unlock()
 	if fake.FindOrphanedDiskStub != nil {
 		return fake.FindOrphanedDiskStub(arg1)
-	} else {
-		return fake.findOrphanedDiskReturns.result1, fake.findOrphanedDiskReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.findOrphanedDiskReturns.result1, fake.findOrphanedDiskReturns.result2
 }
 
 func (fake *FakeDirector) FindOrphanedDiskCallCount() int {
@@ -1323,16 +2018,33 @@ func (fake *FakeDirector) FindOrphanedDiskReturns(result1 director.OrphanedDisk,
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) FindOrphanedDiskReturnsOnCall(i int, result1 director.OrphanedDisk, result2 error) {
+	fake.FindOrphanedDiskStub = nil
+	if fake.findOrphanedDiskReturnsOnCall == nil {
+		fake.findOrphanedDiskReturnsOnCall = make(map[int]struct {
+			result1 director.OrphanedDisk
+			result2 error
+		})
+	}
+	fake.findOrphanedDiskReturnsOnCall[i] = struct {
+		result1 director.OrphanedDisk
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) OrphanedDisks() ([]director.OrphanedDisk, error) {
 	fake.orphanedDisksMutex.Lock()
+	ret, specificReturn := fake.orphanedDisksReturnsOnCall[len(fake.orphanedDisksArgsForCall)]
 	fake.orphanedDisksArgsForCall = append(fake.orphanedDisksArgsForCall, struct{}{})
 	fake.recordInvocation("OrphanedDisks", []interface{}{})
 	fake.orphanedDisksMutex.Unlock()
 	if fake.OrphanedDisksStub != nil {
 		return fake.OrphanedDisksStub()
-	} else {
-		return fake.orphanedDisksReturns.result1, fake.orphanedDisksReturns.result2
 	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.orphanedDisksReturns.result1, fake.orphanedDisksReturns.result2
 }
 
 func (fake *FakeDirector) OrphanedDisksCallCount() int {
@@ -1349,8 +2061,23 @@ func (fake *FakeDirector) OrphanedDisksReturns(result1 []director.OrphanedDisk, 
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) OrphanedDisksReturnsOnCall(i int, result1 []director.OrphanedDisk, result2 error) {
+	fake.OrphanedDisksStub = nil
+	if fake.orphanedDisksReturnsOnCall == nil {
+		fake.orphanedDisksReturnsOnCall = make(map[int]struct {
+			result1 []director.OrphanedDisk
+			result2 error
+		})
+	}
+	fake.orphanedDisksReturnsOnCall[i] = struct {
+		result1 []director.OrphanedDisk
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) EnableResurrection(arg1 bool) error {
 	fake.enableResurrectionMutex.Lock()
+	ret, specificReturn := fake.enableResurrectionReturnsOnCall[len(fake.enableResurrectionArgsForCall)]
 	fake.enableResurrectionArgsForCall = append(fake.enableResurrectionArgsForCall, struct {
 		arg1 bool
 	}{arg1})
@@ -1358,9 +2085,11 @@ func (fake *FakeDirector) EnableResurrection(arg1 bool) error {
 	fake.enableResurrectionMutex.Unlock()
 	if fake.EnableResurrectionStub != nil {
 		return fake.EnableResurrectionStub(arg1)
-	} else {
-		return fake.enableResurrectionReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.enableResurrectionReturns.result1
 }
 
 func (fake *FakeDirector) EnableResurrectionCallCount() int {
@@ -1382,8 +2111,21 @@ func (fake *FakeDirector) EnableResurrectionReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) EnableResurrectionReturnsOnCall(i int, result1 error) {
+	fake.EnableResurrectionStub = nil
+	if fake.enableResurrectionReturnsOnCall == nil {
+		fake.enableResurrectionReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.enableResurrectionReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) CleanUp(arg1 bool) error {
 	fake.cleanUpMutex.Lock()
+	ret, specificReturn := fake.cleanUpReturnsOnCall[len(fake.cleanUpArgsForCall)]
 	fake.cleanUpArgsForCall = append(fake.cleanUpArgsForCall, struct {
 		arg1 bool
 	}{arg1})
@@ -1391,9 +2133,11 @@ func (fake *FakeDirector) CleanUp(arg1 bool) error {
 	fake.cleanUpMutex.Unlock()
 	if fake.CleanUpStub != nil {
 		return fake.CleanUpStub(arg1)
-	} else {
-		return fake.cleanUpReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.cleanUpReturns.result1
 }
 
 func (fake *FakeDirector) CleanUpCallCount() int {
@@ -1415,8 +2159,21 @@ func (fake *FakeDirector) CleanUpReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDirector) CleanUpReturnsOnCall(i int, result1 error) {
+	fake.CleanUpStub = nil
+	if fake.cleanUpReturnsOnCall == nil {
+		fake.cleanUpReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.cleanUpReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeDirector) DownloadResourceUnchecked(blobstoreID string, out io.Writer) error {
 	fake.downloadResourceUncheckedMutex.Lock()
+	ret, specificReturn := fake.downloadResourceUncheckedReturnsOnCall[len(fake.downloadResourceUncheckedArgsForCall)]
 	fake.downloadResourceUncheckedArgsForCall = append(fake.downloadResourceUncheckedArgsForCall, struct {
 		blobstoreID string
 		out         io.Writer
@@ -1425,9 +2182,11 @@ func (fake *FakeDirector) DownloadResourceUnchecked(blobstoreID string, out io.W
 	fake.downloadResourceUncheckedMutex.Unlock()
 	if fake.DownloadResourceUncheckedStub != nil {
 		return fake.DownloadResourceUncheckedStub(blobstoreID, out)
-	} else {
-		return fake.downloadResourceUncheckedReturns.result1
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.downloadResourceUncheckedReturns.result1
 }
 
 func (fake *FakeDirector) DownloadResourceUncheckedCallCount() int {
@@ -1445,6 +2204,18 @@ func (fake *FakeDirector) DownloadResourceUncheckedArgsForCall(i int) (string, i
 func (fake *FakeDirector) DownloadResourceUncheckedReturns(result1 error) {
 	fake.DownloadResourceUncheckedStub = nil
 	fake.downloadResourceUncheckedReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeDirector) DownloadResourceUncheckedReturnsOnCall(i int, result1 error) {
+	fake.DownloadResourceUncheckedStub = nil
+	if fake.downloadResourceUncheckedReturnsOnCall == nil {
+		fake.downloadResourceUncheckedReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.downloadResourceUncheckedReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1504,6 +2275,8 @@ func (fake *FakeDirector) Invocations() map[string][][]interface{} {
 	defer fake.latestCloudConfigMutex.RUnlock()
 	fake.updateCloudConfigMutex.RLock()
 	defer fake.updateCloudConfigMutex.RUnlock()
+	fake.diffCloudConfigMutex.RLock()
+	defer fake.diffCloudConfigMutex.RUnlock()
 	fake.latestCPIConfigMutex.RLock()
 	defer fake.latestCPIConfigMutex.RUnlock()
 	fake.updateCPIConfigMutex.RLock()

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -45,6 +45,7 @@ type Director interface {
 
 	LatestCloudConfig() (CloudConfig, error)
 	UpdateCloudConfig([]byte) error
+	DiffCloudConfig(manifest []byte) (CloudConfigDiff, error)
 
 	LatestCPIConfig() (CPIConfig, error)
 	UpdateCPIConfig([]byte) error


### PR DESCRIPTION
* Regenerates fakes before changing anything. Seems like this hasn't been done in a while. If you don't like this, we can skip the first commit.
* Adds an `ignoreNotFound` flag in `director/client_request`, which seems ugly, but we didn't find a good way to achieve backwards compatibility