### PR TITLE
Homebrew formula defaults to `bosh` binary

### DIFF
--- a/ci/tasks/update-homebrew-formula.sh
+++ b/ci/tasks/update-homebrew-formula.sh
@@ -17,7 +17,7 @@ class BoshCli < Formula
 
   depends_on :arch => :x86_64
 
-  option "without-bosh2", "Don't rename binary to 'bosh2'. Useful if the old Ruby CLI is not needed."
+  option "with-bosh2", "Rename binary to 'bosh2'. Useful if the old Ruby CLI is needed."
 
   def install
     binary_name = build.without?("bosh2") ? "bosh" : "bosh2"


### PR DESCRIPTION
Now that the CLI is GA, this should be the default.

Note: `build.without?` still works even though the property is `with`.