### PR TITLE
Bump github.com/vito/go-interact/interact

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -8,7 +8,7 @@ github.com/onsi/gomega:f4f1cae
 golang.org/x/crypto/ssh:1e856cb
 gopkg.in/check.v1:8d49746
 github.com/pivotal-golang/yaml:8b09e4a
-github.com/vito/go-interact/interact:0eb3903
+github.com/vito/go-interact/interact:c573392
 github.com/cheggaaa/pb:c1f48d5
 github.com/cppforlife/go-semi-semantic/version:576b6af
 github.com/dustin/go-humanize:9436b7a

--- a/vendor/github.com/vito/go-interact/interact/interaction.go
+++ b/vendor/github.com/vito/go-interact/interact/interaction.go
@@ -67,7 +67,12 @@ func (interaction Interaction) Resolve(dst interface{}) error {
 
 		defer terminal.Restore(int(file.Fd()), state)
 
-		user = newTTYUser(interaction.Input, interaction.Output)
+		term, err := newTTYUser(file, interaction.Output)
+		if err != nil {
+			return err
+		}
+
+		user = term
 	} else {
 		user = newNonTTYUser(interaction.Input, interaction.Output)
 	}

--- a/vendor/github.com/vito/go-interact/interact/terminal/terminal.go
+++ b/vendor/github.com/vito/go-interact/interact/terminal/terminal.go
@@ -136,8 +136,11 @@ const (
 	keyPasteEnd
 )
 
-var pasteStart = []byte{keyEscape, '[', '2', '0', '0', '~'}
-var pasteEnd = []byte{keyEscape, '[', '2', '0', '1', '~'}
+var (
+	crlf       = []byte{'\r', '\n'}
+	pasteStart = []byte{keyEscape, '[', '2', '0', '0', '~'}
+	pasteEnd   = []byte{keyEscape, '[', '2', '0', '1', '~'}
+)
 
 // bytesToKey tries to parse a key sequence from b. If successful, it returns
 // the key and the remainder of the input. Otherwise it returns utf8.RuneError.
@@ -337,7 +340,7 @@ func (t *Terminal) advanceCursor(places int) {
 		// So, if we are stopping at the end of a line, we
 		// need to write a newline so that our cursor can be
 		// advanced to the next line.
-		t.outBuf = append(t.outBuf, '\n')
+		t.outBuf = append(t.outBuf, '\r', '\n')
 	}
 }
 
@@ -597,6 +600,35 @@ func (t *Terminal) writeLine(line []rune) {
 	}
 }
 
+// writeWithCRLF writes buf to w but replaces all occurrences of \n with \r\n.
+func writeWithCRLF(w io.Writer, buf []byte) (n int, err error) {
+	for len(buf) > 0 {
+		i := bytes.IndexByte(buf, '\n')
+		todo := len(buf)
+		if i >= 0 {
+			todo = i
+		}
+
+		var nn int
+		nn, err = w.Write(buf[:todo])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		buf = buf[todo:]
+
+		if i >= 0 {
+			if _, err = w.Write(crlf); err != nil {
+				return n, err
+			}
+			n += 1
+			buf = buf[1:]
+		}
+	}
+
+	return n, nil
+}
+
 func (t *Terminal) Write(buf []byte) (n int, err error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
@@ -604,7 +636,7 @@ func (t *Terminal) Write(buf []byte) (n int, err error) {
 	if t.cursorX == 0 && t.cursorY == 0 {
 		// This is the easy case: there's nothing on the screen that we
 		// have to move out of the way.
-		return t.c.Write(buf)
+		return writeWithCRLF(t.c, buf)
 	}
 
 	// We have a prompt and possibly user input on the screen. We
@@ -624,7 +656,7 @@ func (t *Terminal) Write(buf []byte) (n int, err error) {
 	}
 	t.outBuf = t.outBuf[:0]
 
-	if n, err = t.c.Write(buf); err != nil {
+	if n, err = writeWithCRLF(t.c, buf); err != nil {
 		return
 	}
 
@@ -747,8 +779,6 @@ func (t *Terminal) readLine() (line string, err error) {
 
 		t.remainder = t.inBuf[:n+len(t.remainder)]
 	}
-
-	panic("unreachable") // for Go 1.0.
 }
 
 // SetPrompt sets the prompt to be used when reading subsequent lines.
@@ -896,4 +926,33 @@ func (s *stRingBuffer) NthPreviousEntry(n int) (value string, ok bool) {
 		index += s.max
 	}
 	return s.entries[index], true
+}
+
+// readPasswordLine reads from reader until it finds \n or io.EOF.
+// The slice returned does not include the \n.
+// readPasswordLine also ignores any \r it finds.
+func readPasswordLine(reader io.Reader) ([]byte, error) {
+	var buf [1]byte
+	var ret []byte
+
+	for {
+		n, err := reader.Read(buf[:])
+		if n > 0 {
+			switch buf[0] {
+			case '\n':
+				return ret, nil
+			case '\r':
+				// remove \r from passwords on Windows
+			default:
+				ret = append(ret, buf[0])
+			}
+			continue
+		}
+		if err != nil {
+			if err == io.EOF && len(ret) > 0 {
+				return ret, nil
+			}
+			return ret, err
+		}
+	}
 }

--- a/vendor/github.com/vito/go-interact/interact/terminal/util.go
+++ b/vendor/github.com/vito/go-interact/interact/terminal/util.go
@@ -17,7 +17,6 @@
 package terminal
 
 import (
-	"io"
 	"syscall"
 	"unsafe"
 )
@@ -44,8 +43,13 @@ func MakeRaw(fd int) (*State, error) {
 	}
 
 	newState := oldState.termios
-	newState.Iflag &^= syscall.ISTRIP | syscall.INLCR | syscall.ICRNL | syscall.IGNCR | syscall.IXON | syscall.IXOFF
-	newState.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG
+	// This attempts to replicate the behaviour documented for cfmakeraw in
+	// the termios(3) manpage.
+	newState.Iflag &^= syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IXON
+	newState.Oflag &^= syscall.OPOST
+	newState.Lflag &^= syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
+	newState.Cflag &^= syscall.CSIZE | syscall.PARENB
+	newState.Cflag |= syscall.CS8
 	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
 		return nil, err
 	}
@@ -67,8 +71,10 @@ func GetState(fd int) (*State, error) {
 // Restore restores the terminal connected to the given file descriptor to a
 // previous state.
 func Restore(fd int, state *State) error {
-	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&state.termios)), 0, 0, 0)
-	return err
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&state.termios)), 0, 0, 0); err != 0 {
+		return err
+	}
+	return nil
 }
 
 // GetSize returns the dimensions of the given terminal.
@@ -79,6 +85,13 @@ func GetSize(fd int) (width, height int, err error) {
 		return -1, -1, err
 	}
 	return int(dimensions[1]), int(dimensions[0]), nil
+}
+
+// passwordReader is an io.Reader that reads from a specific file descriptor.
+type passwordReader int
+
+func (r passwordReader) Read(buf []byte) (int, error) {
+	return syscall.Read(int(r), buf)
 }
 
 // ReadPassword reads a line of input from a terminal without local echo.  This
@@ -102,27 +115,5 @@ func ReadPassword(fd int) ([]byte, error) {
 		syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0)
 	}()
 
-	var buf [16]byte
-	var ret []byte
-	for {
-		n, err := syscall.Read(fd, buf[:])
-		if err != nil {
-			return nil, err
-		}
-		if n == 0 {
-			if len(ret) == 0 {
-				return nil, io.EOF
-			}
-			break
-		}
-		if buf[n-1] == '\n' {
-			n--
-		}
-		ret = append(ret, buf[:n]...)
-		if n < len(buf) {
-			break
-		}
-	}
-
-	return ret, nil
+	return readPasswordLine(passwordReader(fd))
 }

--- a/vendor/github.com/vito/go-interact/interact/terminal/util_plan9.go
+++ b/vendor/github.com/vito/go-interact/interact/terminal/util_plan9.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type State struct{}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	return false
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	return nil, fmt.Errorf("terminal: MakeRaw not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	return nil, fmt.Errorf("terminal: GetState not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	return fmt.Errorf("terminal: Restore not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	return 0, 0, fmt.Errorf("terminal: GetSize not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	return nil, fmt.Errorf("terminal: ReadPassword not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/vendor/github.com/vito/go-interact/interact/terminal/util_solaris.go
+++ b/vendor/github.com/vito/go-interact/interact/terminal/util_solaris.go
@@ -1,0 +1,73 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build solaris
+
+package terminal // import "golang.org/x/crypto/ssh/terminal"
+
+import (
+	"golang.org/x/sys/unix"
+	"io"
+	"syscall"
+)
+
+// State contains the state of a terminal.
+type State struct {
+	termios syscall.Termios
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(fd, unix.TCGETA, &termio)
+	return err == nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	// see also: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libast/common/uwin/getpass.c
+	val, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return nil, err
+	}
+	oldState := *val
+
+	newState := oldState
+	newState.Lflag &^= syscall.ECHO
+	newState.Lflag |= syscall.ICANON | syscall.ISIG
+	newState.Iflag |= syscall.ICRNL
+	err = unix.IoctlSetTermios(fd, unix.TCSETS, &newState)
+	if err != nil {
+		return nil, err
+	}
+
+	defer unix.IoctlSetTermios(fd, unix.TCSETS, &oldState)
+
+	var buf [16]byte
+	var ret []byte
+	for {
+		n, err := syscall.Read(fd, buf[:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			if len(ret) == 0 {
+				return nil, io.EOF
+			}
+			break
+		}
+		if buf[n-1] == '\n' {
+			n--
+		}
+		ret = append(ret, buf[:n]...)
+		if n < len(buf) {
+			break
+		}
+	}
+
+	return ret, nil
+}

--- a/vendor/github.com/vito/go-interact/interact/userio.go
+++ b/vendor/github.com/vito/go-interact/interact/userio.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/vito/go-interact/interact/terminal"
 )
@@ -21,10 +22,22 @@ type ttyUser struct {
 
 var ErrKeyboardInterrupt = errors.New("keyboard interrupt")
 
-func newTTYUser(input io.Reader, output io.Writer) ttyUser {
-	return ttyUser{
-		Terminal: terminal.NewTerminal(readWriter{input, output}, ""),
+func newTTYUser(input *os.File, output io.Writer) (ttyUser, error) {
+	term := terminal.NewTerminal(readWriter{input, output}, "")
+
+	width, height, err := terminal.GetSize(int(input.Fd()))
+	if err != nil {
+		return ttyUser{}, err
 	}
+
+	err = term.SetSize(width, height)
+	if err != nil {
+		return ttyUser{}, err
+	}
+
+	return ttyUser{
+		Terminal: term,
+	}, nil
 }
 
 func (u ttyUser) WriteLine(line string) error {


### PR DESCRIPTION
 * fixes extra newlines in longer prompts
 * fixes cloudfoundry/bosh-cli#31

Full vendor diff at [0eb3903...c573392](https://github.com/vito/go-interact/compare/0eb3903...c573392); only skimmed it

Manually verified; lightly tested other commands; units/integration green; acceptance too confusing