### PR TITLE
Make SSH username compatible with Windows

### DIFF
--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 var _ = Describe("LogsCmd", func() {
+	const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+	const ExpUsername = "bosh_8c5ff117957245c"
+
 	var (
 		deployment      *fakedir.FakeDeployment
 		downloader      *fakecmd.FakeDownloader
@@ -35,6 +38,7 @@ var _ = Describe("LogsCmd", func() {
 	})
 
 	Describe("Run", func() {
+
 		var (
 			opts LogsOpts
 		)
@@ -136,10 +140,11 @@ var _ = Describe("LogsCmd", func() {
 		})
 
 		Context("when tailing logs (or specifying number of lines)", func() {
+
 			BeforeEach(func() {
 				opts.Follow = true
 				opts.GatewayFlags.UUIDGen = uuidGen
-				uuidGen.GeneratedUUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+				uuidGen.GeneratedUUID = UUID
 			})
 
 			It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
@@ -155,7 +160,7 @@ var _ = Describe("LogsCmd", func() {
 
 				setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
 				Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
-				Expect(setupSSHOpts.Username).To(Equal("bosh_8c5ff117957245c5"))
+				Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
 				Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
 
 				slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)

--- a/cmd/scp_test.go
+++ b/cmd/scp_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 var _ = Describe("SCPCmd", func() {
+	const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+	const ExpUsername = "bosh_8c5ff117957245c"
+
 	var (
 		deployment *fakedir.FakeDeployment
 		uuidGen    *fakeuuid.FakeGenerator
@@ -43,7 +46,7 @@ var _ = Describe("SCPCmd", func() {
 					UUIDGen: uuidGen,
 				},
 			}
-			uuidGen.GeneratedUUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+			uuidGen.GeneratedUUID = UUID
 		})
 
 		act := func() error { return command.Run(opts) }
@@ -66,7 +69,7 @@ var _ = Describe("SCPCmd", func() {
 
 				setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
 				Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("from", "")))
-				Expect(setupSSHOpts.Username).To(Equal("bosh_8c5ff117957245c5"))
+				Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
 				Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
 
 				slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -38,6 +38,9 @@ var _ = Describe("SSHCmd", func() {
 	})
 
 	Describe("Run", func() {
+		const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+		const ExpUsername = "bosh_8c5ff117957245c"
+
 		var (
 			opts SSHOpts
 		)
@@ -53,7 +56,7 @@ var _ = Describe("SSHCmd", func() {
 				},
 			}
 
-			uuidGen.GeneratedUUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+			uuidGen.GeneratedUUID = UUID
 		})
 
 		act := func() error { return command.Run(opts) }
@@ -77,7 +80,7 @@ var _ = Describe("SSHCmd", func() {
 
 					setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
 					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", "")))
-					Expect(setupSSHOpts.Username).To(Equal("bosh_8c5ff117957245c5"))
+					Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
 					Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
 
 					slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
@@ -162,7 +165,7 @@ var _ = Describe("SSHCmd", func() {
 
 					setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
 					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", "")))
-					Expect(setupSSHOpts.Username).To(Equal("bosh_8c5ff117957245c5"))
+					Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
 					Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
 
 					slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)

--- a/director/ssh_opts.go
+++ b/director/ssh_opts.go
@@ -29,8 +29,8 @@ func NewSSHOpts(uuidGen boshuuid.Generator) (SSHOpts, string, error) {
 		return SSHOpts{}, "", bosherr.WrapErrorf(err, "Generating unique SSH user suffix")
 	}
 
-	// username cannot be >32
-	nameSuffix = strings.Replace(nameSuffix, "-", "", -1)[0:16]
+	// username must be <= 20 for Windows
+	nameSuffix = strings.Replace(nameSuffix, "-", "", -1)[0:15]
 
 	sshOpts := SSHOpts{
 		Username:  "bosh_" + nameSuffix,


### PR DESCRIPTION
Windows has a max username length of 20 chars, the bosh-cli was
generating a username 21 chars long, this commit reduces the username
length by 1 to 20.

@natalieparellano 

[#145070025]

Signed-off-by: Charlie Vieth <cviethjr@pivotal.io>