### PR TITLE
Document windows username restrictions

### DIFF
--- a/director/ssh_opts_test.go
+++ b/director/ssh_opts_test.go
@@ -28,6 +28,16 @@ var _ = Describe("NewSSHOpts", func() {
 		}
 	})
 
+	// Windows logon names cannot contain certain characters, and when
+	// created through NET USER, which the BOSH Agent does, must be 20
+	// characters or less (this is to maintain backwards compatibility
+	// with Windows 2000).
+	//
+	// The invalid characters are:
+	//   " / \ [ ] : ; | = , + * ? < >
+	//
+	// Reference: https://msdn.microsoft.com/en-us/library/bb726984.aspx
+	//
 	It("generates a username that is compatible with Windows", func() {
 		const MaxLength = 20
 		const InvalidChars = "\"/\\[]:|<>+=;?*"


### PR DESCRIPTION
Document Windows username restrictions in `ssh` options test and add reference to [Microsoft docs](https://msdn.microsoft.com/en-us/library/bb726984.aspx).

This is done in response to @dpb587-pivotal comments in PR https://github.com/cloudfoundry/bosh-cli/pull/222#discussion_r116620980