### PR TITLE
Upload releases in parallel on deploy

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -238,7 +238,8 @@ func (c Cmd) Execute() (cmdErr error) {
 
 	case *UpdateRuntimeConfigOpts:
 		director := c.director()
-		releaseManager := c.releaseManager(director)
+		parallelUploads := opts.ParallelOpt
+		releaseManager := c.releaseManager(director, parallelUploads)
 		return NewUpdateRuntimeConfigCmd(deps.UI, director, releaseManager).Run(*opts)
 
 	case *ManifestOpts:
@@ -270,7 +271,8 @@ func (c Cmd) Execute() (cmdErr error) {
 
 	case *DeployOpts:
 		director, deployment := c.directorAndDeployment()
-		releaseManager := c.releaseManager(director)
+		parallelUploads := opts.ParallelOpt
+		releaseManager := c.releaseManager(director, parallelUploads)
 		return NewDeployCmd(deps.UI, deployment, releaseManager).Run(*opts)
 
 	case *StartOpts:
@@ -468,7 +470,7 @@ func (c Cmd) releaseProviders() (boshrel.Provider, boshreldir.Provider) {
 	return releaseProvider, releaseDirProvider
 }
 
-func (c Cmd) releaseManager(director boshdir.Director) ReleaseManager {
+func (c Cmd) releaseManager(director boshdir.Director, parallelUploads int) ReleaseManager {
 	relProv, relDirProv := c.releaseProviders()
 
 	releaseDirFactory := func(dir DirOrCWDArg) (boshrel.Reader, boshreldir.ReleaseDir) {
@@ -488,7 +490,7 @@ func (c Cmd) releaseManager(director boshdir.Director) ReleaseManager {
 	uploadReleaseCmd := NewUploadReleaseCmd(
 		releaseDirFactory, releaseWriter, director, releaseArchiveFactory, c.deps.CmdRunner, c.deps.FS, c.deps.UI)
 
-	return NewReleaseManager(createReleaseCmd, uploadReleaseCmd)
+	return NewReleaseManager(createReleaseCmd, uploadReleaseCmd, parallelUploads)
 }
 
 func (c Cmd) blobsDir(dir DirOrCWDArg) boshreldir.BlobsDir {

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -365,6 +365,8 @@ var _ = Describe("Factory", func() {
 			boshOpts.UploadBlobs = UploadBlobsOpts{}
 			boshOpts.SSH = SSHOpts{}
 			boshOpts.SCP = SCPOpts{}
+			boshOpts.Deploy = DeployOpts{}
+			boshOpts.UpdateRuntimeConfig = UpdateRuntimeConfigOpts{}
 			return boshOpts
 		}
 

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -328,7 +328,8 @@ type UpdateRuntimeConfigOpts struct {
 	VarFlags
 	OpsFlags
 
-	Name string `long:"name" description:"Runtime-Config name (default: '')" default:""`
+	Name        string `long:"name" description:"Runtime-Config name (default: '')" default:""`
+	ParallelOpt int    `long:"parallel" description:"Upload releases from manifest in parallel with given number of nodes (default: 5)" default:"5"`
 
 	cmd
 }
@@ -352,7 +353,8 @@ type DeployOpts struct {
 	VarFlags
 	OpsFlags
 
-	NoRedact bool `long:"no-redact" description:"Show non-redacted manifest diff"`
+	NoRedact    bool `long:"no-redact" description:"Show non-redacted manifest diff"`
+	ParallelOpt int  `long:"parallel" description:"Upload releases from manifest in parallel with given number of nodes (default: 5)" default:"5"`
 
 	Recreate  bool                `long:"recreate"                          description:"Recreate all VMs in deployment"`
 	Fix       bool                `long:"fix"                               description:"Recreate unresponsive instances"`

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -1091,6 +1091,12 @@ var _ = Describe("Opts", func() {
 				Expect(getStructTagForName("Name", opts)).To(Equal(`long:"name" description:"Runtime-Config name (default: '')" default:""`))
 			})
 		})
+
+		Describe("ParallelOpt", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("ParallelOpt", opts)).To(Equal(`long:"parallel" description:"Upload releases from manifest in parallel with given number of nodes (default: 5)" default:"5"`))
+			})
+		})
 	})
 
 	Describe("UpdateRuntimeConfigArgs", func() {
@@ -1135,6 +1141,12 @@ var _ = Describe("Opts", func() {
 				Expect(getStructTagForName("NoRedact", opts)).To(Equal(
 					`long:"no-redact" description:"Show non-redacted manifest diff"`,
 				))
+			})
+		})
+
+		Describe("ParallelOpt", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("ParallelOpt", opts)).To(Equal(`long:"parallel" description:"Upload releases from manifest in parallel with given number of nodes (default: 5)" default:"5"`))
 			})
 		})
 

--- a/cmd/release_manager.go
+++ b/cmd/release_manager.go
@@ -13,6 +13,7 @@ import (
 type ReleaseManager struct {
 	createReleaseCmd ReleaseCreatingCmd
 	uploadReleaseCmd ReleaseUploadingCmd
+	parallelThreads  int
 }
 
 type ReleaseUploadingCmd interface {
@@ -26,8 +27,9 @@ type ReleaseCreatingCmd interface {
 func NewReleaseManager(
 	createReleaseCmd ReleaseCreatingCmd,
 	uploadReleaseCmd ReleaseUploadingCmd,
+	parallelThreads int,
 ) ReleaseManager {
-	return ReleaseManager{createReleaseCmd, uploadReleaseCmd}
+	return ReleaseManager{createReleaseCmd, uploadReleaseCmd, parallelThreads}
 }
 
 func (m ReleaseManager) UploadReleases(bytes []byte) ([]byte, error) {
@@ -36,15 +38,9 @@ func (m ReleaseManager) UploadReleases(bytes []byte) ([]byte, error) {
 		return nil, bosherr.WrapErrorf(err, "Parsing manifest")
 	}
 
-	var opss patch.Ops
-
-	for _, rel := range manifest.Releases {
-		ops, err := m.createAndUploadRelease(rel)
-		if err != nil {
-			return nil, bosherr.WrapErrorf(err, "Processing release '%s/%s'", rel.Name, rel.Version)
-		}
-
-		opss = append(opss, ops)
+	opss, err := m.parallelCreateAndUpload(manifest)
+	if err != nil {
+		return nil, bosherr.WrapErrorf(err, "Creating an uploading releases")
 	}
 
 	tpl := boshtpl.NewTemplate(bytes)
@@ -55,6 +51,32 @@ func (m ReleaseManager) UploadReleases(bytes []byte) ([]byte, error) {
 	}
 
 	return bytes, nil
+}
+
+func (m ReleaseManager) parallelCreateAndUpload(manifest boshdir.Manifest) (patch.Ops, error) {
+	pool := WorkerPool{
+		WorkerCount: m.parallelThreads,
+	}
+
+	tasks := []func() (interface{}, error){}
+	for _, r := range manifest.Releases {
+		release := r
+		tasks = append(tasks, func() (interface{}, error) {
+			return m.createAndUploadRelease(release)
+		})
+	}
+
+	results, err := pool.ParallelDo(tasks...)
+	if err != nil {
+		return nil, err
+	}
+
+	var opss patch.Ops
+	for _, result := range results {
+		opss = append(opss, result.(patch.Ops))
+	}
+
+	return opss, nil
 }
 
 func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (patch.Ops, error) {

--- a/cmd/worker_pool.go
+++ b/cmd/worker_pool.go
@@ -1,0 +1,74 @@
+package cmd
+
+import bosherr "github.com/cloudfoundry/bosh-utils/errors"
+
+type WorkerPool struct {
+	WorkerCount int
+}
+
+// Runs the given set of tasks in parallel using the configured number of worker go routines
+// Will stop adding new tasks if a task throws an error, but will wait for in-flight tasks to finish
+func (w WorkerPool) ParallelDo(tasks ...func() (interface{}, error)) ([]interface{}, error) {
+	jobs := make(chan func() (interface{}, error))
+	results := make(chan interface{}, len(tasks))
+	errs := make(chan error, len(tasks))
+	done := make(chan bool)
+
+	for i := 0; i < w.WorkerCount; i++ {
+		w.spawnWorker(jobs, results, errs, done)
+	}
+
+	for _, task := range tasks {
+		select {
+		case jobs <- task:
+			// add another job
+		case err := <-errs:
+			// stop adding jobs
+			errs <- err
+			break
+		}
+	}
+	close(jobs)
+
+	for i := 0; i < w.WorkerCount; i++ {
+		<-done
+	}
+	close(results)
+	close(errs)
+
+	combinedResults := []interface{}{}
+	for result := range results {
+		combinedResults = append(combinedResults, result)
+	}
+
+	var combinedErr error
+	for err := range errs {
+		if combinedErr == nil {
+			combinedErr = err
+		} else {
+			combinedErr = bosherr.WrapError(combinedErr, err.Error())
+		}
+	}
+
+	if combinedErr != nil {
+		return nil, combinedErr
+	}
+
+	return combinedResults, nil
+}
+
+func (w WorkerPool) spawnWorker(tasks <-chan func() (interface{}, error), results chan<- interface{}, errs chan<- error, done chan<- bool) {
+	go func() {
+		for task := range tasks {
+			result, err := task()
+			if err != nil {
+				errs <- err
+				break
+			} else {
+				results <- result
+			}
+		}
+
+		done <- true
+	}()
+}

--- a/cmd/worker_pool_test.go
+++ b/cmd/worker_pool_test.go
@@ -1,0 +1,83 @@
+package cmd_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-cli/cmd"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+)
+
+var _ = Describe("WorkerPool", func() {
+	It("runs the given tasks", func() {
+		pool := WorkerPool{
+			WorkerCount: 2,
+		}
+
+		results, err := pool.ParallelDo(
+			func() (interface{}, error) {
+				return 1, nil
+			},
+			func() (interface{}, error) {
+				return 2, nil
+			},
+			func() (interface{}, error) {
+				return 3, nil
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(results).To(ConsistOf([]int{1, 2, 3}))
+	})
+
+	It("bubbles up any errors", func() {
+		pool := WorkerPool{
+			WorkerCount: 2,
+		}
+
+		_, err := pool.ParallelDo(
+			func() (interface{}, error) {
+				return 1, nil
+			},
+			func() (interface{}, error) {
+				return -1, bosherr.ComplexError{
+					Err:   errors.New("fake-error"),
+					Cause: errors.New("fake-cause"),
+				}
+			},
+			func() (interface{}, error) {
+				return 3, nil
+			},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("fake-error"))
+		Expect(err.Error()).To(ContainSubstring("fake-cause"))
+	})
+
+	It("stops working after the first error", func() {
+		pool := WorkerPool{
+			WorkerCount: 1, // Force serial run
+		}
+
+		_, err := pool.ParallelDo(
+			func() (interface{}, error) {
+				return 1, nil
+			},
+			func() (interface{}, error) {
+				return -1, bosherr.ComplexError{
+					Err:   errors.New("fake-error"),
+					Cause: errors.New("fake-cause"),
+				}
+			},
+			func() (interface{}, error) {
+				Fail("Expected third test to not run")
+				return 3, nil
+			},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("fake-error"))
+		Expect(err.Error()).To(ContainSubstring("fake-cause"))
+	})
+})

--- a/director/factory.go
+++ b/director/factory.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"net/url"
 
+	"time"
+
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshhttp "github.com/cloudfoundry/bosh-utils/http"
 	boshhttpclient "github.com/cloudfoundry/bosh-utils/httpclient"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-	"time"
 )
 
 type Factory struct {

--- a/director/factory_test.go
+++ b/director/factory_test.go
@@ -185,9 +185,16 @@ var _ = Describe("Factory", func() {
 				)
 
 				director.LatestCloudConfig()
-				_, _, args := logger.DebugArgsForCall(1)
 
-				Expect(args[0]).To(ContainSubstring("/cloud_configs?limit=1"))
+				debugMsgs := []interface{}{}
+				for i := 0; i < logger.DebugCallCount(); i++ {
+					_, _, args := logger.DebugArgsForCall(i)
+					if len(args) >= 1 {
+						debugMsgs = append(debugMsgs, args[0])
+					}
+				}
+
+				Expect(debugMsgs).To(ContainElement(ContainSubstring("/cloud_configs?limit=1")))
 			})
 
 			It("succeeds making requests and follow redirects with token", func() {

--- a/ui/task/reporter_test.go
+++ b/ui/task/reporter_test.go
@@ -87,10 +87,9 @@ var _ = Describe("Reporter (for events)", func() {
 			Expect(outBuf.String()).To(Equal(`Task 123
 
 
-Started  Thu Jan  1 00:00:00 UTC 1970
-Finished Thu Jan  1 00:00:00 UTC 1970
-Duration 00:00:00
-
+Task 123 Started  Thu Jan  1 00:00:00 UTC 1970
+Task 123 Finished Thu Jan  1 00:00:00 UTC 1970
+Task 123 Duration 00:00:00
 Task 123 state
 `))
 		})
@@ -114,7 +113,7 @@ Task 123 state
 			reporterWithFakeUI.TaskOutputChunk(123, []byte(
 				`{"time":1454193505,"error":{"code":100,"message":"err-msg"}}`+"\n"))
 			reporterWithFakeUI.TaskFinished(123, "state")
-			Expect(fakeUI.Blocks).To(Equal([]string{"\n22:38:25 | ", "Error: err-msg"}))
+			Expect(fakeUI.Blocks).To(Equal([]string{"\n22:38:25 | Task 123 | ", "Error: err-msg"}))
 		})
 
 		It("renders events", func() {
@@ -166,27 +165,77 @@ Task 123 state
 			reporter.TaskFinished(2663, "error")
 			Expect(outBuf.String()).To(Equal(`Task 2663
 
-19:09:27 | Preparing deployment: Binding releases (00:00:00)
-19:09:27 | Preparing deployment: Binding existing deployment (00:00:00)
-19:09:27 | Preparing deployment: Binding resource pools (00:00:00)
-19:09:27 | Preparing deployment: Binding stemcells (00:00:00)
-19:09:27 | Preparing deployment: Binding templates (00:00:00)
-19:09:27 | Preparing deployment: Binding properties (00:00:00)
-19:09:27 | Preparing deployment: Binding unallocated VMs (00:00:00)
-19:09:27 | Preparing deployment: Binding instance networks (00:00:00)
-19:09:27 | Preparing package compilation: Finding packages to compile (00:00:00)
-19:09:27 | Preparing DNS: Binding DNS (00:00:00)
-19:09:27 | Preparing configuration: Binding configuration (00:00:01)
-19:09:28 | Updating job job: job/0 (canary) (00:01:07)
-            L Error: 'job/0' is not running after update
+19:09:27 | Task 2663 | Preparing deployment: Binding releases (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding existing deployment (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding resource pools (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding stemcells (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding templates (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding properties (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding unallocated VMs (00:00:00)
+19:09:27 | Task 2663 | Preparing deployment: Binding instance networks (00:00:00)
+19:09:27 | Task 2663 | Preparing package compilation: Finding packages to compile (00:00:00)
+19:09:27 | Task 2663 | Preparing DNS: Binding DNS (00:00:00)
+19:09:27 | Task 2663 | Preparing configuration: Binding configuration (00:00:01)
+19:09:28 | Task 2663 | Updating job job: job/0 (canary) (00:01:07)
+         L Task 2663 | Error: 'job/0' is not running after update
 
-19:10:35 | Error: 'job/0' is not running after update
+19:10:35 | Task 2663 | Error: 'job/0' is not running after update
 
-Started  Wed Dec 19 19:09:27 UTC 2204
-Finished Wed Dec 19 19:10:35 UTC 2204
-Duration 00:01:08
-
+Task 2663 Started  Wed Dec 19 19:09:27 UTC 2204
+Task 2663 Finished Wed Dec 19 19:10:35 UTC 2204
+Task 2663 Duration 00:01:08
 Task 2663 error
+`))
+		})
+
+		It("renders multiple events", func() {
+			firstTaskOutput := []string{`
+{"time":7414830567,"stage":"Preparing first deployment","tags":[],"total":1,"task":"Binding releases","index":1,"state":"started","progress":0}
+{"time":7414830567,"stage":"Preparing first deployment","tags":[],"total":1,"task":"Binding releases","index":1,"state":"finished","progress":100}
+{"time":7414830567,"stage":"Updating job","tags":["job"],"total":1,"task":"job/0 (canary)","index":1,"state":"started","progress":0}
+`,
+				`
+{"time":7414830571,"stage":"Updating job","tags":["job"],"total":1,"task":"job/0 (canary)","index":1,"state":"failed","progress":100,"data":{"error":"'job/0' is not running after update"}}
+{"time":7414830571,"error":{"code":400007,"message":"'job/0' is not running after update"}}
+`}
+
+			secondTaskOutput := []string{`
+{"time":7414830568,"stage":"Preparing second deployment","tags":[],"total":1,"task":"Binding releases","index":1,"state":"started","progress":0}
+{"time":7414830568,"stage":"Preparing second deployment","tags":[],"total":1,"task":"Binding releases","index":1,"state":"finished","progress":100}
+`,
+				`
+{"time":7414830569,"stage":"Preparing second package compilation","tags":[],"total":1,"task":"Finding packages to compile","index":1,"state":"started","progress":0}
+{"time":7414830569,"stage":"Preparing second package compilation","tags":[],"total":1,"task":"Finding packages to compile","index":1,"state":"finished","progress":100}
+`}
+			reporter.TaskStarted(2663)
+			reporter.TaskStarted(7777)
+			reporter.TaskOutputChunk(2663, []byte(firstTaskOutput[0]))
+			reporter.TaskOutputChunk(7777, []byte(secondTaskOutput[0]))
+			reporter.TaskOutputChunk(7777, []byte(secondTaskOutput[1]))
+			reporter.TaskOutputChunk(2663, []byte(firstTaskOutput[1]))
+			reporter.TaskFinished(7777, "state-2")
+			reporter.TaskFinished(2663, "state-1")
+			Expect(outBuf.String()).To(Equal(`Task 2663
+Task 7777
+19:09:27 | Task 2663 | Preparing first deployment: Binding releases (00:00:00)
+19:09:27 | Task 2663 | Updating job job: job/0 (canary)
+19:09:28 | Task 7777 | Preparing second deployment: Binding releases (00:00:00)
+19:09:29 | Task 7777 | Preparing second package compilation: Finding packages to compile (00:00:00)
+19:09:31 | Task 2663 | Updating job job: job/0 (canary) (00:00:04)
+         L Task 2663 | Error: 'job/0' is not running after update
+
+19:09:31 | Task 2663 | Error: 'job/0' is not running after update
+
+Task 7777 Started  Wed Dec 19 19:09:28 UTC 2204
+Task 7777 Finished Wed Dec 19 19:09:29 UTC 2204
+Task 7777 Duration 00:00:01
+Task 7777 state-2
+
+
+Task 2663 Started  Wed Dec 19 19:09:27 UTC 2204
+Task 2663 Finished Wed Dec 19 19:09:31 UTC 2204
+Task 2663 Duration 00:00:04
+Task 2663 state-1
 `))
 		})
 
@@ -202,16 +251,15 @@ Task 2663 error
 			reporter.TaskFinished(2663, "error")
 			Expect(outBuf.String()).To(Equal(`Task 2663
 
-00:41:24 | Deprecation: Ignoring cloud config. Manifest contains 'networks' section.
+00:41:24 | Task 2663 | Deprecation: Ignoring cloud config. Manifest contains 'networks' section.
 
-00:41:24 | Error: Failed to find keys in the config server: bool, bool2
+00:41:24 | Task 2663 | Error: Failed to find keys in the config server: bool, bool2
 
-00:41:24 | Error: Failed to wang chung tonite
+00:41:24 | Task 2663 | Error: Failed to wang chung tonite
 
-Started  Tue Jul 19 00:41:24 UTC 2016
-Finished Tue Jul 19 00:41:24 UTC 2016
-Duration 00:00:00
-
+Task 2663 Started  Tue Jul 19 00:41:24 UTC 2016
+Task 2663 Finished Tue Jul 19 00:41:24 UTC 2016
+Task 2663 Duration 00:00:00
 Task 2663 error
 `))
 		})
@@ -230,14 +278,13 @@ Task 2663 error
 			reporter.TaskFinished(2663, "error")
 			Expect(outBuf.String()).To(Equal(`Task 2663
 
-00:26:38 | Preparing deployment: Preparing deployment (00:00:00)
-00:26:38 | Warning: You have ignored instances. They will not be changed.
-00:26:38 | Preparing package compilation: Finding packages to compile (00:00:00)
+00:26:38 | Task 2663 | Preparing deployment: Preparing deployment (00:00:00)
+00:26:38 | Task 2663 | Warning: You have ignored instances. They will not be changed.
+00:26:38 | Task 2663 | Preparing package compilation: Finding packages to compile (00:00:00)
 
-Started  Tue Nov  8 00:26:38 UTC 2016
-Finished Tue Nov  8 00:26:38 UTC 2016
-Duration 00:00:00
-
+Task 2663 Started  Tue Nov  8 00:26:38 UTC 2016
+Task 2663 Finished Tue Nov  8 00:26:38 UTC 2016
+Task 2663 Duration 00:00:00
 Task 2663 error
 `))
 		})


### PR DESCRIPTION
- When release URLs are listed in your manifest, this PR will upload those
  releases to the Director in parallel rather than serial.
- Each line of output in task_reporter now shows the task ID as events
  from multiple tasks can happen in parallel
- If a task returns an error, the WorkerPool will stop adding new tasks
  to the pool and wait for in-flight tasks to finish