### PR TITLE
Follow symlinks in jobs

### DIFF
--- a/release/job/dir_reader.go
+++ b/release/job/dir_reader.go
@@ -25,7 +25,7 @@ func (r DirReaderImpl) Read(path string) (*Job, error) {
 		return nil, bosherr.WrapErrorf(err, "Collecting job files")
 	}
 
-	archive := r.archiveFactory(files, nil, nil)
+	archive := r.archiveFactory(files, nil, nil, true /*followSymlinks*/)
 
 	fp, err := archive.Fingerprint()
 	if err != nil {

--- a/release/job/dir_reader.go
+++ b/release/job/dir_reader.go
@@ -25,7 +25,7 @@ func (r DirReaderImpl) Read(path string) (*Job, error) {
 		return nil, bosherr.WrapErrorf(err, "Collecting job files")
 	}
 
-	archive := r.archiveFactory(files, nil, nil, true /*followSymlinks*/)
+	archive := r.archiveFactory(ArchiveFactoryArgs{Files: files, FollowSymlinks: true})
 
 	fp, err := archive.Fingerprint()
 	if err != nil {

--- a/release/job/dir_reader_test.go
+++ b/release/job/dir_reader_test.go
@@ -15,20 +15,22 @@ import (
 
 var _ = Describe("DirReaderImpl", func() {
 	var (
-		collectedFiles     []File
-		collectedPrepFiles []File
-		collectedChunks    []string
-		archive            *fakeres.FakeArchive
-		fs                 *fakesys.FakeFileSystem
-		reader             DirReaderImpl
+		collectedFiles          []File
+		collectedPrepFiles      []File
+		collectedChunks         []string
+		collectedFollowSymlinks bool
+		archive                 *fakeres.FakeArchive
+		fs                      *fakesys.FakeFileSystem
+		reader                  DirReaderImpl
 	)
 
 	BeforeEach(func() {
 		archive = &fakeres.FakeArchive{}
-		archiveFactory := func(files, prepFiles []File, chunks []string) Archive {
+		archiveFactory := func(files, prepFiles []File, chunks []string, followSymlinks bool) Archive {
 			collectedFiles = files
 			collectedPrepFiles = prepFiles
 			collectedChunks = chunks
+			collectedFollowSymlinks = followSymlinks
 			return archive
 		}
 		fs = fakesys.NewFakeFileSystem()
@@ -67,6 +69,7 @@ properties:
 
 			Expect(collectedPrepFiles).To(BeEmpty())
 			Expect(collectedChunks).To(BeEmpty())
+			Expect(collectedFollowSymlinks).To(BeTrue())
 		})
 
 		It("returns a job with the details without monit file", func() {

--- a/release/job/dir_reader_test.go
+++ b/release/job/dir_reader_test.go
@@ -26,11 +26,11 @@ var _ = Describe("DirReaderImpl", func() {
 
 	BeforeEach(func() {
 		archive = &fakeres.FakeArchive{}
-		archiveFactory := func(files, prepFiles []File, chunks []string, followSymlinks bool) Archive {
-			collectedFiles = files
-			collectedPrepFiles = prepFiles
-			collectedChunks = chunks
-			collectedFollowSymlinks = followSymlinks
+		archiveFactory := func(args ArchiveFactoryArgs) Archive {
+			collectedFiles = args.Files
+			collectedPrepFiles = args.PrepFiles
+			collectedChunks = args.Chunks
+			collectedFollowSymlinks = args.FollowSymlinks
 			return archive
 		}
 		fs = fakesys.NewFakeFileSystem()

--- a/release/license/dir_reader.go
+++ b/release/license/dir_reader.go
@@ -28,7 +28,7 @@ func (r DirReaderImpl) Read(path string) (*License, error) {
 		return nil, nil
 	}
 
-	archive := r.archiveFactory(files, nil, nil)
+	archive := r.archiveFactory(files, nil, nil, false /*followSymlinks*/)
 
 	fp, err := archive.Fingerprint()
 	if err != nil {

--- a/release/license/dir_reader.go
+++ b/release/license/dir_reader.go
@@ -28,7 +28,7 @@ func (r DirReaderImpl) Read(path string) (*License, error) {
 		return nil, nil
 	}
 
-	archive := r.archiveFactory(files, nil, nil, false /*followSymlinks*/)
+	archive := r.archiveFactory(ArchiveFactoryArgs{Files: files})
 
 	fp, err := archive.Fingerprint()
 	if err != nil {

--- a/release/license/dir_reader_test.go
+++ b/release/license/dir_reader_test.go
@@ -26,10 +26,11 @@ var _ = Describe("DirReaderImpl", func() {
 
 	BeforeEach(func() {
 		archive = &fakeres.FakeArchive{}
-		archiveFactory := func(files, prepFiles []File, chunks []string, followSymlinks bool) Archive {
-			collectedFiles = files
-			collectedPrepFiles = prepFiles
-			collectedChunks = chunks
+		archiveFactory := func(args ArchiveFactoryArgs) Archive {
+			collectedFiles = args.Files
+			collectedPrepFiles = args.PrepFiles
+			collectedChunks = args.Chunks
+			collectedFollowSymlinks = args.FollowSymlinks
 			return archive
 		}
 		fs = fakesys.NewFakeFileSystem()

--- a/release/license/dir_reader_test.go
+++ b/release/license/dir_reader_test.go
@@ -15,17 +15,18 @@ import (
 
 var _ = Describe("DirReaderImpl", func() {
 	var (
-		collectedFiles     []File
-		collectedPrepFiles []File
-		collectedChunks    []string
-		archive            *fakeres.FakeArchive
-		fs                 *fakesys.FakeFileSystem
-		reader             DirReader
+		collectedFiles          []File
+		collectedPrepFiles      []File
+		collectedChunks         []string
+		collectedFollowSymlinks bool
+		archive                 *fakeres.FakeArchive
+		fs                      *fakesys.FakeFileSystem
+		reader                  DirReader
 	)
 
 	BeforeEach(func() {
 		archive = &fakeres.FakeArchive{}
-		archiveFactory := func(files, prepFiles []File, chunks []string) Archive {
+		archiveFactory := func(files, prepFiles []File, chunks []string, followSymlinks bool) Archive {
 			collectedFiles = files
 			collectedPrepFiles = prepFiles
 			collectedChunks = chunks
@@ -54,6 +55,7 @@ var _ = Describe("DirReaderImpl", func() {
 
 			Expect(collectedPrepFiles).To(BeEmpty())
 			Expect(collectedChunks).To(BeEmpty())
+			Expect(collectedFollowSymlinks).To(BeFalse())
 		})
 
 		It("returns a license and notice collected from directory", func() {

--- a/release/pkg/dir_reader.go
+++ b/release/pkg/dir_reader.go
@@ -48,7 +48,7 @@ func (r DirReaderImpl) Read(path string) (*Package, error) {
 
 	// Note that files do not include package's spec file,
 	// but rather specify dependencies as additional chunks for the fingerprint.
-	archive := r.archiveFactory(files, prepFiles, manifest.Dependencies)
+	archive := r.archiveFactory(files, prepFiles, manifest.Dependencies, false /*followSymlinks*/)
 
 	fp, err := archive.Fingerprint()
 	if err != nil {

--- a/release/pkg/dir_reader.go
+++ b/release/pkg/dir_reader.go
@@ -48,7 +48,7 @@ func (r DirReaderImpl) Read(path string) (*Package, error) {
 
 	// Note that files do not include package's spec file,
 	// but rather specify dependencies as additional chunks for the fingerprint.
-	archive := r.archiveFactory(files, prepFiles, manifest.Dependencies, false /*followSymlinks*/)
+	archive := r.archiveFactory(ArchiveFactoryArgs{Files: files, PrepFiles: prepFiles, Chunks: manifest.Dependencies})
 
 	fp, err := archive.Fingerprint()
 	if err != nil {

--- a/release/pkg/dir_reader_test.go
+++ b/release/pkg/dir_reader_test.go
@@ -18,20 +18,22 @@ import (
 
 var _ = Describe("DirReaderImpl", func() {
 	var (
-		collectedFiles     []File
-		collectedPrepFiles []File
-		collectedChunks    []string
-		archive            *fakeres.FakeArchive
-		fs                 *fakesys.FakeFileSystem
-		reader             DirReaderImpl
+		collectedFiles          []File
+		collectedPrepFiles      []File
+		collectedChunks         []string
+		collectedFollowSymlinks bool
+		archive                 *fakeres.FakeArchive
+		fs                      *fakesys.FakeFileSystem
+		reader                  DirReaderImpl
 	)
 
 	BeforeEach(func() {
 		archive = &fakeres.FakeArchive{}
-		archiveFactory := func(files, prepFiles []File, chunks []string) Archive {
+		archiveFactory := func(files, prepFiles []File, chunks []string, followSymlinks bool) Archive {
 			collectedFiles = files
 			collectedPrepFiles = prepFiles
 			collectedChunks = chunks
+			collectedFollowSymlinks = followSymlinks
 			return archive
 		}
 		fs = fakesys.NewFakeFileSystem()
@@ -69,6 +71,7 @@ excluded_files: [ex-file1, ex-file2]
 
 			Expect(collectedPrepFiles).To(BeEmpty())
 			Expect(collectedChunks).To(Equal([]string{"pkg1", "pkg2"}))
+			Expect(collectedFollowSymlinks).To(BeFalse())
 		})
 
 		It("returns a package with the details with pre_packaging file", func() {

--- a/release/pkg/dir_reader_test.go
+++ b/release/pkg/dir_reader_test.go
@@ -29,11 +29,11 @@ var _ = Describe("DirReaderImpl", func() {
 
 	BeforeEach(func() {
 		archive = &fakeres.FakeArchive{}
-		archiveFactory := func(files, prepFiles []File, chunks []string, followSymlinks bool) Archive {
-			collectedFiles = files
-			collectedPrepFiles = prepFiles
-			collectedChunks = chunks
-			collectedFollowSymlinks = followSymlinks
+		archiveFactory := func(args ArchiveFactoryArgs) Archive {
+			collectedFiles = args.Files
+			collectedPrepFiles = args.PrepFiles
+			collectedChunks = args.Chunks
+			collectedFollowSymlinks = args.FollowSymlinks
 			return archive
 		}
 		fs = fakesys.NewFakeFileSystem()

--- a/release/provider.go
+++ b/release/provider.go
@@ -62,9 +62,9 @@ func (p Provider) archiveReader(extracting bool) ArchiveReader {
 }
 
 func (p Provider) NewDirReader(dirPath string) DirReader {
-	archiveFactory := func(files []File, prepFiles []File, chunks []string, followSymlinks bool) Archive {
+	archiveFactory := func(args ArchiveFactoryArgs) Archive {
 		return NewArchiveImpl(
-			files, prepFiles, chunks, dirPath, followSymlinks, p.fingerprinterFactory(followSymlinks), p.compressor, p.digestCalculator, p.cmdRunner, p.fs)
+			args.Files, args.PrepFiles, args.Chunks, dirPath, args.FollowSymlinks, p.fingerprinterFactory(args.FollowSymlinks), p.compressor, p.digestCalculator, p.cmdRunner, p.fs)
 	}
 
 	srcDirPath := filepath.Join(dirPath, "src")

--- a/release/provider.go
+++ b/release/provider.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Provider struct {
-	fingerprinter Fingerprinter
+	fingerprinterFactory func(bool) Fingerprinter
 
 	cmdRunner        boshsys.CmdRunner
 	compressor       boshcmd.Compressor
@@ -31,10 +31,10 @@ func NewProvider(
 	fs boshsys.FileSystem,
 	logger boshlog.Logger,
 ) Provider {
-	fingerprinter := NewFingerprinterImpl(digestCalculator, fs)
-
 	return Provider{
-		fingerprinter:    fingerprinter,
+		fingerprinterFactory: func(followSymlinks bool) Fingerprinter {
+			return NewFingerprinterImpl(digestCalculator, fs, followSymlinks)
+		},
 		cmdRunner:        cmdRunner,
 		compressor:       compressor,
 		digestCalculator: digestCalculator,
@@ -62,9 +62,9 @@ func (p Provider) archiveReader(extracting bool) ArchiveReader {
 }
 
 func (p Provider) NewDirReader(dirPath string) DirReader {
-	archiveFactory := func(files []File, prepFiles []File, chunks []string) Archive {
+	archiveFactory := func(files []File, prepFiles []File, chunks []string, followSymlinks bool) Archive {
 		return NewArchiveImpl(
-			files, prepFiles, chunks, dirPath, p.fingerprinter, p.compressor, p.digestCalculator, p.cmdRunner, p.fs)
+			files, prepFiles, chunks, dirPath, followSymlinks, p.fingerprinterFactory(followSymlinks), p.compressor, p.digestCalculator, p.cmdRunner, p.fs)
 	}
 
 	srcDirPath := filepath.Join(dirPath, "src")

--- a/release/provider.go
+++ b/release/provider.go
@@ -64,7 +64,7 @@ func (p Provider) archiveReader(extracting bool) ArchiveReader {
 func (p Provider) NewDirReader(dirPath string) DirReader {
 	archiveFactory := func(args ArchiveFactoryArgs) Archive {
 		return NewArchiveImpl(
-			args.Files, args.PrepFiles, args.Chunks, dirPath, args.FollowSymlinks, p.fingerprinterFactory(args.FollowSymlinks), p.compressor, p.digestCalculator, p.cmdRunner, p.fs)
+			args, dirPath, p.fingerprinterFactory(args.FollowSymlinks), p.compressor, p.digestCalculator, p.cmdRunner, p.fs)
 	}
 
 	srcDirPath := filepath.Join(dirPath, "src")

--- a/release/resource/archive.go
+++ b/release/resource/archive.go
@@ -26,11 +26,8 @@ type ArchiveImpl struct {
 }
 
 func NewArchiveImpl(
-	files []File,
-	prepFiles []File,
-	additionalChunks []string,
+	args ArchiveFactoryArgs,
 	releaseDirPath string,
-	followSymlinks bool,
 	fingerprinter Fingerprinter,
 	compressor boshcmd.Compressor,
 	digestCalculator bicrypto.DigestCalculator,
@@ -38,11 +35,11 @@ func NewArchiveImpl(
 	fs boshsys.FileSystem,
 ) ArchiveImpl {
 	return ArchiveImpl{
-		files:            files,
-		prepFiles:        prepFiles,
-		additionalChunks: additionalChunks,
+		files:            args.Files,
+		prepFiles:        args.PrepFiles,
+		additionalChunks: args.Chunks,
+		followSymlinks:   args.FollowSymlinks,
 		releaseDirPath:   releaseDirPath,
-		followSymlinks:   followSymlinks,
 
 		fingerprinter:    fingerprinter,
 		compressor:       compressor,
@@ -211,5 +208,5 @@ func (a ArchiveImpl) buildStagingArchive(stagingDir string) Archive {
 	}
 
 	// Initialize with bare minimum deps so that fingerprinting can be performed
-	return NewArchiveImpl(stagingFiles, nil, a.additionalChunks, "", false, a.fingerprinter, nil, nil, nil, nil)
+	return NewArchiveImpl(ArchiveFactoryArgs{Files: stagingFiles, Chunks: a.additionalChunks}, "", a.fingerprinter, nil, nil, nil, nil)
 }

--- a/release/resource/archive_test.go
+++ b/release/resource/archive_test.go
@@ -47,12 +47,16 @@ var _ = Describe("Archive", func() {
 			compressor = fakecmd.NewFakeCompressor()
 			cmdRunner = fakesys.NewFakeCmdRunner()
 			fs = fakesys.NewFakeFileSystem()
+			archiveFactoryArgs := ArchiveFactoryArgs{
+				Files:          []File{NewFile(filepath.Join("/", "tmp", "file"), filepath.Join("/", "tmp"))},
+				PrepFiles:      []File{NewFile(filepath.Join("/", "tmp", "prep-file"), filepath.Join("/", "tmp"))},
+				Chunks:         []string{"chunk"},
+				FollowSymlinks: false,
+			}
+
 			archive = NewArchiveImpl(
-				[]File{NewFile(filepath.Join("/", "tmp", "file"), filepath.Join("/", "tmp"))},
-				[]File{NewFile(filepath.Join("/", "tmp", "prep-file"), filepath.Join("/", "tmp"))},
-				[]string{"chunk"},
+				archiveFactoryArgs,
 				releaseDirPath,
-				false,
 				fingerprinter,
 				compressor,
 				digestCalculator,
@@ -190,16 +194,21 @@ var _ = Describe("Archive", func() {
 				files = append(files, NewFile(filepath.Join(uniqueDir, "dir", "symlink-dir"), uniqueDir))
 				files = append(files, NewFile(filepath.Join(uniqueDir, "dir", "symlink-file-missing"), uniqueDir))
 			}
-			archive = NewArchiveImpl(
-				files,
-				[]File{
+
+			archiveFactoryArgs := ArchiveFactoryArgs{
+				Files: files,
+				PrepFiles: []File{
 					NewFile(filepath.Join(uniqueDir, "run-build-dir"), uniqueDir),
 					NewFile(filepath.Join(uniqueDir, "run-release-dir"), uniqueDir),
 					NewFile(filepath.Join(uniqueDir, "run-file3"), uniqueDir),
 				},
-				[]string{"chunk"},
+				Chunks:         []string{"chunk"},
+				FollowSymlinks: followSymlinks,
+			}
+
+			archive = NewArchiveImpl(
+				archiveFactoryArgs,
 				releaseDirPath,
-				followSymlinks,
 				fingerprinter,
 				compressor,
 				digestCalculator,

--- a/release/resource/fingerprint.go
+++ b/release/resource/fingerprint.go
@@ -75,30 +75,28 @@ func (f FingerprinterImpl) fingerprintPath(file File) (string, error) {
 		result += file.RelativePath
 	}
 
+	targetFilePath := file.Path
+
 	fileInfo, err := f.fs.Lstat(file.Path)
 	if err != nil {
 		return "", err
 	}
 
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		symlinkTarget, err := f.fs.Readlink(file.Path)
+		var err error
+		targetFilePath, err = f.fs.ReadAndFollowLink(file.Path)
 		if err != nil {
 			return "", err
 		}
-
-		//generation of digest string
-		sha1 := f.digestCalculator.CalculateString(symlinkTarget)
-
-		result += sha1
-	} else {
-		//generation of digest string
-		sha1, err := f.digestCalculator.Calculate(file.Path)
-		if err != nil {
-			return "", err
-		}
-
-		result += sha1
 	}
+
+	//generation of digest string
+	sha1, err := f.digestCalculator.Calculate(targetFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	result += sha1
 
 	if !file.ExcludeMode {
 		// Git doesn't really track file permissions, it just looks at executable
@@ -111,8 +109,6 @@ func (f FingerprinterImpl) fingerprintPath(file File) (string, error) {
 
 		if fileInfo.IsDir() {
 			modeStr = "40755"
-		} else if fileInfo.Mode()&os.ModeSymlink != 0 {
-			modeStr = "symlink"
 		} else if fileInfo.Mode()&0111 != 0 {
 			modeStr = "100755"
 		} else {

--- a/release/resource/interfaces.go
+++ b/release/resource/interfaces.go
@@ -12,7 +12,14 @@ type Archive interface {
 	Build(expectedFp string) (string, string, error)
 }
 
-type ArchiveFunc func([]File, []File, []string, bool) Archive
+type ArchiveFunc func(args ArchiveFactoryArgs) Archive
+
+type ArchiveFactoryArgs struct {
+	Files          []File
+	PrepFiles      []File
+	Chunks         []string
+	FollowSymlinks bool
+}
 
 //go:generate counterfeiter . ArchiveIndex
 

--- a/release/resource/interfaces.go
+++ b/release/resource/interfaces.go
@@ -12,7 +12,7 @@ type Archive interface {
 	Build(expectedFp string) (string, string, error)
 }
 
-type ArchiveFunc func([]File, []File, []string) Archive
+type ArchiveFunc func([]File, []File, []string, bool) Archive
 
 //go:generate counterfeiter . ArchiveIndex
 


### PR DESCRIPTION
This PR implements symlink-following (i.e., copying the contents of the target of the symlink) in the jobs folder when creating a release.

- capi-release and others make use of symlinks to share templates between multiple jobs, e.g., https://github.com/cloudfoundry/cloud_controller_ng/blob/3db08e602ef4f7156c681a8799bc53a2c6e65848/bosh/shared_job_templates/setup_local_blobstore.sh.erb
- While some of our shared templates could be moved into packages or links, there are some files that don't fit this pattern like scripts that require ERB interpolation.
- Some bosh users want to copy the symlink itself (not the target) from a package onto the BOSH VM, so we restrict this symlink-following behavior to only happen when processing the jobs directory.

Verification: We were able to create and upload capi-release without any errors using this version of the CLI. We additionally added a symlink inside one of the capi-release packages which pointed to /var/vcap/sys/logs, which doesn't exist on our development system. When we deployed the release, all the jobs started successfully and we verified that our logs symlink correctly pointed to /var/vcap/sys/logs on the bosh VM.

This completes the work of the WIP PR #157 and implements story [#145780425](https://www.pivotaltracker.com/story/show/145780425) in the capi tracker.

-- @jenspinney and @mikexuu