### PR TITLE
Upload binaries to GitHub release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -174,6 +174,16 @@ jobs:
             tag: version-semver/number
             tag_as_latest: true
 
+      - put: github-release
+        params:
+          name: version-semver/number
+          tag: version-semver/number
+          tag_prefix: v
+          globs:
+            - compiled-linux/bosh-cli-*-linux-amd64
+            - compiled-darwin/bosh-cli-*-darwin-amd64
+            - compiled-windows/bosh-cli-*-windows-amd64.exe
+
       - task: update-homebrew-formula
         file: bosh-cli/ci/tasks/update-homebrew-formula.yml
       - put: homebrew-tap
@@ -345,6 +355,13 @@ resources:
       uri: git@github.com:cloudfoundry/homebrew-tap
       branch: master
       private_key: {{cloudfoundry_homebrew_tap_deploy_key}}
+
+  - name: github-release
+    type: github-release
+    source:
+      owner: cloudfoundry
+      repository: bosh-cli
+      access_token: {{concourse_github_access_token}}
 
   - name: final-docker
     type: docker-image


### PR DESCRIPTION
If desired. Seems like it should be done as a courtesy for users and automation. If they want to be secure they should be checking from bosh.io with the checksum.

May want to consider enabling `drafts` to avoid publishing a release for every build.

Requires a new variable of `concourse_github_access_token` with a GitHub token which can create releases.

Fixes #187