### PR TITLE
Introduce GCSBlobstore with provider hook

### DIFF
--- a/releasedir/gcs_blobstore.go
+++ b/releasedir/gcs_blobstore.go
@@ -1,0 +1,113 @@
+package releasedir
+
+import (
+	gobytes "bytes"
+	"context"
+	"encoding/json"
+	"os"
+
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
+	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
+
+	gcsclient "github.com/cloudfoundry/bosh-gcscli/client"
+	gcsconfig "github.com/cloudfoundry/bosh-gcscli/config"
+)
+
+type GCSBlobstore struct {
+	fs      boshsys.FileSystem
+	uuidGen boshuuid.Generator
+	options map[string]interface{}
+}
+
+func NewGCSBlobstore(
+	fs boshsys.FileSystem,
+	uuidGen boshuuid.Generator,
+	options map[string]interface{},
+) GCSBlobstore {
+	return GCSBlobstore{
+		fs:      fs,
+		uuidGen: uuidGen,
+		options: options,
+	}
+}
+
+func (b GCSBlobstore) Get(blobID string) (string, error) {
+	client, err := b.client()
+	if err != nil {
+		return "", err
+	}
+
+	file, err := b.fs.TempFile("bosh-gcs-blob")
+	if err != nil {
+		return "", bosherr.WrapError(err, "Creating destination file")
+	}
+	defer file.Close()
+
+	if err := client.Get(blobID, file); err != nil {
+		return "", err
+	}
+
+	return file.Name(), nil
+}
+
+func (b GCSBlobstore) Create(path string) (string, error) {
+	client, err := b.client()
+	if err != nil {
+		return "", err
+	}
+
+	blobID, err := b.uuidGen.Generate()
+	if err != nil {
+		return "", bosherr.WrapError(err, "Generating blobstore ID")
+	}
+
+	file, err := b.fs.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Opening source file")
+	}
+	defer file.Close()
+
+	if err := client.Put(file, blobID); err != nil {
+		return "", err
+	}
+
+	return blobID, nil
+}
+
+func (b GCSBlobstore) CleanUp(path string) error {
+	return b.fs.RemoveAll(path)
+}
+
+func (b GCSBlobstore) Delete(blobID string) error {
+	panic("Not implemented")
+}
+
+func (b GCSBlobstore) Validate() error {
+	_, err := b.client()
+	return err
+}
+
+func (b GCSBlobstore) client() (*gcsclient.GCSBlobstore, error) {
+	bytes, err := json.Marshal(b.options)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Marshaling config")
+	}
+
+	conf, err := gcsconfig.NewFromReader(gobytes.NewBuffer(bytes))
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Reading config")
+	}
+
+	_, gcsSDK, err := gcsclient.NewSDK(conf)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Building client SDK")
+	}
+
+	client, err := gcsclient.New(context.Background(), gcsSDK, &conf)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Validating config")
+	}
+
+	return &client, nil
+}

--- a/releasedir/provider.go
+++ b/releasedir/provider.go
@@ -103,6 +103,8 @@ func (p Provider) newBlobstore(dirPath string) boshblob.DigestBlobstore {
 		blobstore = boshblob.NewLocalBlobstore(p.fs, p.uuidGen, options)
 	case "s3":
 		blobstore = NewS3Blobstore(p.fs, p.uuidGen, options)
+	case "gcs":
+		blobstore = NewGCSBlobstore(p.fs, p.uuidGen, options)
 	default:
 		return NewErrBlobstore(bosherr.Error("Expected release blobstore to be configured"))
 	}


### PR DESCRIPTION
GCSBlobstore introduces initial support for native
GCS blobstore support. We use bosh-gcscli/client as
our client package.
https://github.com/cloudfoundry/bosh-gcscli

This mirrors the existing patterns of S3Blobstore.
Specifically, we leave Delete unimplemented to keep parity.

Significant portions of S3Blobstore are duplicated due to an
SDK-level compatibility issue. Specifically, s3cli/client.Get
expects an io.WriterAt as the SDK accepts that. The GCS SDK
accepts only io.Writer. Hence, we cannot share the code by
having a common interface for bosh-gcscli/client and s3cli/client.
The other option is using interface{} and a type-switch in
each Blobstore method wherever the client is used. The result
of this was undesirable.