### PR TITLE
log-out command requires the environment to be set

### DIFF
--- a/cmd/log_out.go
+++ b/cmd/log_out.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+
 	cmdconf "github.com/cloudfoundry/bosh-cli/cmd/config"
 	biui "github.com/cloudfoundry/bosh-cli/ui"
 )
@@ -16,6 +18,10 @@ func NewLogOutCmd(environment string, config cmdconf.Config, ui biui.UI) LogOutC
 }
 
 func (c LogOutCmd) Run() error {
+	if c.environment == "" {
+		return errors.New("Expected non-empty Director URL")
+	}
+
 	updatedConfig := c.config.UnsetCredentials(c.environment)
 
 	err := updatedConfig.Save()

--- a/cmd/log_out_test.go
+++ b/cmd/log_out_test.go
@@ -57,5 +57,12 @@ var _ = Describe("LogOutCmd", func() {
 
 			Expect(ui.Said).To(BeEmpty())
 		})
+
+		It("returns error if environment is empty", func() {
+			command = NewLogOutCmd("", config, ui)
+			err := act()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Expected non-empty Director URL"))
+		})
 	})
 })


### PR DESCRIPTION
This prevents a user from doing `bosh log-out` without providing an environment.