### PR TITLE
make bosh create-release error out with hint to `reset-release` when old-style blobs dir is present

### DIFF
--- a/releasedir/fs_blobs_dir.go
+++ b/releasedir/fs_blobs_dir.go
@@ -312,8 +312,7 @@ func (d FSBlobsDir) containsSymlinks() bool {
 
 	for _, file := range files {
 		fileInfo, _ := d.fs.Lstat(file)
-
-		if fileInfo.Mode()&os.ModeSymlink != 0 {
+		if fileInfo != nil && fileInfo.Mode()&os.ModeSymlink != 0 {
 			return true
 		}
 	}

--- a/releasedir/fs_blobs_dir_test.go
+++ b/releasedir/fs_blobs_dir_test.go
@@ -439,6 +439,24 @@ bad-sha-blob.tgz:
 			})
 		})
 
+		Context("when getting the symlink description errors", func() {
+			It("passes the error along", func() {
+				existingFilePath := filepath.Join("/", "dir", "blobs", "does-exist")
+				symlink := filepath.Join("/", "dir", "blobs", "fake-symlink")
+
+				fs.Symlink(existingFilePath, symlink)
+
+				fs.SetGlob(filepath.Join("/", "dir", "blobs", "**", "*"), []string{symlink})
+
+				fs.RegisterOpenFile(symlink, &fakesys.FakeFile{
+					StatErr: errors.New("fake-err"),
+				})
+
+				err := act(1)
+				Expect(err).To(MatchError("Syncing blobs: fake-err"))
+			})
+		})
+
 		Context("when no symlink exists", func() {
 			It("succeeds", func() {
 				existingFilePath := filepath.Join("/", "dir", "blobs", "does-exist")

--- a/releasedir/fs_blobs_dir_test.go
+++ b/releasedir/fs_blobs_dir_test.go
@@ -419,7 +419,6 @@ bad-sha-blob.tgz:
 
 		Context("when a symlink exists", func() {
 			It("returns an error", func() {
-
 				missingFilePath := filepath.Join("/", "dir", ".blobs", "does-not-exist")
 				symlink := filepath.Join("/", "dir", "blobs", "fake-symlink")
 
@@ -441,7 +440,7 @@ bad-sha-blob.tgz:
 		})
 
 		Context("when no symlink exists", func() {
-			It("returns false", func() {
+			It("succeeds", func() {
 				existingFilePath := filepath.Join("/", "dir", "blobs", "does-exist")
 
 				fs.SetGlob(filepath.Join("/", "dir", "blobs", "**", "*"), []string{existingFilePath})


### PR DESCRIPTION
If you run `create-release` with bosh-cli v2 on a release that has previously generated blobs from bosh-cli v1 then cli will exit and hint you to run `reset-release`.

There is a conversation in [slack](https://cloudfoundry.slack.com/messages/C094QRLEQ/convo/C094QRLEQ-1499156841.349691/) if you want to follow up.

[#145341545](https://www.pivotaltracker.com/story/show/145341545)