### PR TITLE
allow leading slash for variables in manifest files while using vars-store file

### DIFF
--- a/director/template/template.go
+++ b/director/template/template.go
@@ -87,7 +87,7 @@ func (t Template) interpolateRoot(obj interface{}, tracker varsTracker) (interfa
 type interpolator struct{}
 
 var (
-	interpolationRegex         = regexp.MustCompile(`\(\((!?[-\/\.\w\pL]+)\)\)`)
+	interpolationRegex         = regexp.MustCompile(`\(\((!?[-/\.\w\pL]+)\)\)`)
 	interpolationAnchoredRegex = regexp.MustCompile("\\A" + interpolationRegex.String() + "\\z")
 )
 

--- a/director/template/template.go
+++ b/director/template/template.go
@@ -87,7 +87,7 @@ func (t Template) interpolateRoot(obj interface{}, tracker varsTracker) (interfa
 type interpolator struct{}
 
 var (
-	interpolationRegex         = regexp.MustCompile(`\(\((!?[-\.\w\pL]+)\)\)`)
+	interpolationRegex         = regexp.MustCompile(`\(\((!?[-\/\.\w\pL]+)\)\)`)
 	interpolationAnchoredRegex = regexp.MustCompile("\\A" + interpolationRegex.String() + "\\z")
 )
 

--- a/director/template/template_test.go
+++ b/director/template/template_test.go
@@ -21,6 +21,15 @@ var _ = Describe("Template", func() {
 		Expect(result).To(Equal([]byte("foo\n")))
 	})
 
+	It("can interpolate values with leading slash into a struct with byte slice", func() {
+		template := NewTemplate([]byte("((/key))"))
+		vars := StaticVariables{"/key": "foo"}
+
+		result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]byte("foo\n")))
+	})
+
 	It("can interpolate multiple values into a byte slice", func() {
 		template := NewTemplate([]byte("((key)): ((value))"))
 		vars := StaticVariables{

--- a/director/template/template_test.go
+++ b/director/template/template_test.go
@@ -22,8 +22,8 @@ var _ = Describe("Template", func() {
 	})
 
 	It("can interpolate values with leading slash into a struct with byte slice", func() {
-		template := NewTemplate([]byte("((/key))"))
-		vars := StaticVariables{"/key": "foo"}
+		template := NewTemplate([]byte("((/key/foo))"))
+		vars := StaticVariables{"/key/foo": "foo"}
 
 		result, err := template.Evaluate(vars, nil, EvaluateOpts{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Currently the BOSH CLI doesn't allow to reference variables with leading slashes, i.e. ((/foo)) when using a vars-store file. It is only allowed when using credhub instead of vars-file. In our use case we want to provide manifest files which can be deployed using credhub as well as using the vars-store file. 