### PR TITLE
Helpful ssh error if multiple hosts/no hosts

### DIFF
--- a/ssh/interactive.go
+++ b/ssh/interactive.go
@@ -18,8 +18,12 @@ func NewInteractiveRunner(comboRunner ComboRunner) InteractiveRunner {
 }
 
 func (r InteractiveRunner) Run(connOpts ConnectionOpts, result boshdir.SSHResult, rawCmd []string) error {
-	if len(result.Hosts) != 1 {
-		return bosherr.Errorf("Interactive SSH only works for a single host at a time")
+	if len(result.Hosts) == 0 {
+		return bosherr.Errorf("Interactive SSH requires at least one host to be running.")
+	}
+	if len(result.Hosts) > 1 {
+		firstHost := result.Hosts[0]
+		return bosherr.Errorf("Interactive SSH only works for a single host at a time. Try `bosh ssh %s/%s`.", firstHost.Job, firstHost.IndexOrID)
 	}
 
 	if len(rawCmd) != 0 {


### PR DESCRIPTION
Example:

```
out/bosh ssh
Using environment 'https://10.58.111.49:25555' as client 'admin'

Using deployment 'consul'

Task 1054. Done

Running SSH:
  Interactive SSH only works for a single host at a time. Try `bosh ssh consul/6117487d-7277-42ef-adc0-da1e5e37afae`
```
