### PR TITLE
Add --empty-image switch to produce light stemcells with repack-stemcell

### DIFF
--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -450,6 +450,7 @@ type RepackStemcellOpts struct {
 	Args            RepackStemcellArgs `positional-args:"true" required:"true"`
 	Name            string             `long:"name" description:"Repacked stemcell name"`
 	CloudProperties string             `long:"cloud-properties" description:"Repacked stemcell cloud properties"`
+	EmptyImage      bool               `long:"empty-image" description:"Pack zero byte file instead of image"`
 	Version         string             `long:"version" description:"Repacked stemcell version"`
 
 	cmd

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -1351,6 +1351,12 @@ var _ = Describe("Opts", func() {
 				`long:"cloud-properties" description:"Repacked stemcell cloud properties"`,
 			))
 		})
+
+		It("has --empty-image", func() {
+			Expect(getStructTagForName("EmptyImage", opts)).To(Equal(
+				`long:"empty-image" description:"Pack zero byte file instead of image"`,
+			))
+		})
 	})
 
 	Describe("RepackStemcellArgs", func() {

--- a/cmd/repack_stemcell.go
+++ b/cmd/repack_stemcell.go
@@ -36,6 +36,13 @@ func (c RepackStemcellCmd) Run(opts RepackStemcellOpts) error {
 		extractedStemcell.SetVersion(opts.Version)
 	}
 
+	if opts.EmptyImage {
+		err = extractedStemcell.EmptyImage()
+		if err != nil {
+			return err
+		}
+	}
+
 	if opts.CloudProperties != "" {
 		cloudProperties := new(biproperty.Map)
 		err = yaml.Unmarshal([]byte(opts.CloudProperties), cloudProperties)

--- a/cmd/repack_stemcell_test.go
+++ b/cmd/repack_stemcell_test.go
@@ -83,6 +83,11 @@ var _ = Describe("RepackStemcellCmd", func() {
 					Expect(extractedStemcell.SetVersionCallCount()).To(BeZero())
 				})
 
+				It("should NOT use an empty image", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(extractedStemcell.EmptyImageCallCount()).To(Equal(0))
+				})
+
 				It("should NOT set empty cloud_properties", func() {
 					Expect(err).ToNot(HaveOccurred())
 
@@ -103,6 +108,18 @@ var _ = Describe("RepackStemcellCmd", func() {
 					Expect(extractedStemcell.SetNameArgsForCall(0)).To(Equal("new-name"))
 
 					Expect(extractedStemcell.PackCallCount()).To(Equal(1))
+				})
+			})
+
+			Context("and --empty-image is specified", func() {
+				It("uses an empty image", func() {
+					opts.EmptyImage = true
+					extractor.SetExtractBehavior("some-stemcell.tgz", extractedStemcell, nil)
+
+					extractedStemcell.PackReturns(nil)
+					err = act()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(extractedStemcell.EmptyImageCallCount()).To(Equal(1))
 				})
 			})
 

--- a/stemcell/stemcell.go
+++ b/stemcell/stemcell.go
@@ -21,6 +21,7 @@ type ExtractedStemcell interface {
 	SetCloudProperties(biproperty.Map)
 	GetExtractedPath() string
 	Pack(string) error
+	EmptyImage() error
 	fmt.Stringer
 }
 
@@ -87,6 +88,15 @@ func (s *extractedStemcell) Pack(destinationPath string) error {
 	}
 
 	return s.fs.Rename(intermediateStemcellPath, destinationPath)
+}
+
+func (s *extractedStemcell) EmptyImage() error {
+	imagePath := filepath.Join(s.extractedPath, "image")
+	err := s.fs.WriteFile(imagePath, []byte{})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *extractedStemcell) GetExtractedPath() string {

--- a/stemcell/stemcellfakes/fake_extracted_stemcell.go
+++ b/stemcell/stemcellfakes/fake_extracted_stemcell.go
@@ -71,6 +71,15 @@ type FakeExtractedStemcell struct {
 	packReturnsOnCall map[int]struct {
 		result1 error
 	}
+	EmptyImageStub        func() error
+	emptyImageMutex       sync.RWMutex
+	emptyImageArgsForCall []struct{}
+	emptyImageReturns     struct {
+		result1 error
+	}
+	emptyImageReturnsOnCall map[int]struct {
+		result1 error
+	}
 	StringStub        func() string
 	stringMutex       sync.RWMutex
 	stringArgsForCall []struct{}
@@ -364,6 +373,46 @@ func (fake *FakeExtractedStemcell) PackReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeExtractedStemcell) EmptyImage() error {
+	fake.emptyImageMutex.Lock()
+	ret, specificReturn := fake.emptyImageReturnsOnCall[len(fake.emptyImageArgsForCall)]
+	fake.emptyImageArgsForCall = append(fake.emptyImageArgsForCall, struct{}{})
+	fake.recordInvocation("EmptyImage", []interface{}{})
+	fake.emptyImageMutex.Unlock()
+	if fake.EmptyImageStub != nil {
+		return fake.EmptyImageStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.emptyImageReturns.result1
+}
+
+func (fake *FakeExtractedStemcell) EmptyImageCallCount() int {
+	fake.emptyImageMutex.RLock()
+	defer fake.emptyImageMutex.RUnlock()
+	return len(fake.emptyImageArgsForCall)
+}
+
+func (fake *FakeExtractedStemcell) EmptyImageReturns(result1 error) {
+	fake.EmptyImageStub = nil
+	fake.emptyImageReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeExtractedStemcell) EmptyImageReturnsOnCall(i int, result1 error) {
+	fake.EmptyImageStub = nil
+	if fake.emptyImageReturnsOnCall == nil {
+		fake.emptyImageReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.emptyImageReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeExtractedStemcell) String() string {
 	fake.stringMutex.Lock()
 	ret, specificReturn := fake.stringReturnsOnCall[len(fake.stringArgsForCall)]
@@ -423,6 +472,8 @@ func (fake *FakeExtractedStemcell) Invocations() map[string][][]interface{} {
 	defer fake.getExtractedPathMutex.RUnlock()
 	fake.packMutex.RLock()
 	defer fake.packMutex.RUnlock()
+	fake.emptyImageMutex.RLock()
+	defer fake.emptyImageMutex.RUnlock()
 	fake.stringMutex.RLock()
 	defer fake.stringMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
Puts a zero byte file into the repackaged stemcell instead of the original image.


https://www.pivotaltracker.com/story/show/144851625