### PR TITLE
Remove IPv6 bracketing from ssh shell out

### DIFF
--- a/ssh/interactive.go
+++ b/ssh/interactive.go
@@ -29,7 +29,7 @@ func (r InteractiveRunner) Run(connOpts ConnectionOpts, result boshdir.SSHResult
 	cmdFactory := func(host boshdir.Host) boshsys.Command {
 		return boshsys.Command{
 			Name: "ssh",
-			Args: []string{printableHost{host}.String(), "-l", host.Username},
+			Args: []string{host.Host, "-l", host.Username},
 
 			Stdin:  os.Stdin,
 			Stdout: os.Stdout,

--- a/ssh/non_interactive.go
+++ b/ssh/non_interactive.go
@@ -27,7 +27,7 @@ func (r NonInteractiveRunner) Run(connOpts ConnectionOpts, result boshdir.SSHRes
 	cmdFactory := func(host boshdir.Host) boshsys.Command {
 		return boshsys.Command{
 			Name: "ssh",
-			Args: append([]string{printableHost{host}.String(), "-l", host.Username}, rawCmd...),
+			Args: append([]string{host.Host, "-l", host.Username}, rawCmd...),
 		}
 	}
 

--- a/ssh/session.go
+++ b/ssh/session.go
@@ -153,7 +153,7 @@ func (r SessionImpl) makeKnownHostsFile() (boshsys.File, error) {
 
 	for _, host := range r.result.Hosts {
 		if len(host.HostPublicKey) > 0 {
-			content += fmt.Sprintf("%s %s\n", printableHost{host}, host.HostPublicKey)
+			content += fmt.Sprintf("%s %s\n", host.Host, host.HostPublicKey)
 		}
 	}
 

--- a/ssh/session_test.go
+++ b/ssh/session_test.go
@@ -76,7 +76,7 @@ var _ = Describe("SessionImpl", func() {
 			_, err := act().Start()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fs.ReadFileString("/tmp/known-hosts")).To(Equal(
-				"127.0.0.1 pub-key1\n127.0.0.2 pub-key2\n[::1] pub-key3\n"))
+				"127.0.0.1 pub-key1\n127.0.0.2 pub-key2\n::1 pub-key3\n"))
 		})
 
 		It("returns error if cannot create known hosts temp file and deletes private key", func() {


### PR DESCRIPTION
Still keep it for scp since it cannot determine if it's a IPv6 address or a file location.