### PR TITLE
IPv6 addresses are only bracketed when SSH gateway is used

### DIFF
--- a/ssh/interactive.go
+++ b/ssh/interactive.go
@@ -26,10 +26,10 @@ func (r InteractiveRunner) Run(connOpts ConnectionOpts, result boshdir.SSHResult
 		return bosherr.Errorf("Interactive SSH does not accept commands")
 	}
 
-	cmdFactory := func(host boshdir.Host) boshsys.Command {
+	cmdFactory := func(host boshdir.Host, sshArgs SSHArgs) boshsys.Command {
 		return boshsys.Command{
 			Name: "ssh",
-			Args: []string{host.Host, "-l", host.Username},
+			Args: append(sshArgs.OptsForHost(host), sshArgs.LoginForHost(host)...),
 
 			Stdin:  os.Stdin,
 			Stdout: os.Stdout,

--- a/ssh/interfaces.go
+++ b/ssh/interfaces.go
@@ -35,7 +35,7 @@ type ConnectionOpts struct {
 //go:generate counterfeiter . Session
 
 type Session interface {
-	Start() ([]string, error)
+	Start() (SSHArgs, error)
 	Finish() error
 }
 

--- a/ssh/non_interactive.go
+++ b/ssh/non_interactive.go
@@ -24,10 +24,10 @@ func (r NonInteractiveRunner) Run(connOpts ConnectionOpts, result boshdir.SSHRes
 		return bosherr.Errorf("Non-interactive SSH expects non-empty command")
 	}
 
-	cmdFactory := func(host boshdir.Host) boshsys.Command {
+	cmdFactory := func(host boshdir.Host, sshArgs SSHArgs) boshsys.Command {
 		return boshsys.Command{
 			Name: "ssh",
-			Args: append([]string{host.Host, "-l", host.Username}, rawCmd...),
+			Args: append(append(sshArgs.OptsForHost(host), sshArgs.LoginForHost(host)...), rawCmd...),
 		}
 	}
 

--- a/ssh/scp.go
+++ b/ssh/scp.go
@@ -15,10 +15,10 @@ func NewSCPRunner(comboRunner ComboRunner) SCPRunnerImpl {
 }
 
 func (r SCPRunnerImpl) Run(connOpts ConnectionOpts, result boshdir.SSHResult, scpArgs SCPArgs) error {
-	cmdFactory := func(host boshdir.Host) boshsys.Command {
+	cmdFactory := func(host boshdir.Host, sshArgs SSHArgs) boshsys.Command {
 		return boshsys.Command{
 			Name: "scp",
-			Args: scpArgs.ForHost(host), // src/dst args come last
+			Args: append(sshArgs.OptsForHost(host), scpArgs.ForHost(host)...), // src/dst args come last
 		}
 	}
 

--- a/ssh/session_test.go
+++ b/ssh/session_test.go
@@ -104,154 +104,30 @@ var _ = Describe("SessionImpl", func() {
 			Expect(fs.FileExists("/tmp/priv-key")).To(BeFalse())
 		})
 
-		It("returns ssh options with correct paths to private key and known hosts", func() {
-			cmdOpts, err := session.Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-			}))
-		})
+		It("returns ssh arguments with appropriate configuration", func() {
+			result.Hosts = []boshdir.Host{{Host: "127.0.0.1"}} // populate results
+			connOpts.PrivateKey = "priv-key"                   // populate connOpts
 
-		It("returns ssh options with forced tty option if requested", func() {
+			args, err := act().Start()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(args).To(Equal(SSHArgs{
+				ConnOpts:       connOpts,
+				Result:         result,
+				ForceTTY:       false,
+				PrivKeyFile:    privKeyFile,
+				KnownHostsFile: knownHostsFile,
+			}))
+
 			sessOpts.ForceTTY = true
 
-			cmdOpts, err := act().Start()
+			args, err = act().Start()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-tt",
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-			}))
-		})
-
-		It("returns ssh options with custom raw options specified", func() {
-			connOpts.RawOpts = []string{"raw1", "raw2"}
-
-			cmdOpts, err := act().Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-				"raw1", "raw2",
-			}))
-		})
-
-		It("returns ssh options with gateway settings returned from the Director", func() {
-			result.GatewayUsername = "gw-user"
-			result.GatewayHost = "gw-host"
-
-			cmdOpts, err := act().Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-				"-o", "ProxyCommand=ssh -tt -W %h:%p -l gw-user gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
-			}))
-		})
-
-		It("returns ssh options with gateway settings returned from the Director and private key set by user", func() {
-			connOpts.GatewayPrivateKeyPath = "/tmp/gw-priv-key"
-
-			result.GatewayUsername = "gw-user"
-			result.GatewayHost = "gw-host"
-
-			cmdOpts, err := act().Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-				"-o", "ProxyCommand=ssh -tt -W %h:%p -l gw-user gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o IdentitiesOnly=yes -o IdentityFile=/tmp/gw-priv-key",
-			}))
-		})
-
-		It("returns ssh options with gateway settings overridden by user even if the Director specifies some", func() {
-			connOpts.GatewayUsername = "user-gw-user"
-			connOpts.GatewayHost = "user-gw-host"
-
-			result.GatewayUsername = "gw-user"
-			result.GatewayHost = "gw-host"
-
-			cmdOpts, err := act().Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-				"-o", "ProxyCommand=ssh -tt -W %h:%p -l user-gw-user user-gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
-			}))
-		})
-
-		It("returns ssh options without gateway settings if disabled even if user or the Director specifies some", func() {
-			connOpts.GatewayDisable = true
-			connOpts.GatewayUsername = "user-gw-user"
-			connOpts.GatewayHost = "user-gw-host"
-
-			result.GatewayUsername = "gw-user"
-			result.GatewayHost = "gw-host"
-
-			cmdOpts, err := act().Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-			}))
-		})
-
-		It("returns ssh options without socks5 settings if SOCKS5Proxy is set", func() {
-			connOpts.GatewayDisable = true
-			connOpts.GatewayUsername = "user-gw-user"
-			connOpts.GatewayHost = "user-gw-host"
-			connOpts.SOCKS5Proxy = "socks5://some-proxy"
-
-			result.GatewayUsername = "gw-user"
-			result.GatewayHost = "gw-host"
-
-			cmdOpts, err := act().Start()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cmdOpts).To(Equal([]string{
-				"-o", "ServerAliveInterval=30",
-				"-o", "ForwardAgent=no",
-				"-o", "PasswordAuthentication=no",
-				"-o", "IdentitiesOnly=yes",
-				"-o", "IdentityFile=/tmp/priv-key",
-				"-o", "StrictHostKeyChecking=yes",
-				"-o", "UserKnownHostsFile=/tmp/known-hosts",
-				"-o", "ProxyCommand=nc -X 5 -x some-proxy %h %p",
+			Expect(args).To(Equal(SSHArgs{
+				ConnOpts:       connOpts,
+				Result:         result,
+				ForceTTY:       true,
+				PrivKeyFile:    privKeyFile,
+				KnownHostsFile: knownHostsFile,
 			}))
 		})
 	})

--- a/ssh/ssh_args.go
+++ b/ssh/ssh_args.go
@@ -1,0 +1,119 @@
+package ssh
+
+import (
+	"fmt"
+	"strings"
+
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
+
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+)
+
+type SSHArgs struct {
+	ConnOpts ConnectionOpts
+	Result   boshdir.SSHResult
+
+	ForceTTY bool
+
+	PrivKeyFile    boshsys.File
+	KnownHostsFile boshsys.File
+}
+
+func (a SSHArgs) LoginForHost(host boshdir.Host) []string {
+	return []string{host.Host, "-l", host.Username}
+}
+
+func (a SSHArgs) OptsForHost(host boshdir.Host) []string {
+	// Options are used for both ssh and scp
+	cmdOpts := []string{}
+
+	if a.ForceTTY {
+		cmdOpts = append(cmdOpts, "-tt")
+	}
+
+	cmdOpts = append(cmdOpts, []string{
+		"-o", "ServerAliveInterval=30",
+		"-o", "ForwardAgent=no",
+		"-o", "PasswordAuthentication=no",
+		"-o", "IdentitiesOnly=yes",
+		"-o", "IdentityFile=" + a.PrivKeyFile.Name(),
+		"-o", "StrictHostKeyChecking=yes",
+		"-o", "UserKnownHostsFile=" + a.KnownHostsFile.Name(),
+	}...)
+
+	gwUsername, gwHost, gwPrivKeyPath := a.gwOpts()
+
+	if len(a.ConnOpts.SOCKS5Proxy) > 0 {
+		proxyOpt := fmt.Sprintf(
+			"ProxyCommand=nc -x %s %%h %%p",
+			strings.TrimPrefix(a.ConnOpts.SOCKS5Proxy, "socks5://"),
+		)
+
+		cmdOpts = append(cmdOpts, "-o", proxyOpt)
+
+	} else if len(gwHost) > 0 {
+		gwCmdOpts := []string{
+			"-o", "ServerAliveInterval=30",
+			"-o", "ForwardAgent=no",
+			"-o", "ClearAllForwardings=yes",
+			// Strict host key checking for a gateway is not necessary
+			// since ProxyCommand is only used for forwarding TCP and
+			// agent forwarding is disabled
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "UserKnownHostsFile=/dev/null",
+		}
+
+		if len(gwPrivKeyPath) > 0 {
+			gwCmdOpts = append(
+				gwCmdOpts,
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile="+gwPrivKeyPath,
+			)
+		}
+
+		// It appears that when using ssh -W, IPv6 address needs to be put in brackets
+		// fixes: `Bad stdio forwarding specification 'fd7a:eeed:e696:...'`
+		proxyHostPortTmpl := "%h:%p"
+		if strings.Contains(host.Host, ":") {
+			proxyHostPortTmpl = "[%h]:%p"
+		}
+
+		proxyOpt := fmt.Sprintf(
+			// Always force TTY for gateway ssh
+			"ProxyCommand=ssh -tt -W %s -l %s %s %s",
+			proxyHostPortTmpl,
+			gwUsername,
+			gwHost,
+			strings.Join(gwCmdOpts, " "),
+		)
+
+		cmdOpts = append(cmdOpts, "-o", proxyOpt)
+	}
+
+	cmdOpts = append(cmdOpts, a.ConnOpts.RawOpts...)
+
+	return cmdOpts
+}
+
+func (a SSHArgs) gwOpts() (string, string, string) {
+	if a.ConnOpts.GatewayDisable {
+		return "", "", ""
+	}
+
+	// Take server provided gateway options
+	username := a.Result.GatewayUsername
+	host := a.Result.GatewayHost
+
+	if len(a.ConnOpts.GatewayUsername) > 0 {
+		username = a.ConnOpts.GatewayUsername
+	}
+
+	if len(a.ConnOpts.GatewayHost) > 0 {
+		host = a.ConnOpts.GatewayHost
+	}
+
+	privKeyPath := a.ConnOpts.GatewayPrivateKeyPath
+
+	return username, host, privKeyPath
+}

--- a/ssh/ssh_args_test.go
+++ b/ssh/ssh_args_test.go
@@ -1,0 +1,261 @@
+package ssh_test
+
+import (
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	. "github.com/cloudfoundry/bosh-cli/ssh"
+)
+
+var _ = Describe("SSHArgs", func() {
+	var (
+		connOpts       ConnectionOpts
+		result         boshdir.SSHResult
+		forceTTY       bool
+		privKeyFile    *fakesys.FakeFile
+		knownHostsFile *fakesys.FakeFile
+		fs             *fakesys.FakeFileSystem
+		host           boshdir.Host
+	)
+
+	BeforeEach(func() {
+		connOpts = ConnectionOpts{}
+		result = boshdir.SSHResult{}
+		forceTTY = false
+		fs = fakesys.NewFakeFileSystem()
+		privKeyFile = fakesys.NewFakeFile("/tmp/priv-key", fs)
+		knownHostsFile = fakesys.NewFakeFile("/tmp/known-hosts", fs)
+		host = boshdir.Host{Host: "127.0.0.1", Username: "user"}
+	})
+
+	Describe("LoginForHost", func() {
+		act := func() []string {
+			return SSHArgs{}.LoginForHost(host)
+		}
+
+		It("returns login details with IPv4", func() {
+			Expect(act()).To(Equal([]string{"127.0.0.1", "-l", "user"}))
+		})
+
+		It("returns login details with IPv6 non-bracketed", func() {
+			host.Host = "::1"
+			Expect(act()).To(Equal([]string{"::1", "-l", "user"}))
+		})
+	})
+
+	Describe("OptsForHost", func() {
+		act := func() []string {
+			args := SSHArgs{
+				ConnOpts:       connOpts,
+				Result:         result,
+				ForceTTY:       forceTTY,
+				PrivKeyFile:    privKeyFile,
+				KnownHostsFile: knownHostsFile,
+			}
+			return args.OptsForHost(host)
+		}
+
+		It("returns ssh options with correct paths to private key and known hosts", func() {
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+			}))
+		})
+
+		It("returns ssh options with forced tty option if requested", func() {
+			forceTTY = true
+
+			Expect(act()).To(Equal([]string{
+				"-tt",
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+			}))
+		})
+
+		It("returns ssh options with custom raw options specified", func() {
+			connOpts.RawOpts = []string{"raw1", "raw2"}
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"raw1", "raw2",
+			}))
+		})
+
+		It("returns ssh options with gateway settings returned from the Director", func() {
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "gw-host"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=ssh -tt -W %h:%p -l gw-user gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+			}))
+		})
+
+		It("returns ssh options with gateway settings returned from the Director and private key set by user", func() {
+			connOpts.GatewayPrivateKeyPath = "/tmp/gw-priv-key"
+
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "gw-host"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=ssh -tt -W %h:%p -l gw-user gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o IdentitiesOnly=yes -o IdentityFile=/tmp/gw-priv-key",
+			}))
+		})
+
+		It("returns ssh options with gateway settings overridden by user even if the Director specifies some", func() {
+			connOpts.GatewayUsername = "user-gw-user"
+			connOpts.GatewayHost = "user-gw-host"
+
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "gw-host"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=ssh -tt -W %h:%p -l user-gw-user user-gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+			}))
+		})
+
+		It("returns ssh options without gateway settings if disabled even if user or the Director specifies some", func() {
+			connOpts.GatewayDisable = true
+			connOpts.GatewayUsername = "user-gw-user"
+			connOpts.GatewayHost = "user-gw-host"
+
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "gw-host"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+			}))
+		})
+
+		It("returns ssh options without socks5 settings if SOCKS5Proxy is set", func() {
+			connOpts.GatewayDisable = true
+			connOpts.GatewayUsername = "user-gw-user"
+			connOpts.GatewayHost = "user-gw-host"
+			connOpts.SOCKS5Proxy = "socks5://some-proxy"
+
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "gw-host"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=nc -x some-proxy %h %p",
+			}))
+		})
+
+		It("returns ssh options with bracketed gateway proxy command if host IP is IPv6", func() {
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "gw-host"
+			host = boshdir.Host{Host: "::1", Username: "user"}
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=ssh -tt -W [%h]:%p -l gw-user gw-host -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+			}))
+		})
+
+		It("returns ssh options with non-bracketed IPs if gateway IP is IPv6", func() {
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "::1"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=ssh -tt -W %h:%p -l gw-user ::1 -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+			}))
+		})
+
+		It("returns ssh options with bracketed and non-bracketed IPs if host and gateway IP is IPv6", func() {
+			result.GatewayUsername = "gw-user"
+			result.GatewayHost = "::1"
+			host = boshdir.Host{Host: "::2", Username: "user"}
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=ssh -tt -W [%h]:%p -l gw-user ::1 -o ServerAliveInterval=30 -o ForwardAgent=no -o ClearAllForwardings=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+			}))
+		})
+
+		It("returns ssh options non-bracketed if host is IPv6 and SOCKS5Proxy is set", func() {
+			host = boshdir.Host{Host: "::1", Username: "user"}
+			connOpts.SOCKS5Proxy = "socks5://some-proxy"
+
+			Expect(act()).To(Equal([]string{
+				"-o", "ServerAliveInterval=30",
+				"-o", "ForwardAgent=no",
+				"-o", "PasswordAuthentication=no",
+				"-o", "IdentitiesOnly=yes",
+				"-o", "IdentityFile=/tmp/priv-key",
+				"-o", "StrictHostKeyChecking=yes",
+				"-o", "UserKnownHostsFile=/tmp/known-hosts",
+				"-o", "ProxyCommand=nc -x some-proxy %h %p",
+			}))
+		})
+	})
+})

--- a/ssh/sshfakes/fake_session.go
+++ b/ssh/sshfakes/fake_session.go
@@ -8,15 +8,15 @@ import (
 )
 
 type FakeSession struct {
-	StartStub        func() ([]string, error)
+	StartStub        func() (ssh.SSHArgs, error)
 	startMutex       sync.RWMutex
 	startArgsForCall []struct{}
 	startReturns     struct {
-		result1 []string
+		result1 ssh.SSHArgs
 		result2 error
 	}
 	startReturnsOnCall map[int]struct {
-		result1 []string
+		result1 ssh.SSHArgs
 		result2 error
 	}
 	FinishStub        func() error
@@ -32,7 +32,7 @@ type FakeSession struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeSession) Start() ([]string, error) {
+func (fake *FakeSession) Start() (ssh.SSHArgs, error) {
 	fake.startMutex.Lock()
 	ret, specificReturn := fake.startReturnsOnCall[len(fake.startArgsForCall)]
 	fake.startArgsForCall = append(fake.startArgsForCall, struct{}{})
@@ -53,24 +53,24 @@ func (fake *FakeSession) StartCallCount() int {
 	return len(fake.startArgsForCall)
 }
 
-func (fake *FakeSession) StartReturns(result1 []string, result2 error) {
+func (fake *FakeSession) StartReturns(result1 ssh.SSHArgs, result2 error) {
 	fake.StartStub = nil
 	fake.startReturns = struct {
-		result1 []string
+		result1 ssh.SSHArgs
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeSession) StartReturnsOnCall(i int, result1 []string, result2 error) {
+func (fake *FakeSession) StartReturnsOnCall(i int, result1 ssh.SSHArgs, result2 error) {
 	fake.StartStub = nil
 	if fake.startReturnsOnCall == nil {
 		fake.startReturnsOnCall = make(map[int]struct {
-			result1 []string
+			result1 ssh.SSHArgs
 			result2 error
 		})
 	}
 	fake.startReturnsOnCall[i] = struct {
-		result1 []string
+		result1 ssh.SSHArgs
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
- tested manually with variety of different IPv4 and IPv6 combinations
- also removes `-X 5` from `nc`