### PR TITLE
display 'Using environment' within 'bosh login' [fixes #347]

### DIFF
--- a/cmd/basic_login_strategy.go
+++ b/cmd/basic_login_strategy.go
@@ -48,6 +48,8 @@ func (s BasicLoginStrategy) Try() error {
 }
 
 func (s BasicLoginStrategy) tryOnce(environment string, creds cmdconf.Creds) (bool, error) {
+	s.ui.PrintLinef("Using environment '%s'", environment)
+
 	creds, err := s.askForCreds(creds)
 	if err != nil {
 		return false, err

--- a/cmd/uaa_login_strategy.go
+++ b/cmd/uaa_login_strategy.go
@@ -89,6 +89,8 @@ func (c UAALoginStrategy) tryUser(sess Session, uaa boshuaa.UAA) error {
 func (c UAALoginStrategy) tryUserOnce(environment string, prompts []boshuaa.Prompt, uaa boshuaa.UAA) (bool, error) {
 	var answers []boshuaa.PromptAnswer
 
+	c.ui.PrintLinef("Using environment '%s'", environment)
+
 	for _, prompt := range prompts {
 		var askFunc func(string) (string, error)
 


### PR DESCRIPTION
Shows what environment is being targetted:

```
$ out/bosh login
Using environment 'https://10.58.111.4:25555'

Email ():
```