### PR TITLE
Add bash completion with default handling

### DIFF
--- a/ci/tasks/update-homebrew-formula.sh
+++ b/ci/tasks/update-homebrew-formula.sh
@@ -22,6 +22,19 @@ class BoshCli < Formula
   def install
     binary_name = build.with?("bosh2") ? "bosh2" : "bosh"
     bin.install "bosh-cli-#{version}-darwin-amd64" => binary_name
+    (bash_completion/"bosh-cli").write <<-completion
+      _#{binary_name}() {
+          # All arguments except the first one
+          args=("\${COMP_WORDS[@]:1:\$COMP_CWORD}")
+          # Only split on newlines
+          local IFS=$'\n'
+          # Call completion (note that the first element of COMP_WORDS is
+          # the executable itself)
+          COMPREPLY=(\$(GO_FLAGS_COMPLETION=1 \${COMP_WORDS[0]} "\${args[@]}"))
+          return 0
+      }
+      complete -o default -F _#{binary_name} #{binary_name}
+    completion
   end
 
   test do


### PR DESCRIPTION
Re-adds bash completion with `default` option as suggested in https://github.com/cloudfoundry/homebrew-tap/issues/28.

In case there is no completion implemented for custom go-flags args or option, it falls back to default file and folder completion. As a small drawback, this also happens where file completion might not be appropriate, as for example with the `-d` option.

Tested on Mac and on Ubuntu, probably Mac is just fine as this is for homebrew.  

Fixes #175