### PR TITLE
Show stemcell when compiled release already exists

### DIFF
--- a/cmd/upload_release.go
+++ b/cmd/upload_release.go
@@ -162,7 +162,12 @@ func (c UploadReleaseCmd) needToUpload(opts UploadReleaseOpts) (bool, error) {
 	}
 
 	if found {
-		c.ui.PrintLinef("Release '%s/%s' already exists.", opts.Name, version)
+		if opts.Stemcell.IsProvided() {
+			c.ui.PrintLinef("Release '%s/%s' for stemcell '%s' already exists.", opts.Name, version, opts.Stemcell)
+		} else {
+			c.ui.PrintLinef("Release '%s/%s' already exists.", opts.Name, version)
+		}
+
 		return false, nil
 	}
 

--- a/cmd/upload_release_test.go
+++ b/cmd/upload_release_test.go
@@ -175,7 +175,7 @@ var _ = Describe("UploadReleaseCmd", func() {
 				Expect(stemcell).To(Equal(boshdir.NewOSVersionSlug("ubuntu-trusty", "3421")))
 
 				Expect(ui.Said).To(Equal(
-					[]string{"Release 'existing-name/existing-ver' already exists."}))
+					[]string{"Release 'existing-name/existing-ver' for stemcell 'ubuntu-trusty/3421' already exists."}))
 			})
 
 			It("uploads release if name and version does not match existing release", func() {


### PR DESCRIPTION
To keep it explicit and avoid confusion when multiple stemcells are used in a deployment.