### PR TITLE
Asynchronous Update and Delete Deployments

### DIFF
--- a/director/directorfakes/fake_deployment.go
+++ b/director/directorfakes/fake_deployment.go
@@ -381,6 +381,20 @@ type FakeDeployment struct {
 	updateReturnsOnCall map[int]struct {
 		result1 error
 	}
+	UpdateAsyncStub        func(manifest []byte, opts director.UpdateOpts) (int, error)
+	updateAsyncMutex       sync.RWMutex
+	updateAsyncArgsForCall []struct {
+		manifest []byte
+		opts     director.UpdateOpts
+	}
+	updateAsyncReturns struct {
+		result1 int
+		result2 error
+	}
+	updateAsyncReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	DeleteStub        func(force bool) error
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
@@ -391,6 +405,19 @@ type FakeDeployment struct {
 	}
 	deleteReturnsOnCall map[int]struct {
 		result1 error
+	}
+	DeleteAsyncStub        func(force bool) (int, error)
+	deleteAsyncMutex       sync.RWMutex
+	deleteAsyncArgsForCall []struct {
+		force bool
+	}
+	deleteAsyncReturns struct {
+		result1 int
+		result2 error
+	}
+	deleteAsyncReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
 	}
 	AttachDiskStub        func(slug director.InstanceSlug, diskCID string) error
 	attachDiskMutex       sync.RWMutex
@@ -1922,6 +1949,63 @@ func (fake *FakeDeployment) UpdateReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeDeployment) UpdateAsync(manifest []byte, opts director.UpdateOpts) (int, error) {
+	var manifestCopy []byte
+	if manifest != nil {
+		manifestCopy = make([]byte, len(manifest))
+		copy(manifestCopy, manifest)
+	}
+	fake.updateAsyncMutex.Lock()
+	ret, specificReturn := fake.updateAsyncReturnsOnCall[len(fake.updateAsyncArgsForCall)]
+	fake.updateAsyncArgsForCall = append(fake.updateAsyncArgsForCall, struct {
+		manifest []byte
+		opts     director.UpdateOpts
+	}{manifestCopy, opts})
+	fake.recordInvocation("UpdateAsync", []interface{}{manifestCopy, opts})
+	fake.updateAsyncMutex.Unlock()
+	if fake.UpdateAsyncStub != nil {
+		return fake.UpdateAsyncStub(manifest, opts)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.updateAsyncReturns.result1, fake.updateAsyncReturns.result2
+}
+
+func (fake *FakeDeployment) UpdateAsyncCallCount() int {
+	fake.updateAsyncMutex.RLock()
+	defer fake.updateAsyncMutex.RUnlock()
+	return len(fake.updateAsyncArgsForCall)
+}
+
+func (fake *FakeDeployment) UpdateAsyncArgsForCall(i int) ([]byte, director.UpdateOpts) {
+	fake.updateAsyncMutex.RLock()
+	defer fake.updateAsyncMutex.RUnlock()
+	return fake.updateAsyncArgsForCall[i].manifest, fake.updateAsyncArgsForCall[i].opts
+}
+
+func (fake *FakeDeployment) UpdateAsyncReturns(result1 int, result2 error) {
+	fake.UpdateAsyncStub = nil
+	fake.updateAsyncReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDeployment) UpdateAsyncReturnsOnCall(i int, result1 int, result2 error) {
+	fake.UpdateAsyncStub = nil
+	if fake.updateAsyncReturnsOnCall == nil {
+		fake.updateAsyncReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.updateAsyncReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDeployment) Delete(force bool) error {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
@@ -1968,6 +2052,57 @@ func (fake *FakeDeployment) DeleteReturnsOnCall(i int, result1 error) {
 	fake.deleteReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeDeployment) DeleteAsync(force bool) (int, error) {
+	fake.deleteAsyncMutex.Lock()
+	ret, specificReturn := fake.deleteAsyncReturnsOnCall[len(fake.deleteAsyncArgsForCall)]
+	fake.deleteAsyncArgsForCall = append(fake.deleteAsyncArgsForCall, struct {
+		force bool
+	}{force})
+	fake.recordInvocation("DeleteAsync", []interface{}{force})
+	fake.deleteAsyncMutex.Unlock()
+	if fake.DeleteAsyncStub != nil {
+		return fake.DeleteAsyncStub(force)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.deleteAsyncReturns.result1, fake.deleteAsyncReturns.result2
+}
+
+func (fake *FakeDeployment) DeleteAsyncCallCount() int {
+	fake.deleteAsyncMutex.RLock()
+	defer fake.deleteAsyncMutex.RUnlock()
+	return len(fake.deleteAsyncArgsForCall)
+}
+
+func (fake *FakeDeployment) DeleteAsyncArgsForCall(i int) bool {
+	fake.deleteAsyncMutex.RLock()
+	defer fake.deleteAsyncMutex.RUnlock()
+	return fake.deleteAsyncArgsForCall[i].force
+}
+
+func (fake *FakeDeployment) DeleteAsyncReturns(result1 int, result2 error) {
+	fake.DeleteAsyncStub = nil
+	fake.deleteAsyncReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDeployment) DeleteAsyncReturnsOnCall(i int, result1 int, result2 error) {
+	fake.DeleteAsyncStub = nil
+	if fake.deleteAsyncReturnsOnCall == nil {
+		fake.deleteAsyncReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.deleteAsyncReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeDeployment) AttachDisk(slug director.InstanceSlug, diskCID string) error {
@@ -2086,8 +2221,12 @@ func (fake *FakeDeployment) Invocations() map[string][][]interface{} {
 	defer fake.enableResurrectionMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
+	fake.updateAsyncMutex.RLock()
+	defer fake.updateAsyncMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.deleteAsyncMutex.RLock()
+	defer fake.deleteAsyncMutex.RUnlock()
 	fake.attachDiskMutex.RLock()
 	defer fake.attachDiskMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -146,7 +146,9 @@ type Deployment interface {
 	EnableResurrection(InstanceSlug, bool) error
 
 	Update(manifest []byte, opts UpdateOpts) error
+	UpdateAsync(manifest []byte, opts UpdateOpts) (int, error)
 	Delete(force bool) error
+	DeleteAsync(force bool) (int, error)
 
 	AttachDisk(slug InstanceSlug, diskCID string) error
 }
@@ -188,6 +190,7 @@ type UpdateOpts struct {
 	MaxInFlight string
 	DryRun      bool
 	Diff        DeploymentDiff
+	async       bool
 }
 
 //go:generate counterfeiter . ReleaseSeries

--- a/director/task_helpers_test.go
+++ b/director/task_helpers_test.go
@@ -38,6 +38,23 @@ func ConfigureTaskResult(firstHandler http.HandlerFunc, result string, server *g
 	)
 }
 
+func ConfigureTask(firstHandler http.HandlerFunc, result string, server *ghttp.Server) {
+	redirectHeader := http.Header{}
+	redirectHeader.Add("Location", "/tasks/123")
+
+	server.AppendHandlers(
+		ghttp.CombineHandlers(
+			firstHandler,
+			ghttp.RespondWith(http.StatusFound, nil, redirectHeader),
+		),
+		ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/tasks/123"),
+			ghttp.VerifyBasicAuth("username", "password"),
+			ghttp.RespondWith(http.StatusOK, `{"id":123, "state":"done"}`),
+		),
+	)
+}
+
 func AppendBadRequest(firstHandler http.HandlerFunc, server *ghttp.Server) {
 	server.AppendHandlers(
 		ghttp.CombineHandlers(


### PR DESCRIPTION
We are using the bosh-cli as a library on the [Services-Enablement](https://github.com/pivotal-cf/on-demand-service-broker) team and were encountering issues with the Cloud Controller timing out due to the synchronous nature of the Update and Delete Deployment functions. We return the task id of the tasks so that polling may be done on our side.

We added new methods in order to preserve the behaviour of the existing functions and to not introduce any breaking changes. Please let us know if that's appropriate.

Any feedback welcome.

Thanks

with @kirederik