### PR TITLE
Always trust system certificates.

### DIFF
--- a/director/factory_config.go
+++ b/director/factory_config.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cloudfoundry/bosh-utils/crypto"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
@@ -83,9 +82,16 @@ func (c FactoryConfig) Validate() error {
 }
 
 func (c FactoryConfig) CACertPool() (*x509.CertPool, error) {
-	if len(c.CACert) == 0 {
-		return nil, nil
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
 	}
 
-	return crypto.CertPoolFromPEM([]byte(c.CACert))
+	if len(c.CACert) != 0 {
+		if ok := pool.AppendCertsFromPEM([]byte(c.CACert)); !ok {
+			return nil, bosherr.Error("No certs found")
+		}
+	}
+
+	return pool, err
 }

--- a/director/factory_config_test.go
+++ b/director/factory_config_test.go
@@ -1,6 +1,8 @@
 package director_test
 
 import (
+	"crypto/x509"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -102,7 +104,7 @@ var _ = Describe("FactoryConfig", func() {
 			}.Validate()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Parsing certificate 1: Missing PEM block"))
+			Expect(err.Error()).To(ContainSubstring("No certs found"))
 		})
 	})
 
@@ -115,15 +117,19 @@ var _ = Describe("FactoryConfig", func() {
 			}.CACertPool()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Parsing certificate 1: Missing PEM block"))
+			Expect(err.Error()).To(ContainSubstring("No certs found"))
 		})
 
-		It("does not create a cert pool from an empty string", func() {
+		It("uses the system certificates an empty string", func() {
 			caCert := ``
 
 			certPool, err := FactoryConfig{CACert: caCert}.CACertPool()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(certPool).To(BeNil())
+
+			systemPool, err := x509.SystemCertPool()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(certPool.Subjects()).To(Equal(systemPool.Subjects()))
 		})
 
 		It("returns without error for basic config", func() {
@@ -151,7 +157,7 @@ QAOSxgrLBblGLWcDF9fjMeYaUnI34pHviCKeVxfgsxDR+Jg11F78sPdYLOF6ipBe
 
 			certPool, err := FactoryConfig{CACert: caCert}.CACertPool()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(certPool.Subjects()[0]).To(ContainSubstring("Internet Widgits Pty Ltd"))
+			Expect(certPool.Subjects()[len(certPool.Subjects())-1]).To(ContainSubstring("Internet Widgits Pty Ltd"))
 		})
 	})
 })

--- a/uaa/factory_config.go
+++ b/uaa/factory_config.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cloudfoundry/bosh-utils/crypto"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
@@ -85,9 +84,16 @@ func (c Config) Validate() error {
 }
 
 func (c Config) CACertPool() (*x509.CertPool, error) {
-	if len(c.CACert) == 0 {
-		return nil, nil
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
 	}
 
-	return crypto.CertPoolFromPEM([]byte(c.CACert))
+	if len(c.CACert) != 0 {
+		if ok := pool.AppendCertsFromPEM([]byte(c.CACert)); !ok {
+			return nil, bosherr.Error("No certs found")
+		}
+	}
+
+	return pool, err
 }

--- a/uaa/factory_config_test.go
+++ b/uaa/factory_config_test.go
@@ -1,6 +1,8 @@
 package uaa_test
 
 import (
+	"crypto/x509"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -115,7 +117,7 @@ var _ = Describe("FactoryConfig", func() {
 			}.Validate()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Parsing certificate 1: Missing PEM block"))
+			Expect(err.Error()).To(ContainSubstring("No certs found"))
 		})
 	})
 
@@ -129,15 +131,19 @@ var _ = Describe("FactoryConfig", func() {
 			}.CACertPool()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Parsing certificate 1: Missing PEM block"))
+			Expect(err.Error()).To(ContainSubstring("No certs found"))
 		})
 
-		It("does not create a cert pool from an empty string", func() {
+		It("uses the system certificates an empty string", func() {
 			caCert := ``
 
 			certPool, err := Config{CACert: caCert}.CACertPool()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(certPool).To(BeNil())
+
+			systemPool, err := x509.SystemCertPool()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(certPool.Subjects()).To(Equal(systemPool.Subjects()))
 		})
 
 		It("parses the certificate", func() {
@@ -165,7 +171,7 @@ QAOSxgrLBblGLWcDF9fjMeYaUnI34pHviCKeVxfgsxDR+Jg11F78sPdYLOF6ipBe
 
 			certPool, err := Config{CACert: caCert}.CACertPool()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(certPool.Subjects()[0]).To(ContainSubstring("Internet Widgits Pty Ltd"))
+			Expect(certPool.Subjects()[len(certPool.Subjects())-1]).To(ContainSubstring("Internet Widgits Pty Ltd"))
 		})
 	})
 })


### PR DESCRIPTION
Because the cli [assumes the same ca certificate for the director and the uaa](https://github.com/cloudfoundry/bosh-cli/issues/375), authentication fails when the director cert is signed by a private ca and the uaa cert is signed by a public ca. In this case, users *could* append the public ca to the private ca and pass both to `BOSH_CA_CERT`, but we shouldn't have to duplicate certs already trusted by the system. This patch handles this use case without extra cert copy-pasta by starting from the system certs and appending the director ca cert if specified.

@LinuxBozo