### PR TITLE
Fix file descriptor leak

### DIFF
--- a/director/adjustable_client.go
+++ b/director/adjustable_client.go
@@ -41,6 +41,7 @@ func (c AdjustableClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	if c.adjustment.NeedsReadjustment(resp) {
+		resp.Body.Close()
 		err := c.adjustment.Adjust(req, true)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Response bodies must always be closed by someone, and they were being ignored in this case.

If someone wants a bigger project, I think this entire `AdjustableClient` class needs a rethink. As I understand it, an `http.Request` carries some state, so it probably isn't safe to just retry it.

Perhaps it would be better to check if the OAuth token isn't expired before sending it to begin with?

Anyway for now I wanted to keep this patch small, as I believe it will fix <https://github.com/bosh-prometheus/bosh_exporter/issues/14> which is affecting us in production.