### PR TITLE
Delete should set the X-Bosh-Context-Id header if contextID has been set

### DIFF
--- a/director/client_request.go
+++ b/director/client_request.go
@@ -153,7 +153,9 @@ func (r ClientRequest) RawPut(path string, payload []byte, f func(*http.Request)
 func (r ClientRequest) RawDelete(path string) ([]byte, *http.Response, error) {
 	url := fmt.Sprintf("%s%s", r.endpoint, path)
 
-	resp, err := r.httpClient.Delete(url)
+	wrapperFunc := r.setContextIDHeader(nil)
+
+	resp, err := r.httpClient.DeleteCustomized(url, wrapperFunc)
 	if err != nil {
 		return nil, nil, bosherr.WrapErrorf(err, "Performing request DELETE '%s'", url)
 	}

--- a/director/client_request_test.go
+++ b/director/client_request_test.go
@@ -649,6 +649,48 @@ var _ = Describe("ClientRequest", func() {
 					Expect(err.Error()).To(ContainSubstring("Unmarshaling Director response"))
 				})
 			})
+
+			Context("when context id is not set", func() {
+				verifyContextIdNotSet := func(_ http.ResponseWriter, req *http.Request) {
+					_, found := req.Header["X-Bosh-Context-Id"]
+					Expect(found).To(BeFalse())
+				}
+
+				It("does not set a X-Bosh-Context-Id header", func() {
+					server.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/path", ""),
+							ghttp.VerifyBody([]byte("")),
+							verifyContextIdNotSet,
+							ghttp.RespondWith(code, `["val"]`),
+						),
+					)
+
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when context id set", func() {
+				contextId := "example-context-id"
+				BeforeEach(func() {
+					req = req.WithContext(contextId)
+				})
+
+				It("makes request with correct header", func() {
+					server.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/path", ""),
+							ghttp.VerifyBody([]byte("")),
+							ghttp.VerifyHeaderKV("X-Bosh-Context-Id", contextId),
+							ghttp.RespondWith(code, `["val"]`),
+						),
+					)
+
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
 		}
 
 		Describe("'302' response", func() {


### PR DESCRIPTION
In services enablement, we rely on context ID to associate a pre-delete errand task and the corresponding deletion task. When using the bosh-cli library, we found that the context ID header was not being sent for the delete request. This PR makes sure context ID is passed in a header if it has been set.