### PR TITLE
director package doesn't depend on ui package

### DIFF
--- a/director/client_request_test.go
+++ b/director/client_request_test.go
@@ -16,7 +16,7 @@ import (
 
 	. "github.com/cloudfoundry/bosh-cli/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/director/directorfakes"
-	"github.com/cloudfoundry/bosh-cli/ui"
+	bio "github.com/cloudfoundry/bosh-cli/io"
 )
 
 var _ = Describe("ClientRequest", func() {
@@ -400,7 +400,7 @@ var _ = Describe("ClientRequest", func() {
 
 			It("tracks uploading", func() {
 				fileReporter := &fakedir.FakeFileReporter{
-					TrackUploadStub: func(size int64, reader io.ReadCloser) ui.ReadSeekCloser {
+					TrackUploadStub: func(size int64, reader io.ReadCloser) bio.ReadSeekCloser {
 						Expect(size).To(Equal(int64(8)))
 						Expect(ioutil.ReadAll(reader)).To(Equal([]byte("req-body")))
 						return NoopReadSeekCloser{Reader: ioutil.NopCloser(bytes.NewBufferString("req-body"))}

--- a/director/directorfakes/fake_file_reporter.go
+++ b/director/directorfakes/fake_file_reporter.go
@@ -6,21 +6,21 @@ import (
 	"sync"
 
 	"github.com/cloudfoundry/bosh-cli/director"
-	"github.com/cloudfoundry/bosh-cli/ui"
+	bio "github.com/cloudfoundry/bosh-cli/io"
 )
 
 type FakeFileReporter struct {
-	TrackUploadStub        func(int64, io.ReadCloser) ui.ReadSeekCloser
+	TrackUploadStub        func(int64, io.ReadCloser) bio.ReadSeekCloser
 	trackUploadMutex       sync.RWMutex
 	trackUploadArgsForCall []struct {
 		arg1 int64
 		arg2 io.ReadCloser
 	}
 	trackUploadReturns struct {
-		result1 ui.ReadSeekCloser
+		result1 bio.ReadSeekCloser
 	}
 	trackUploadReturnsOnCall map[int]struct {
-		result1 ui.ReadSeekCloser
+		result1 bio.ReadSeekCloser
 	}
 	TrackDownloadStub        func(int64, io.Writer) io.Writer
 	trackDownloadMutex       sync.RWMutex
@@ -38,7 +38,7 @@ type FakeFileReporter struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeFileReporter) TrackUpload(arg1 int64, arg2 io.ReadCloser) ui.ReadSeekCloser {
+func (fake *FakeFileReporter) TrackUpload(arg1 int64, arg2 io.ReadCloser) bio.ReadSeekCloser {
 	fake.trackUploadMutex.Lock()
 	ret, specificReturn := fake.trackUploadReturnsOnCall[len(fake.trackUploadArgsForCall)]
 	fake.trackUploadArgsForCall = append(fake.trackUploadArgsForCall, struct {
@@ -68,22 +68,22 @@ func (fake *FakeFileReporter) TrackUploadArgsForCall(i int) (int64, io.ReadClose
 	return fake.trackUploadArgsForCall[i].arg1, fake.trackUploadArgsForCall[i].arg2
 }
 
-func (fake *FakeFileReporter) TrackUploadReturns(result1 ui.ReadSeekCloser) {
+func (fake *FakeFileReporter) TrackUploadReturns(result1 bio.ReadSeekCloser) {
 	fake.TrackUploadStub = nil
 	fake.trackUploadReturns = struct {
-		result1 ui.ReadSeekCloser
+		result1 bio.ReadSeekCloser
 	}{result1}
 }
 
-func (fake *FakeFileReporter) TrackUploadReturnsOnCall(i int, result1 ui.ReadSeekCloser) {
+func (fake *FakeFileReporter) TrackUploadReturnsOnCall(i int, result1 bio.ReadSeekCloser) {
 	fake.TrackUploadStub = nil
 	if fake.trackUploadReturnsOnCall == nil {
 		fake.trackUploadReturnsOnCall = make(map[int]struct {
-			result1 ui.ReadSeekCloser
+			result1 bio.ReadSeekCloser
 		})
 	}
 	fake.trackUploadReturnsOnCall[i] = struct {
-		result1 ui.ReadSeekCloser
+		result1 bio.ReadSeekCloser
 	}{result1}
 }
 

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/cloudfoundry/bosh-cli/ui"
+	bio "github.com/cloudfoundry/bosh-cli/io"
 	semver "github.com/cppforlife/go-semi-semantic/version"
 )
 
@@ -100,7 +100,7 @@ type StemcellArchive interface {
 //go:generate counterfeiter . FileReporter
 
 type FileReporter interface {
-	TrackUpload(int64, io.ReadCloser) ui.ReadSeekCloser
+	TrackUpload(int64, io.ReadCloser) bio.ReadSeekCloser
 	TrackDownload(int64, io.Writer) io.Writer
 }
 

--- a/director/noop_reporters.go
+++ b/director/noop_reporters.go
@@ -1,8 +1,9 @@
 package director
 
 import (
-	"github.com/cloudfoundry/bosh-cli/ui"
 	"io"
+
+	bio "github.com/cloudfoundry/bosh-cli/io"
 )
 
 type NoopFileReporter struct{}
@@ -31,7 +32,7 @@ func NewNoopFileReporter() NoopFileReporter {
 	return NoopFileReporter{}
 }
 
-func (r NoopFileReporter) TrackUpload(size int64, reader io.ReadCloser) ui.ReadSeekCloser {
+func (r NoopFileReporter) TrackUpload(size int64, reader io.ReadCloser) bio.ReadSeekCloser {
 	return NoopReadSeekCloser{reader}
 }
 func (r NoopFileReporter) TrackDownload(size int64, writer io.Writer) io.Writer { return writer }

--- a/io/interfaces.go
+++ b/io/interfaces.go
@@ -1,0 +1,8 @@
+package io
+
+import sysio "io"
+
+type ReadSeekCloser interface {
+	sysio.Seeker
+	sysio.ReadCloser
+}

--- a/ui/file_reporter.go
+++ b/ui/file_reporter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/cheggaaa/pb"
+	bio "github.com/cloudfoundry/bosh-cli/io"
 )
 
 type FileReporter struct {
@@ -14,17 +15,12 @@ func NewFileReporter(ui UI) FileReporter {
 	return FileReporter{ui: ui}
 }
 
-type ReadSeekCloser interface {
-	io.Seeker
-	io.ReadCloser
-}
-
 func (r FileReporter) Write(b []byte) (int, error) {
 	r.ui.BeginLinef("%s", b)
 	return len(b), nil
 }
 
-func (r FileReporter) TrackUpload(size int64, reader io.ReadCloser) ReadSeekCloser {
+func (r FileReporter) TrackUpload(size int64, reader io.ReadCloser) bio.ReadSeekCloser {
 	return &ReadCloserProxy{reader: reader, bar: r.buildBar(size), ui: r.ui}
 }
 


### PR DESCRIPTION
I'm trying to use the `director` package in another program.

I was surprised to find that `director` depends on `ui`.  But that's only so that it can use a `ReadSeekCloser` type.

This commit breaks that dependency.

I think it may help with https://github.com/cloudfoundry/bosh-cli/issues/329

package import graphs:
- [current master](https://godoc.org/github.com/cloudfoundry/bosh-cli/director?import-graph&hide=2)
- [with this change](https://godoc.org/github.com/rosenhouse/bosh-cli/director?import-graph&hide=2)


