### PR TITLE
Relative local release blobstore (for git lfs)

### DIFF
--- a/releasedir/provider.go
+++ b/releasedir/provider.go
@@ -2,6 +2,7 @@ package releasedir
 
 import (
 	"path/filepath"
+	"strings"
 
 	"code.cloudfoundry.org/clock"
 	boshblob "github.com/cloudfoundry/bosh-utils/blobstore"
@@ -112,6 +113,10 @@ func (p Provider) newBlobstore(dirPath string) boshblob.DigestBlobstore {
 
 	switch provider {
 	case "local":
+		blobstorePath, found := options["blobstore_path"].(string)
+		if found && !strings.HasPrefix(blobstorePath, "/") {
+			options["blobstore_path"] = filepath.Join(dirPath, blobstorePath)
+		}
 		blobstore = boshblob.NewLocalBlobstore(p.fs, p.uuidGen, options)
 	case "s3":
 		blobstore = NewS3Blobstore(p.fs, p.uuidGen, options)

--- a/releasedir/provider.go
+++ b/releasedir/provider.go
@@ -2,7 +2,6 @@ package releasedir
 
 import (
 	"path/filepath"
-	"strings"
 
 	"code.cloudfoundry.org/clock"
 	boshblob "github.com/cloudfoundry/bosh-utils/blobstore"
@@ -114,7 +113,7 @@ func (p Provider) newBlobstore(dirPath string) boshblob.DigestBlobstore {
 	switch provider {
 	case "local":
 		blobstorePath, found := options["blobstore_path"].(string)
-		if found && !strings.HasPrefix(blobstorePath, "/") {
+		if found && !filepath.IsAbs(blobstorePath) {
 			options["blobstore_path"] = filepath.Join(dirPath, blobstorePath)
 		}
 		blobstore = boshblob.NewLocalBlobstore(p.fs, p.uuidGen, options)


### PR DESCRIPTION
After publishing: https://www.starkandwayne.com/blog/bosh-releases-with-git-lfs/, and publishing [a final release with git lfs](https://github.com/starkandwayne/bucc-bbr-boshrelease/commit/db31f89ca2ba12f150579f4dcb1e86054ba8a1ca). 

I wanted to use it via [`git+`](https://github.com/starkandwayne/bucc/blob/develop/ops/6-bucc-bbr.yml#L5) release url. This turned out to not work out of the box, first I had to add `git lfs` support to the bosh-deployment-resource: https://github.com/cloudfoundry/bosh-deployment-resource/pull/37. But further testing revealed that the bosh cli was not picking up the relative directory. 
It works fine when running `bosh {create,upload}-release` from the release directory, since `blobstore.Get()` [resolves the blob path against the PWD](https://github.com/cloudfoundry/bosh-utils/blob/master/blobstore/local_blobstore.go#L43). 
This however does not work when using `bosh upload-release` with `--dir`, it also does not work when cloning the release into a tmp dir with `git+` release url.

This is why I would like to propose appending the release dir to the local blobstore path, if the path is relative (does not start with a /). To illustrate what this would look like I have included a proof of concept implementation. If the proposed functionality would be considered to be merged I'm happy to add tests. 