### PR TITLE
VarsStore accepts file containing only yaml header

### DIFF
--- a/cmd/vars_fs_store.go
+++ b/cmd/vars_fs_store.go
@@ -97,6 +97,9 @@ func (s VarsFSStore) load() (boshtpl.StaticVariables, error) {
 			return vars, bosherr.WrapErrorf(err, "Deserializing variables file store '%s'", s.path)
 		}
 	}
+	if vars == nil {
+		return boshtpl.StaticVariables{}, nil
+	}
 
 	return vars, nil
 }

--- a/cmd/vars_fs_store_test.go
+++ b/cmd/vars_fs_store_test.go
@@ -120,6 +120,18 @@ var _ = Describe("VarsFSStore", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Deserializing variables file store '/file'"))
 		})
+
+		Context("when file contains only the yaml header", func() {
+			It("tries to generate value and save it if variable type is available", func() {
+				fs.WriteFileString("/file", "---")
+
+				val, found, err := store.Get(boshtpl.VariableDefinition{Name: "key", Type: "password"})
+				Expect(len(val.(string))).To(BeNumerically(">", 10))
+				Expect(found).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fs.ReadFileString("/file")).To(MatchYAML(fmt.Sprintf("---\nkey:  %s\n", val.(string))))
+			})
+		})
 	})
 
 	Describe("List", func() {


### PR DESCRIPTION
Previously, if the vars-store file only contained `---`, then the CLI
would panic when trying to set a variable on the map created from the
unmarshaled file.

Signed-off-by: Anand Gaitonde <agaitonde@pivotal.io>