### PR TITLE
log sshtunnel errors

### DIFF
--- a/deployment/instance/instance.go
+++ b/deployment/instance/instance.go
@@ -100,6 +100,13 @@ func (i *instance) WaitUntilReady(
 			sshTunnel := i.sshTunnelFactory.NewSSHTunnel(sshTunnelOptions)
 			go sshTunnel.Start(sshReadyErrCh, sshErrCh)
 
+			go func() {
+				for {
+					sshErr := <-sshErrCh
+					i.logger.Warn(i.logTag, "Received SSH tunnel error: %s", sshErr)
+				}
+			}()
+
 			err := <-sshReadyErrCh
 			if err != nil {
 				return bosherr.WrapError(err, "Starting SSH tunnel")

--- a/deployment/instance/instance.go
+++ b/deployment/instance/instance.go
@@ -101,8 +101,7 @@ func (i *instance) WaitUntilReady(
 			go sshTunnel.Start(sshReadyErrCh, sshErrCh)
 
 			go func() {
-				for {
-					sshErr := <-sshErrCh
+				for sshErr := range sshErrCh{
 					i.logger.Warn(i.logTag, "Received SSH tunnel error: %s", sshErr)
 				}
 			}()


### PR DESCRIPTION
This PR is to improve logging around ssh tunnel errors. With this PR, it will be easier to debug issues like #392 in future.