### PR TITLE
'bosh logs' support for Windows

### DIFF
--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -71,6 +71,11 @@ func (d UIDownloader) Download(blobstoreID, sha1, prefix, dstDirPath string) err
 		}
 	}
 
+	err = tmpFile.Close()
+	if err != nil {
+		return err
+	}
+
 	err = boshfu.NewFileMover(d.fs).Move(tmpFile.Name(), dstFilePath)
 	if err != nil {
 		return bosherr.WrapErrorf(err, "Moving to final destination")

--- a/cmd/downloader_test.go
+++ b/cmd/downloader_test.go
@@ -76,6 +76,22 @@ var _ = Describe("UIDownloader", func() {
 				Expect(director.DownloadResourceUncheckedCallCount()).To(Equal(0))
 				Expect(fs.FileExists(expectedPath)).To(BeFalse())
 			})
+
+			It("returns error if temp file cannot be closed", func() {
+				fakeFile := fakesys.NewFakeFile("/some-tmp-file", fs)
+				fakeFile.CloseErr = errors.New("fake-err")
+				fs.ReturnTempFile = fakeFile
+
+				director.DownloadResourceUncheckedStub = func(_ string, out io.Writer) error {
+					out.Write([]byte("file-contents"))
+					return nil
+				}
+
+				err := act()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("fake-err"))
+				Expect(fs.FileExists(expectedPath)).To(BeFalse())
+			})
 		}
 
 		Context("when SHA1 is provided", func() {


### PR DESCRIPTION
Fix #419 by closing the temp file before attempting to move it