### PR TITLE
Allow INT signals bypass via ssh

### DIFF
--- a/ssh/non_interactive.go
+++ b/ssh/non_interactive.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"os"
+
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 
@@ -28,6 +30,10 @@ func (r NonInteractiveRunner) Run(connOpts ConnectionOpts, result boshdir.SSHRes
 		return boshsys.Command{
 			Name: "ssh",
 			Args: append(append(sshArgs.OptsForHost(host), sshArgs.LoginForHost(host)...), rawCmd...),
+
+			Stdin:  os.Stdin,
+
+			KeepAttached: true,
 		}
 	}
 


### PR DESCRIPTION
Resolves #447

additionally this fix allows to run `bosh instance/0 htop`. Maybe it makes sense to obsolete non-interactive part of the ssh subclient, or rewrite ssh part using go functions in order to allow Windows users use bosh cli.