### PR TITLE
Don't include process rows in instance count

### DIFF
--- a/ui/table/table.go
+++ b/ui/table/table.go
@@ -87,7 +87,7 @@ func (t Table) Print(w io.Writer) error {
 	writer := NewWriter(w, "-", t.BackgroundStr, t.BorderStr)
 	rowCount := len(t.Rows)
 	for _, section := range t.Sections {
-		// rowDupes := 4 //ValueString{"~"}
+		// we're removing process rows from the instance count
 		rowCount += len(section.Rows)
 		for _, r := range section.Rows {
 			fmt.Println(r)

--- a/ui/table/table.go
+++ b/ui/table/table.go
@@ -87,7 +87,14 @@ func (t Table) Print(w io.Writer) error {
 	writer := NewWriter(w, "-", t.BackgroundStr, t.BorderStr)
 	rowCount := len(t.Rows)
 	for _, section := range t.Sections {
+		// rowDupes := 4 //ValueString{"~"}
 		rowCount += len(section.Rows)
+		for _, r := range section.Rows {
+			fmt.Println(r)
+			if r[0].String() == "" {
+				rowCount -= 1
+			}
+		}
 	}
 
 	rows := t.AsRows()

--- a/ui/table/table_test.go
+++ b/ui/table/table_test.go
@@ -314,7 +314,7 @@ s1c1...|s1r2c2|
 r3c1...|r3c2|
 r4c1...|r4c2|
 
-4 things
+2 things
 `))
 			})
 		})


### PR DESCRIPTION
Don't include process rows in instance count. See https://github.com/cloudfoundry/bosh-cli/issues/414