### PR TITLE
Add option to rotate certificates during deploy

### DIFF
--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -455,6 +455,8 @@ type DeployOpts struct {
 
 	DryRun bool `long:"dry-run" description:"Renders job templates without altering deployment"`
 
+	ProgressiveCertRotation bool `long:"progressive-certificate-rotation" description:"Always be rotating"`
+
 	cmd
 }
 

--- a/rotation/README.md
+++ b/rotation/README.md
@@ -25,6 +25,22 @@ We have built an experimental flag to rotate certificates in a deployment for yo
 
 3. This has only been tested with `cf-deployment` version `5.4.0`. There is at least one change in that particular version that is known to help this process succeed, so best not to try with older versions.
 
+## Build and install
+
+Currently this exists as a fork of bosh-cli v5.3.1. To build:
+
+```bash
+go get github.com/cloudfoundry/bosh-cli
+cd ${GOPATH:-$HOME/go}/src/github.com/cloudfoundry/bosh-cli
+git remote add govau https://github.com/govau/bosh-cli
+git fetch govau
+git checkout govau
+go install github.com/cloudfoundry/bosh-cli
+
+# copy binary to somewhere on your path
+cp ${GOPATH:-$HOME/go}/bin/bosh-cli /path/to/where/you/normally/put/bosh
+```
+
 ## Running
 
 This flag should be used during a deploy, e.g.:

--- a/rotation/README.md
+++ b/rotation/README.md
@@ -1,0 +1,182 @@
+# Certificate Rotation
+
+Many `bosh` deployments use generated certificates for authentication between components.
+
+While `bosh` and `credhub` can generate these automatically, they expire after 1 year, which is problematic.
+
+We have built an experimental flag to rotate certificates in a deployment for you.
+
+## Pre-requisites
+
+1. `bosh` must be configured to use `credhub` as a configuration server. It should be easy to adapt this technique for other configuration options, but that's all that is supported so far.
+
+2. Before running with this option, you need to ensure the following environment variables are set so that the `bosh` CLI can communicate directly with `credhub`. e.g. you might set as follows (assuming a `creds.yml` for your `bosh` is nearby):
+
+    ```bash
+    export CREDHUB_SERVER="https://director.bosh.cld.internal:8844"
+    export CREDHUB_CLIENT=credhub-admin
+    export CREDHUB_SECRET="$(bosh int creds.yml --path /credhub_admin_client_secret)"
+    export CREDHUB_CA_CERT="$(cat <<EOF
+    $(bosh int creds.yml --path /credhub_tls/ca)
+    $(bosh int creds.yml --path /uaa_ssl/ca)
+    EOF
+    )"
+    ```
+
+3. This has only been tested with `cf-deployment` version `5.4.0`. There is at least one change in that particular version that is known to help this process succeed, so best not to try with older versions.
+
+## Running
+
+This flag should be used during a deploy, e.g.:
+
+```bash
+bosh -d cf deploy cf-deployment/cf-deployment.yml \
+  -v system_domain=example.com \
+  --no-redact \
+  -n \
+  ...
+  --progressive-certificate-rotation
+```
+
+When this executes, the first thing that it will do is look for the value `credential_rotation_action` in `credhub` for the deployment.
+
+If this value is not set, then no special actions will take place and deployment will occur normally.
+
+To initiate certificate rotation, run the following *before* invoking `bosh deploy` (use the correct bosh director and deployment name for your installation):
+
+```bash
+credhub set -n /main/cf/credential_rotation_action -t value -v create-and-deploy-transitional-cas
+```
+
+And then, when calling `bosh deploy ... --progressive-certificate-rotation`, you should see the following output:
+
+```
+Using deployment 'cf'
+
+Beginning certificate rotation process, step 1 of 3 - Creating transitional CAs...
+
+Creating new transitional CA: /main/cf/service_cf_internal_ca
+Creating new transitional CA: /main/cf/application_ca
+Creating new transitional CA: /main/cf/silk_ca
+Creating new transitional CA: /main/cf/log_cache_ca
+Creating new transitional CA: /main/cf/uaa_ca
+Creating new transitional CA: /main/cf/consul_agent_ca
+Creating new transitional CA: /main/cf/network_policy_ca
+Creating new transitional CA: /main/cf/diego_instance_identity_ca
+Creating new transitional CA: /main/cf/credhub_ca
+Creating new transitional CA: /main/cf/loggregator_ca
+
+... a normal deployment occurs ...
+
+Continuing certificate rotation process, step 2 of 3 - regenerating leaf certificates...
+
+Deleting leaf certificate: /main/cf/cc_tls
+Deleting leaf certificate: /main/cf/log_cache
+Deleting leaf certificate: /main/cf/scheduler_api_tls
+Deleting leaf certificate: /main/cf/adapter_rlp_tls
+Deleting leaf certificate: /main/cf/logs_provider
+Deleting leaf certificate: /main/cf/loggregator_tls_rlp
+Deleting leaf certificate: /main/cf/gorouter_backend_tls
+Deleting leaf certificate: /main/cf/uaa_login_saml
+Deleting leaf certificate: /main/cf/adapter_tls
+Deleting leaf certificate: /main/cf/loggregator_rlp_gateway
+Deleting leaf certificate: /main/cf/network_policy_server
+Deleting leaf certificate: /main/cf/cc_bridge_cc_uploader_server
+Deleting leaf certificate: /main/cf/cc_bridge_tps
+Deleting leaf certificate: /main/cf/log_cache_tls_cc_auth_proxy
+Deleting leaf certificate: /main/cf/scheduler_client_tls
+Deleting leaf certificate: /main/cf/loggregator_tls_doppler
+Deleting leaf certificate: /main/cf/silk_controller
+Deleting leaf certificate: /main/cf/credhub_tls
+Deleting leaf certificate: /main/cf/diego_locket_client
+Deleting leaf certificate: /main/cf/cc_public_tls
+Deleting leaf certificate: /main/cf/loggregator_rlp_gateway_tls_cc
+Deleting leaf certificate: /main/cf/loggregator_tls_agent
+Deleting leaf certificate: /main/cf/diego_rep_client
+Deleting leaf certificate: /main/cf/silk_daemon
+Deleting leaf certificate: /main/cf/diego_auctioneer_client
+Deleting leaf certificate: /main/cf/diego_locket_server
+Deleting leaf certificate: /main/cf/uaa_ssl
+Deleting leaf certificate: /main/cf/loggregator_tls_cc_tc
+Deleting leaf certificate: /main/cf/loggregator_tls_tc
+Deleting leaf certificate: /main/cf/loggregator_tls_statsdinjector
+Deleting leaf certificate: /main/cf/diego_bbs_server
+Deleting leaf certificate: /main/cf/diego_bbs_client
+Deleting leaf certificate: /main/cf/network_policy_client
+Deleting leaf certificate: /main/cf/cc_bridge_cc_uploader
+Deleting leaf certificate: /main/cf/diego_rep_agent_v2
+Deleting leaf certificate: /main/cf/diego_auctioneer_server
+
+Flipping transitional flags for: /main/cf/network_policy_ca
+Flipping transitional flags for: /main/cf/consul_agent_ca
+Flipping transitional flags for: /main/cf/log_cache_ca
+Flipping transitional flags for: /main/cf/silk_ca
+Flipping transitional flags for: /main/cf/application_ca
+Flipping transitional flags for: /main/cf/tls_credhub_ca
+Flipping transitional flags for: /main/cf/loggregator_ca
+Flipping transitional flags for: /main/cf/credhub_ca
+Flipping transitional flags for: /main/cf/diego_instance_identity_ca
+Flipping transitional flags for: /main/cf/uaa_ca
+Flipping transitional flags for: /main/cf/service_cf_internal_ca
+
+... a second deployment occurs ...
+
+Continuing certificate rotation process, step 3 of 3 - removing legacy CAs...
+
+Removing transitional flags for: /main/cf/loggregator_ca
+Removing transitional flags for: /main/cf/credhub_ca
+Removing transitional flags for: /main/cf/log_cache_ca
+Removing transitional flags for: /main/cf/silk_ca
+Removing transitional flags for: /main/cf/service_cf_internal_ca
+Removing transitional flags for: /main/cf/diego_instance_identity_ca
+Removing transitional flags for: /main/cf/network_policy_ca
+Removing transitional flags for: /main/cf/consul_agent_ca
+Removing transitional flags for: /main/cf/uaa_ca
+Removing transitional flags for: /main/cf/application_ca
+
+... a third deployment occurs ...
+```
+
+After each successful deployment, the `credential_rotation_action` value is updated so that if any of the deployments fails for any reason, and then same command is run again, it will skip the deployments that previously succeeded and should be safe to re-run.
+
+After the third and final deployment, `credential_rotation_action` is set to `no-action-needed`, which means that if the command is re-run, no certificate rotation actions are taken.
+
+## Details
+
+### Step 1: Creating transitional CAs
+
+This enumerates all certificates from credhub that were generated for this deployment and filters this to CAs only.
+
+`credhub` is then requested to generate a new transitional certificate for each CA.
+
+Since the bosh director currently appears unable to fetch multiple certificates (active and transitional) from `credhub` directly, we then inject the older (but still active) CA certificates directly into the manifest, just after each of the normal equivalent variable expansions. When the bosh director receives the manifest, it then augments these with the newer transitional CA certificates so that each configured CA certificate variable expansion ends up with 2 PEM encoded certificates.
+
+The deployment then proceeds - however at this time no new credentials are generated, rather the outcome is that each job now trusts both the old and the new CAs.
+
+### Step 2: Regenerating leaf certificates
+
+This first deletes all non-CA certificates in the deployment from `credhub`. When deployed, `credhub` will regenerate these with the new CA certificates using normal process.
+
+Next the transitional flag is flipped on all CA certificates so that `credhub` will use the new CAs to generate the new leaf certificates at deployment time.
+
+As in the previous step, the manifest is augmented in the same manner so that both old and new CAs are trusted by all jobs.
+
+When this deployment is complete, all new credentials have been generated and are in use.
+
+### Step 3: Removing legacy CAs
+
+As a final step we remove the transitional flag from the old CAs, and then re-deploy without augmenting the manifest.
+
+After this, the jobs are now configured to only trust the new CAs.
+
+## What else needs to be done?
+
+We note the following TODOs:
+
+1. There are some global certificates, such as `/dns_api_tls_ca` that are not contemplated in the above.
+2. There are `bosh` credentials, stored in `creds.yml` (such as `credhub_tls`) that are not contemplated above.
+3. Why does `cf-deployment` need so many CAs?
+
+## Authors
+
+Adam Eijdenberg (cloud.gov.au) <adam.eijdenberg@digital.gov.au>

--- a/rotation/credhub_mini_client.go
+++ b/rotation/credhub_mini_client.go
@@ -1,0 +1,388 @@
+package rotation
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type credhubClient interface {
+	ListCredentials(prefix string) (*credhubListResponse, error)
+	GetCredential(name string) (*credhubCredResp, error)
+	SetValueCredential(name, value string) error
+
+	// GetCredentialValue looks for a value, returning default if not found (and nil error)
+	// Other errors will be returned
+	GetCredentialValue(name, defaultValue string) (string, error)
+	DeleteCredential(name string) error
+	GetCertificateID(name string) (string, error)
+	MakeTransitionalCertificate(certificateID string) (*credVersionData, error)
+	MakeThisOneTransitional(certificateID, otherOneToMakeTransitionalOrBlankForNone string) error
+}
+
+type credhubListResponse struct {
+	Credentials []struct {
+		Name string `json:"name"`
+	} `json:"credentials"`
+}
+
+type credVersionData struct {
+	VersionCreatedAt time.Time   `json:"version_created_at"`
+	Type             string      `json:"type"`
+	ID               string      `json:"id"`
+	Transitional     bool        `json:"transitional"`
+	Value            interface{} `json:"value"` // poor choice of API surface...
+}
+
+type credhubCredResp struct {
+	Data []*credVersionData `json:"data"`
+}
+
+func newCredhubClient(credhubCerts, credhubBaseURL, credhubClient, credhubClientSecret string) (credhubClient, error) {
+	cp := x509.NewCertPool()
+	if !cp.AppendCertsFromPEM([]byte(credhubCerts)) {
+		return nil, errors.New("CREDHUB_CA_CERT must be set and include PEMs")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: cp,
+			},
+		},
+	}
+
+	uaaURL, err := getUAAURL(client, credhubBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := getUAAToken(client, uaaURL, credhubClient, credhubClientSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &miniCredhubClient{
+		AccessToken: token,
+		Client:      client,
+		BaseURL:     credhubBaseURL,
+	}, nil
+}
+
+type miniCredhubClient struct {
+	AccessToken string
+	Client      *http.Client
+	BaseURL     string
+}
+
+func (chc *miniCredhubClient) MakeThisOneTransitional(certificateID, otherOneToMakeTransitionalOrBlankForNone string) error {
+	var reqData []byte
+	if otherOneToMakeTransitionalOrBlankForNone == "" {
+		reqData = []byte(`{"version":null}`)
+	} else {
+		var err error
+		reqData, err = json.Marshal(&(struct {
+			S string `json:"version"`
+		}{S: otherOneToMakeTransitionalOrBlankForNone}))
+		if err != nil {
+			return err
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/v1/certificates/%s/update_transitional_version", chc.BaseURL, certificateID), bytes.NewReader(reqData))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("bad status code")
+	}
+
+	return nil
+}
+
+func (chc *miniCredhubClient) MakeTransitionalCertificate(certificateID string) (*credVersionData, error) {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/certificates/%s/regenerate", chc.BaseURL, certificateID), bytes.NewReader([]byte(`{"set_as_transitional":true}`)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("bad status code")
+	}
+
+	var x credVersionData
+	err = json.NewDecoder(resp.Body).Decode(&x)
+	if err != nil {
+		return nil, err
+	}
+
+	return &x, nil
+}
+
+func (chc *miniCredhubClient) GetCertificateID(name string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/certificates?%s", chc.BaseURL, (&url.Values{
+		"name": []string{name},
+	}).Encode()), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("bad status code")
+	}
+
+	var x struct {
+		Certificates []struct {
+			ID string `json:"id"`
+		} `json:"certificates"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&x)
+	if err != nil {
+		return "", err
+	}
+
+	if len(x.Certificates) != 1 {
+		return "", errors.New("wrong num certs")
+	}
+
+	if x.Certificates[0].ID == "" {
+		return "", errors.New("no cert ID")
+	}
+
+	return x.Certificates[0].ID, nil
+}
+
+func (chc *miniCredhubClient) DeleteCredential(name string) error {
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/data?%s", chc.BaseURL, (&url.Values{
+		"name": []string{name},
+	}).Encode()), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.New("bad status code")
+	}
+
+	return nil
+}
+
+func (chc *miniCredhubClient) SetValueCredential(name, value string) error {
+	rd, err := json.Marshal(struct {
+		Name  string `json:"name"`
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	}{
+		Name:  name,
+		Type:  "value",
+		Value: value,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/v1/data", chc.BaseURL), bytes.NewReader(rd))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("bad status code")
+	}
+
+	return nil
+}
+
+func (chc *miniCredhubClient) GetCredentialValue(name, defaultValue string) (string, error) {
+	cr, err := chc.GetCredential(name)
+	switch err {
+	case nil:
+		if len(cr.Data) != 1 {
+			return "", errors.New("unexpected number of results")
+		}
+		rv, ok := cr.Data[0].Value.(string)
+		if !ok {
+			return "", errors.New("unable to coerce data to string")
+		}
+		return rv, nil
+
+	case errNotFound:
+		return defaultValue, nil
+
+	default:
+		return "", err
+	}
+}
+
+var (
+	errNotFound = errors.New("not found")
+)
+
+func (chc *miniCredhubClient) GetCredential(name string) (*credhubCredResp, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/data?%s", chc.BaseURL, (&url.Values{
+		"name":    []string{name},
+		"current": []string{"true"},
+	}).Encode()), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, errNotFound
+		}
+		return nil, errors.New("bad status code")
+	}
+
+	var x credhubCredResp
+	err = json.NewDecoder(resp.Body).Decode(&x)
+	if err != nil {
+		return nil, err
+	}
+
+	return &x, nil
+}
+
+func (chc *miniCredhubClient) ListCredentials(path string) (*credhubListResponse, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/data?%s", chc.BaseURL, (&url.Values{
+		"path": []string{path},
+	}).Encode()), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", chc.AccessToken))
+	resp, err := chc.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("bad status code")
+	}
+
+	var x credhubListResponse
+	err = json.NewDecoder(resp.Body).Decode(&x)
+	if err != nil {
+		return nil, err
+	}
+
+	return &x, nil
+}
+
+func getUAAToken(client *http.Client, uaaURL, clientID, clientSecret string) (string, error) {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/oauth/token", uaaURL), bytes.NewReader([]byte((&url.Values{
+		"client_id":     []string{clientID},
+		"client_secret": []string{clientSecret},
+		"grant_type":    []string{"client_credentials"},
+		"token_type":    []string{"jwt"},
+	}).Encode())))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("bad status code")
+	}
+
+	var x struct {
+		AccessToken string `json:"access_token"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&x)
+	if err != nil {
+		return "", err
+	}
+
+	if x.AccessToken == "" {
+		return "", errors.New("no access token found in response")
+	}
+	return x.AccessToken, nil
+}
+
+func getUAAURL(client *http.Client, baseURL string) (string, error) {
+	resp, err := client.Get(fmt.Sprintf("%s/info", baseURL))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("bad status code")
+	}
+
+	var x struct {
+		AuthServer struct {
+			URL string `json:"url"`
+		} `json:"auth-server"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&x)
+	if err != nil {
+		return "", err
+	}
+
+	if x.AuthServer.URL == "" {
+		return "", errors.New("no auth server URL found in response")
+	}
+
+	return x.AuthServer.URL, nil
+}

--- a/rotation/credhub_rotator.go
+++ b/rotation/credhub_rotator.go
@@ -1,0 +1,343 @@
+package rotation
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	boshui "github.com/cloudfoundry/bosh-cli/ui"
+)
+
+/*
+To kick-off you need:
+
+1. credhub set -n /main/cf/credential_rotation_action -t value -v create-and-deploy-transitional-cas
+2. bosh deploy ... --progressive-certificate-rotation
+*/
+
+const (
+	// PhaseCreateAndDeployTransitionals will look for all CAs in the deployment, and generate a new transitional CA,
+	// if no transitional CA already exists. Any transitional CAs are then appended into the manifest before deployment.
+	PhaseCreateAndDeployTransitionals = "create-and-deploy-transitional-cas"
+
+	// PhaseCreateAndDeployChildCerts will delete all leaf certificates in a deployment, and then look for all CAs,
+	// and ensure that the oldest current version is marked as transitional, and that value appended into the manifest
+	// before deployment. During deployment bosh will then generate new leaf certificates for all child nodes.
+	PhaseCreateAndDeployChildCerts = "create-and-deploy-new-child-certs"
+
+	// PhaseRemoveLegacyCAs will remove all transitional CAs
+	PhaseRemoveLegacyCAs = "remove-legacy-cas"
+
+	// PhaseNone will do nothing.
+	PhaseNone = "no-action-required"
+)
+
+// CredhubRotator will talk directly to Credhub prior to a bosh deployment to rotate certificates as needed.
+type CredhubRotator struct {
+	Prefix                 string
+	CredhubBaseURL         string
+	CredhubCACerts         string
+	CredhubUAAClient       string
+	CredhubUAAClientSecret string
+
+	UI boshui.UI
+}
+
+const (
+	actionPreDeploy  = 1
+	actionPostDeploy = 2
+)
+
+// enumerateCertificates find all certificates under prefix, only returning those that are or are not CAs (depending on isCA flag)
+// Return value is a map of name to the credhub response object
+func enumerateCertificates(chc credhubClient, prefix string, isCA bool) (map[string]*credhubCredResp, error) {
+	creds, err := chc.ListCredentials(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	rv := make(map[string]*credhubCredResp)
+	for _, cred := range creds.Credentials {
+		cd, err := chc.GetCredential(cred.Name)
+		if err != nil {
+			return nil, err
+		}
+		if len(cd.Data) == 0 {
+			return nil, errors.New("no creds returned")
+		}
+
+		for _, c := range cd.Data {
+			if c.Type == "certificate" {
+				asMap, ok := c.Value.(map[string]interface{})
+				if !ok {
+					return nil, errors.New("cannot decode cert type value")
+				}
+				certificateString, ok := asMap["certificate"].(string)
+				if !ok {
+					return nil, errors.New("cannot decode cert type value (2)")
+				}
+
+				block, _ := pem.Decode([]byte(certificateString))
+				if block == nil {
+					return nil, errors.New("no cert found")
+				}
+				if block.Type != "CERTIFICATE" {
+					return nil, errors.New("pem not cert")
+				}
+				cert, err := x509.ParseCertificate(block.Bytes)
+				if err != nil {
+					return nil, err
+				}
+				if cert.IsCA == isCA {
+					rv[cred.Name] = cd
+				}
+			}
+		}
+	}
+	return rv, nil
+}
+
+func (c *CredhubRotator) prepareForCreateAndDeployTransitionals(chc credhubClient) (map[string]string, error) {
+	c.UI.PrintLinef("Beginning certificate rotation process, step 1 of 3 - Creating transitional CAs...")
+
+	certsToRotate, err := enumerateCertificates(chc, c.Prefix, true)
+	if err != nil {
+		return nil, err
+	}
+
+	rv := make(map[string]string)
+	for certName, cd := range certsToRotate {
+		if len(cd.Data) > 1 {
+			c.UI.PrintLinef("More than one active cert found, we won't create new transitional: %s", certName)
+			for _, cvd := range cd.Data {
+				if !cvd.Transitional { // bosh seems to pick up the transitional one?
+					err = c.setTransitionalInRVMap(rv, certName, cvd)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+			continue
+		}
+
+		// only attempt rotation if we are in a clean state, ie exactly one active
+		c.UI.PrintLinef("Creating new transitional CA: %s", certName)
+
+		// get certificate ID - (this is different?)
+		certID, err := chc.GetCertificateID(certName)
+		if err != nil {
+			return nil, err
+		}
+
+		// regenerate it
+		_, err = chc.MakeTransitionalCertificate(certID)
+		if err != nil {
+			return nil, err
+		}
+
+		// include old one in map, as bosh seems to pick up the new one
+		err = c.setTransitionalInRVMap(rv, certName, cd.Data[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rv, nil
+}
+
+func (c *CredhubRotator) setTransitionalInRVMap(rv map[string]string, certName string, cvd *credVersionData) error {
+	m, ok := cvd.Value.(map[string]interface{})
+	if !ok {
+		return errors.New("bad coersion")
+	}
+	key := fmt.Sprintf("%s.certificate", certName[len(c.Prefix)+1:])
+	rv[key] = fmt.Sprintf("%s\n%s", m["certificate"], rv[key])
+	return nil
+}
+
+func (c *CredhubRotator) prepareForCreateAndDeployChildCerts(chc credhubClient) (map[string]string, error) {
+	c.UI.PrintLinef("Continuing certificate rotation process, step 2 of 3 - regenerating leaf certificates...")
+
+	// First, delete all leaf certificates - regardless of what happens next, these are always safe to regenerate
+	certsToDelete, err := enumerateCertificates(chc, c.Prefix, false)
+	if err != nil {
+		return nil, err
+	}
+	for certName := range certsToDelete {
+		c.UI.PrintLinef("Deleting leaf certificate: %s", certName)
+		err := chc.DeleteCredential(certName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Now make sure oldest CAs are the transitional ones
+	certsToRotate, err := enumerateCertificates(chc, c.Prefix, true)
+	if err != nil {
+		return nil, err
+	}
+	rv := make(map[string]string)
+	for certName, cd := range certsToRotate {
+		transitionalID := ""
+
+		// Assume first, and that's OK as we surely wouldn't be here if there were 0?
+		oldestID := cd.Data[0].ID
+		oldestTime := cd.Data[0].VersionCreatedAt
+		for _, cvd := range cd.Data {
+			if cvd.Transitional {
+				transitionalID = cvd.ID
+			}
+			if cvd.VersionCreatedAt.Before(oldestTime) {
+				oldestID = cvd.ID
+			}
+		}
+
+		switch transitionalID {
+		case "":
+			c.UI.PrintLinef("No transitional CA found to flip: %s", certName)
+
+		case oldestID:
+			c.UI.PrintLinef("Oldest CA is already transitional: %s", certName)
+
+		default:
+			c.UI.PrintLinef("Flipping transitional flags for: %s", certName)
+
+			// get certificate ID - (this is different?)
+			certID, err := chc.GetCertificateID(certName)
+			if err != nil {
+				return nil, err
+			}
+
+			err = chc.MakeThisOneTransitional(certID, oldestID)
+			if err != nil {
+				return nil, err
+			}
+
+			// make the rest of this code easier
+			transitionalID = oldestID
+		}
+
+		// Now transitional is the old one, so put that as extra
+		for _, cvd := range cd.Data {
+			if cvd.ID == transitionalID {
+				c.setTransitionalInRVMap(rv, certName, cvd)
+			}
+		}
+	}
+
+	return rv, nil
+}
+
+func (c *CredhubRotator) prepareForRemoveLegacyCAs(chc credhubClient) (map[string]string, error) {
+	c.UI.PrintLinef("Continuing certificate rotation process, step 3 of 3 - removing legacy CAs...")
+
+	certsToRotate, err := enumerateCertificates(chc, c.Prefix, true)
+	if err != nil {
+		return nil, err
+	}
+	for certName, cd := range certsToRotate {
+		hasTransitional := false
+		for _, cvd := range cd.Data {
+			if cvd.Transitional {
+				hasTransitional = true
+			}
+		}
+		if !hasTransitional {
+			c.UI.PrintLinef("No transitional CA found for: %s", certName)
+			continue
+		}
+
+		// get certificate ID - (this is different?)
+		certID, err := chc.GetCertificateID(certName)
+		if err != nil {
+			return nil, err
+		}
+
+		c.UI.PrintLinef("Removing transitional flags for: %s", certName)
+		err = chc.MakeThisOneTransitional(certID, "")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+// PrepareForNewDeploy returns a map of values that should be appended before normal
+// variable substition.
+func (c *CredhubRotator) PrepareForNewDeploy() (map[string]string, error) {
+	chc, action, err := c.getActionAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case PhaseCreateAndDeployTransitionals:
+		return c.prepareForCreateAndDeployTransitionals(chc)
+
+	case PhaseCreateAndDeployChildCerts:
+		return c.prepareForCreateAndDeployChildCerts(chc)
+
+	case PhaseRemoveLegacyCAs:
+		return c.prepareForRemoveLegacyCAs(chc)
+
+	case PhaseNone:
+		c.UI.PrintLinef("No certification rotation will be performed.")
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("unrecognized certificate rotation action requested: %s", action)
+	}
+}
+
+// PostSuccessfulDeploy returns whether another deployment run is needed.
+func (c *CredhubRotator) PostSuccessfulDeploy() (bool, error) {
+	chc, action, err := c.getActionAndClient()
+	if err != nil {
+		return false, err
+	}
+
+	var nextAction string
+	var newDeploy bool
+	switch action {
+	case PhaseCreateAndDeployTransitionals:
+		nextAction, newDeploy = PhaseCreateAndDeployChildCerts, true
+
+	case PhaseCreateAndDeployChildCerts:
+		nextAction, newDeploy = PhaseRemoveLegacyCAs, true
+
+	case PhaseRemoveLegacyCAs:
+		nextAction, newDeploy = PhaseNone, false
+
+	case PhaseNone:
+		nextAction, newDeploy = PhaseNone, false
+
+	default:
+		return false, fmt.Errorf("unrecognized certificate rotation action requested: %s", action)
+	}
+
+	err = chc.SetValueCredential(c.actionKey(), nextAction)
+	if err != nil {
+		return false, err
+	}
+
+	return newDeploy, nil
+}
+
+func (c *CredhubRotator) actionKey() string {
+	return fmt.Sprintf("%s/credential_rotation_action", c.Prefix)
+}
+
+func (c *CredhubRotator) getActionAndClient() (credhubClient, string, error) {
+	chc, err := newCredhubClient(c.CredhubCACerts, c.CredhubBaseURL, c.CredhubUAAClient, c.CredhubUAAClientSecret)
+	if err != nil {
+		return nil, "", err
+	}
+
+	cr, err := chc.GetCredentialValue(c.actionKey(), PhaseNone)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return chc, cr, nil
+}


### PR DESCRIPTION
Our bosh are integrated with Credhub, and we have a number of deployments that are nearly a year old with bosh/Credhub generated certificates that are about to expire.

This patch adds a flag to bosh-cli which rotates the certificates during a 3-pass deployment.

See the [README](https://github.com/govau/bosh-cli/blob/govau/rotation/README.md) for more details and caveats.

We've been able to use this to rotate our cf-deployment certificates without any downtime for either end-users or developer pushing new applications.