### PR TITLE
Add new inspect-local-release command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -285,6 +285,14 @@ func (c Cmd) Execute() (cmdErr error) {
 	case *InspectReleaseOpts:
 		return NewInspectReleaseCmd(deps.UI, c.director()).Run(*opts)
 
+	case *InspectLocalReleaseOpts:
+		relProv, _ := c.releaseProviders()
+
+		return NewInspectLocalReleaseCmd(
+			relProv.NewArchiveReader(),
+			deps.UI,
+		).Run(*opts)
+
 	case *VMsOpts:
 		return NewVMsCmd(deps.UI, c.director(), c.BoshOpts.Parallel).Run(*opts)
 

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Factory", func() {
 			"generate-package":       []string{filepath.Join("/", "file")},
 			"init-release":           []string{},
 			"inspect-release":        []string{"name/version"},
+			"inspect-local-release":  []string{filepath.Join("/", "file")},
 			"inspect-local-stemcell": []string{filepath.Join("/", "file")},
 			"instances":              []string{},
 			"locks":                  []string{},

--- a/cmd/inspect_local_release.go
+++ b/cmd/inspect_local_release.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	boshrel "github.com/cloudfoundry/bosh-cli/release"
+	biui "github.com/cloudfoundry/bosh-cli/ui"
+)
+
+type InspectLocalReleaseCmd struct {
+	reader boshrel.Reader
+	ui     biui.UI
+}
+
+func NewInspectLocalReleaseCmd(
+	reader boshrel.Reader,
+	ui biui.UI,
+) InspectLocalReleaseCmd {
+	return InspectLocalReleaseCmd{
+		reader: reader,
+		ui:     ui,
+	}
+}
+
+func (cmd InspectLocalReleaseCmd) Run(opts InspectLocalReleaseOpts) error {
+	release, err := cmd.reader.Read(opts.Args.PathToRelease)
+	if err != nil {
+		return err
+	}
+
+	ReleaseTables{Release: release, ArchivePath: opts.Args.PathToRelease}.Print(cmd.ui)
+
+	return nil
+}

--- a/cmd/inspect_local_release_test.go
+++ b/cmd/inspect_local_release_test.go
@@ -1,0 +1,156 @@
+package cmd_test
+
+import (
+	"errors"
+
+	. "github.com/cloudfoundry/bosh-cli/cmd"
+
+	. "github.com/cloudfoundry/bosh-cli/release/resource"
+
+	boshjob "github.com/cloudfoundry/bosh-cli/release/job"
+	boshpkg "github.com/cloudfoundry/bosh-cli/release/pkg"
+
+	fakerel "github.com/cloudfoundry/bosh-cli/release/releasefakes"
+	fakeui "github.com/cloudfoundry/bosh-cli/ui/fakes"
+	boshtbl "github.com/cloudfoundry/bosh-cli/ui/table"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InspectLocalReleaseCmd", func() {
+	Describe("Run", func() {
+		var (
+			fakeRelease   *fakerel.FakeRelease
+			releaseReader *fakerel.FakeReader
+			ui            *fakeui.FakeUI
+			opts          InspectLocalReleaseOpts
+			command       InspectLocalReleaseCmd
+		)
+
+		BeforeEach(func() {
+			fakeRelease = &fakerel.FakeRelease{}
+			fakeRelease.NameReturns("rel")
+			fakeRelease.VersionReturns("ver")
+			fakeRelease.CommitHashWithMarkReturns("commit")
+
+			job := boshjob.NewJob(NewResourceWithBuiltArchive(
+				"job-name",
+				"job-fp",
+				"/job-resource-path",
+				"job-digest",
+			))
+			job.PackageNames = []string{"pkg-1-name", "pkg-2-name"}
+
+			pkg1 := boshpkg.NewPackage(NewResourceWithBuiltArchive(
+				"pkg-1-name",
+				"pkg-1-fp",
+				"/pkg-1-resource-path",
+				"pkg-1-digest",
+			), nil)
+			pkg2 := boshpkg.NewPackage(NewResourceWithBuiltArchive(
+				"pkg-2-name",
+				"pkg-2-fp",
+				"/pkg-2-resource-path",
+				"pkg-2-digest",
+			), []string{
+				"pkg-1-name",
+			})
+			pkg2.AttachDependencies([]*boshpkg.Package{pkg1})
+
+			err := job.AttachPackages([]*boshpkg.Package{pkg1, pkg2})
+			Expect(err).ToNot(HaveOccurred())
+
+			fakeRelease.JobsReturns([]*boshjob.Job{job})
+			fakeRelease.PackagesReturns([]*boshpkg.Package{pkg1, pkg2})
+
+			releaseReader = &fakerel.FakeReader{}
+			releaseReader.ReadReturns(fakeRelease, nil)
+
+			opts = InspectLocalReleaseOpts{
+				Args: InspectLocalReleaseArgs{
+					PathToRelease: "/some/release.tgz",
+				},
+			}
+
+			ui = &fakeui.FakeUI{}
+
+			command = NewInspectLocalReleaseCmd(releaseReader, ui)
+		})
+
+		It("prints tables with release, job and package information", func() {
+			err := command.Run(opts)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(ui.Tables[0]).To(Equal(boshtbl.Table{
+				Header: []boshtbl.Header{
+					boshtbl.NewHeader("Name"),
+					boshtbl.NewHeader("Version"),
+					boshtbl.NewHeader("Commit Hash"),
+					boshtbl.NewHeader("Archive"),
+				},
+
+				Rows: [][]boshtbl.Value{
+					{
+						boshtbl.NewValueString("rel"),
+						boshtbl.NewValueString("ver"),
+						boshtbl.NewValueString("commit"),
+						boshtbl.NewValueString("/some/release.tgz"),
+					},
+				},
+				Transpose: true,
+			}))
+
+			Expect(ui.Tables[1]).To(Equal(boshtbl.Table{
+				Content: "jobs",
+				Header: []boshtbl.Header{
+					boshtbl.NewHeader("Job"),
+					boshtbl.NewHeader("Digest"),
+					boshtbl.NewHeader("Packages"),
+				},
+				SortBy: []boshtbl.ColumnSort{{Column: 0, Asc: true}},
+
+				Rows: [][]boshtbl.Value{
+					{
+						boshtbl.NewValueString("job-name/job-fp"),
+						boshtbl.NewValueString("job-digest"),
+						boshtbl.NewValueStrings([]string{"pkg-1-name", "pkg-2-name"}),
+					},
+				},
+			}))
+
+			var emptyNames []string
+
+			Expect(ui.Tables[2]).To(Equal(boshtbl.Table{
+				Content: "packages",
+				Header: []boshtbl.Header{
+					boshtbl.NewHeader("Package"),
+					boshtbl.NewHeader("Digest"),
+					boshtbl.NewHeader("Dependencies"),
+				},
+				SortBy: []boshtbl.ColumnSort{{Column: 0, Asc: true}},
+
+				Rows: [][]boshtbl.Value{
+					{
+						boshtbl.NewValueString("pkg-1-name/pkg-1-fp"),
+						boshtbl.NewValueString("pkg-1-digest"),
+						boshtbl.NewValueStrings(emptyNames),
+					},
+					{
+						boshtbl.NewValueString("pkg-2-name/pkg-2-fp"),
+						boshtbl.NewValueString("pkg-2-digest"),
+						boshtbl.NewValueStrings([]string{"pkg-1-name"}),
+					},
+				},
+			}))
+		})
+
+		It("returns error if reading the release manifest fails", func() {
+			releaseReader.ReadReturns(nil, errors.New("fake-err"))
+
+			err := command.Run(opts)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-err"))
+		})
+	})
+})

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -102,11 +102,12 @@ type BoshOpts struct {
 	RepackStemcell       RepackStemcellOpts         `command:"repack-stemcell"              description:"Repack stemcell"`
 
 	// Releases
-	Releases       ReleasesOpts       `command:"releases"        alias:"rs"   description:"List releases"`
-	UploadRelease  UploadReleaseOpts  `command:"upload-release"  alias:"ur"   description:"Upload release"`
-	ExportRelease  ExportReleaseOpts  `command:"export-release"               description:"Export the compiled release to a tarball"`
-	InspectRelease InspectReleaseOpts `command:"inspect-release"              description:"List release contents such as jobs"`
-	DeleteRelease  DeleteReleaseOpts  `command:"delete-release"  alias:"delr" description:"Delete release"`
+	Releases            ReleasesOpts            `command:"releases"        alias:"rs"   description:"List releases"`
+	UploadRelease       UploadReleaseOpts       `command:"upload-release"  alias:"ur"   description:"Upload release"`
+	ExportRelease       ExportReleaseOpts       `command:"export-release"               description:"Export the compiled release to a tarball"`
+	InspectRelease      InspectReleaseOpts      `command:"inspect-release"              description:"List release contents such as jobs"`
+	InspectLocalRelease InspectLocalReleaseOpts `command:"inspect-local-release"     description:"Display information from release metadata"`
+	DeleteRelease       DeleteReleaseOpts       `command:"delete-release"  alias:"delr" description:"Delete release"`
 
 	// Errands
 	Errands   ErrandsOpts   `command:"errands"    alias:"es" description:"List errands"`
@@ -622,6 +623,15 @@ type InspectReleaseOpts struct {
 
 type InspectReleaseArgs struct {
 	Slug boshdir.ReleaseSlug `positional-arg-name:"NAME/VERSION"`
+}
+
+type InspectLocalReleaseOpts struct {
+	Args InspectLocalReleaseArgs `positional-args:"true" required:"true"`
+	cmd
+}
+
+type InspectLocalReleaseArgs struct {
+	PathToRelease string `positional-arg-name:"PATH-TO-RELEASE" description:"Path to release"`
 }
 
 // Errands

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -496,6 +496,14 @@ var _ = Describe("Opts", func() {
 			})
 		})
 
+		Describe("InspectLocalRelease", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("InspectLocalRelease", opts)).To(Equal(
+					`command:"inspect-local-release" description:"Display information from release metadata"`,
+				))
+			})
+		})
+
 		Describe("InspectLocalStemcell", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("InspectLocalStemcell", opts)).To(Equal(
@@ -1867,6 +1875,36 @@ var _ = Describe("Opts", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Slug", opts)).To(Equal(
 					`positional-arg-name:"NAME/VERSION"`,
+				))
+			})
+		})
+	})
+
+	Describe("InspectLocalReleaseOpts", func() {
+		var opts *InspectLocalReleaseOpts
+
+		BeforeEach(func() {
+			opts = &InspectLocalReleaseOpts{}
+		})
+
+		Describe("Args", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("Args", opts)).To(Equal(`positional-args:"true" required:"true"`))
+			})
+		})
+	})
+
+	Describe("InspectLocalReleaseArgs", func() {
+		var opts *InspectLocalReleaseArgs
+
+		BeforeEach(func() {
+			opts = &InspectLocalReleaseArgs{}
+		})
+
+		Describe("PathToRelease", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("PathToRelease", opts)).To(Equal(
+					`positional-arg-name:"PATH-TO-RELEASE" description:"Path to release"`,
 				))
 			})
 		})


### PR DESCRIPTION
Hi,

This PR adds a new `inspect-local-release` command, similar to the existing `inspect-local-stemcell` command.

Please let me know if you have any questions.

Regards,
Dave