### PR TITLE
Test for source when uploading a release

### DIFF
--- a/director/releases.go
+++ b/director/releases.go
@@ -127,6 +127,10 @@ type CompiledPackage struct {
 	SHA1        string `json:"sha1"`
 }
 
+func (p Package) HasSource() bool {
+	return p.BlobstoreID != "" && p.SHA1 != ""
+}
+
 func (d DirectorImpl) Releases() ([]Release, error) {
 	var rels []Release
 
@@ -184,7 +188,7 @@ func (d DirectorImpl) HasRelease(name, version string, stemcell OSVersionSlug) (
 		return false, err
 	}
 
-	if !stemcell.IsProvided() || !found {
+	if !found {
 		return found, nil
 	}
 
@@ -205,6 +209,9 @@ func (d DirectorImpl) releaseHasCompiledPackage(releaseSlug ReleaseSlug, osVersi
 	}
 
 	for _, pkg := range pkgs {
+		if !osVersionSlug.IsProvided() {
+			return pkg.HasSource(), nil
+		}
 		for _, compiledPkg := range pkg.CompiledPackages {
 			if compiledPkg.Stemcell == osVersionSlug {
 				return true, nil


### PR DESCRIPTION
When uploading releases, the bosh-cli first tests if a release exists
before attempting to upload that release.  Previously, it would consider
a release to exist on the director regardless of whether source bits
exist for that release.  This could result in skipping release uploads
when they actually should be uploaded in the case where the only
releases that are present are compiled.  This commit changes that in the
following way: when checking whether a release has already been uploaded
to the director and no stemcell is specified, we consider if the given
release has any packages that have both a sha1 and a blobstore_id and
therefore have source bits that can be compiled when needed.