### PR TITLE
Check if release exists before deleting it

### DIFF
--- a/cmd/delete_release.go
+++ b/cmd/delete_release.go
@@ -27,12 +27,31 @@ func (c DeleteReleaseCmd) Run(opts DeleteReleaseOpts) error {
 			return err
 		}
 
+		exists, err := release.Exists()
+		if err != nil {
+			return err
+		}
+		if !exists {
+			c.ui.PrintLinef("Release '%s/%s' does not exist.", release.Name(), release.Version())
+			return nil
+		}
+
 		return release.Delete(opts.Force)
 	}
 
 	releaseSeries, err := c.director.FindReleaseSeries(opts.Args.Slug.SeriesSlug())
 	if err != nil {
 		return err
+	}
+
+	exists, err := releaseSeries.Exists()
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		c.ui.PrintLinef("Release '%s' does not exist.", releaseSeries.Name())
+		return nil
 	}
 
 	return releaseSeries.Delete(opts.Force)

--- a/director/directorfakes/fake_release.go
+++ b/director/directorfakes/fake_release.go
@@ -27,6 +27,17 @@ type FakeRelease struct {
 	versionReturnsOnCall map[int]struct {
 		result1 semver.Version
 	}
+	ExistsStub        func() (bool, error)
+	existsMutex       sync.RWMutex
+	existsArgsForCall []struct{}
+	existsReturns     struct {
+		result1 bool
+		result2 error
+	}
+	existsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	VersionMarkStub        func(mark string) string
 	versionMarkMutex       sync.RWMutex
 	versionMarkArgsForCall []struct {
@@ -164,6 +175,49 @@ func (fake *FakeRelease) VersionReturnsOnCall(i int, result1 semver.Version) {
 	fake.versionReturnsOnCall[i] = struct {
 		result1 semver.Version
 	}{result1}
+}
+
+func (fake *FakeRelease) Exists() (bool, error) {
+	fake.existsMutex.Lock()
+	ret, specificReturn := fake.existsReturnsOnCall[len(fake.existsArgsForCall)]
+	fake.existsArgsForCall = append(fake.existsArgsForCall, struct{}{})
+	fake.recordInvocation("Exists", []interface{}{})
+	fake.existsMutex.Unlock()
+	if fake.ExistsStub != nil {
+		return fake.ExistsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.existsReturns.result1, fake.existsReturns.result2
+}
+
+func (fake *FakeRelease) ExistsCallCount() int {
+	fake.existsMutex.RLock()
+	defer fake.existsMutex.RUnlock()
+	return len(fake.existsArgsForCall)
+}
+
+func (fake *FakeRelease) ExistsReturns(result1 bool, result2 error) {
+	fake.ExistsStub = nil
+	fake.existsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRelease) ExistsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.ExistsStub = nil
+	if fake.existsReturnsOnCall == nil {
+		fake.existsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.existsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeRelease) VersionMark(mark string) string {
@@ -403,6 +457,8 @@ func (fake *FakeRelease) Invocations() map[string][][]interface{} {
 	defer fake.nameMutex.RUnlock()
 	fake.versionMutex.RLock()
 	defer fake.versionMutex.RUnlock()
+	fake.existsMutex.RLock()
+	defer fake.existsMutex.RUnlock()
 	fake.versionMarkMutex.RLock()
 	defer fake.versionMarkMutex.RUnlock()
 	fake.commitHashWithMarkMutex.RLock()

--- a/director/directorfakes/fake_release_series.go
+++ b/director/directorfakes/fake_release_series.go
@@ -28,6 +28,17 @@ type FakeReleaseSeries struct {
 	deleteReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ExistsStub        func() (bool, error)
+	existsMutex       sync.RWMutex
+	existsArgsForCall []struct{}
+	existsReturns     struct {
+		result1 bool
+		result2 error
+	}
+	existsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -120,6 +131,49 @@ func (fake *FakeReleaseSeries) DeleteReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeReleaseSeries) Exists() (bool, error) {
+	fake.existsMutex.Lock()
+	ret, specificReturn := fake.existsReturnsOnCall[len(fake.existsArgsForCall)]
+	fake.existsArgsForCall = append(fake.existsArgsForCall, struct{}{})
+	fake.recordInvocation("Exists", []interface{}{})
+	fake.existsMutex.Unlock()
+	if fake.ExistsStub != nil {
+		return fake.ExistsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.existsReturns.result1, fake.existsReturns.result2
+}
+
+func (fake *FakeReleaseSeries) ExistsCallCount() int {
+	fake.existsMutex.RLock()
+	defer fake.existsMutex.RUnlock()
+	return len(fake.existsArgsForCall)
+}
+
+func (fake *FakeReleaseSeries) ExistsReturns(result1 bool, result2 error) {
+	fake.ExistsStub = nil
+	fake.existsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeReleaseSeries) ExistsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.ExistsStub = nil
+	if fake.existsReturnsOnCall == nil {
+		fake.existsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.existsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeReleaseSeries) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -127,6 +181,8 @@ func (fake *FakeReleaseSeries) Invocations() map[string][][]interface{} {
 	defer fake.nameMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.existsMutex.RLock()
+	defer fake.existsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -225,6 +225,7 @@ type UpdateOpts struct {
 type ReleaseSeries interface {
 	Name() string
 	Delete(force bool) error
+	Exists() (bool, error)
 }
 
 //go:generate counterfeiter . Release
@@ -232,6 +233,7 @@ type ReleaseSeries interface {
 type Release interface {
 	Name() string
 	Version() semver.Version
+	Exists() (bool, error)
 	VersionMark(mark string) string
 	CommitHashWithMark(mark string) string
 

--- a/director/release_series.go
+++ b/director/release_series.go
@@ -15,18 +15,30 @@ type ReleaseSeriesImpl struct {
 
 func (rs ReleaseSeriesImpl) Name() string { return rs.name }
 
+func (rs ReleaseSeriesImpl) Exists() (bool, error) {
+	exist := false
+	resps, err := rs.client.ReleaseSeries()
+	if err != nil {
+		return exist, err
+	}
+
+	for _, resp := range resps {
+		if resp.Name == rs.name {
+			exist = true
+			break
+		}
+	}
+
+	return exist, nil
+}
+
 func (rs ReleaseSeriesImpl) Delete(force bool) error {
 	err := rs.client.DeleteReleaseOrSeries(rs.name, "", force)
 	if err != nil {
-		resps, listErr := rs.client.ReleaseSeries()
-		if listErr != nil {
-			return err
-		}
+		exist, existErr := rs.Exists()
 
-		for _, resp := range resps {
-			if resp.Name == rs.name {
-				return err
-			}
+		if exist || existErr != nil {
+			return err
 		}
 	}
 

--- a/director/release_series_test.go
+++ b/director/release_series_test.go
@@ -48,6 +48,44 @@ var _ = Describe("ReleaseSeries", func() {
 		})
 	})
 
+	Describe("Exists", func() {
+		It("returns true when release series exists", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/releases"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.RespondWith(http.StatusOK, `[{"name": "name"}]`),
+				),
+			)
+			exist, err := series.Exists()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exist).To(Equal(true))
+		})
+
+		It("returns false when release series does not exist", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/releases"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.RespondWith(http.StatusOK, `[{"name": "other-name"}]`),
+				),
+			)
+			exist, err := series.Exists()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exist).To(Equal(false))
+		})
+
+		It("returns false and an error when failing to get the release series", func() {
+			AppendBadRequest(ghttp.VerifyRequest("GET", "/releases"), server)
+			exist, err := series.Exists()
+
+			Expect(err).To(HaveOccurred())
+			Expect(exist).To(Equal(false))
+		})
+	})
+
 	Describe("Delete", func() {
 		It("succeeds deleting", func() {
 			ConfigureTaskResult(

--- a/director/releases.go
+++ b/director/releases.go
@@ -32,6 +32,10 @@ type ReleaseImpl struct {
 func (r ReleaseImpl) Name() string            { return r.name }
 func (r ReleaseImpl) Version() semver.Version { return r.version }
 
+func (r ReleaseImpl) Exists() (bool, error) {
+	return r.client.HasRelease(r.name, r.version.String())
+}
+
 func (r ReleaseImpl) VersionMark(suffix string) string {
 	if r.currentlyDeployed {
 		return suffix

--- a/director/releases_test.go
+++ b/director/releases_test.go
@@ -419,6 +419,44 @@ var _ = Describe("Release", func() {
 		})
 	})
 
+	Describe("Exists", func() {
+		It("returns true if release exists", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/releases"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.RespondWith(http.StatusOK, `[{"name":"name","release_versions":[{"version":"ver"}]}]`),
+				),
+			)
+
+			exists, err := release.Exists()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+		})
+
+		It("returns false if release does not exist", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/releases"),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.RespondWith(http.StatusOK, `[{"name":"other-name","release_versions":[{"version":"other-ver"}]}]`),
+				),
+			)
+
+			exists, err := release.Exists()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("returns false and an error when failing to get the release slug", func() {
+			AppendBadRequest(ghttp.VerifyRequest("GET", "/releases"), server)
+
+			exists, err := release.Exists()
+			Expect(err).To(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+	})
+
 	Describe("Delete", func() {
 		It("succeeds deleting", func() {
 			ConfigureTaskResult(


### PR DESCRIPTION
When deleting a release whcih does not exist, a warning will be printed
to the human CLI indicating that it didn't do anything, because the
release/version wasn't found.

[#162726208](https://www.pivotaltracker.com/story/show/162726208)

Co-authored-by: Sebastian Heid <sebastian.heid@sap.com>
Co-authored-by: Denis Langer <denis.langer@sap.com>