### PR TITLE
Deprecate max-in-flight and canaries opts for deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -57,6 +57,14 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 		return err
 	}
 
+	if len(opts.MaxInFlight) > 0 {
+		c.ui.ErrorLinef("The --max-in-flight option has been deprecated. Please specify max_in_flight in the update section of the manifest. See https://bosh.io/docs/manifest-v2/#update for more details.")
+	}
+
+	if len(opts.Canaries) > 0 {
+		c.ui.ErrorLinef("The --canaries option has been deprecated. Please specify canaries in the update section of the manifest. See https://bosh.io/docs/manifest-v2/#update for more details.")
+	}
+
 	updateOpts := boshdir.UpdateOpts{
 		RecreatePersistentDisks: opts.RecreatePersistentDisks,
 		Recreate:                opts.Recreate,

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -473,8 +473,8 @@ type DeployOpts struct {
 	Fix                     bool                `long:"fix"                                     description:"Recreate an instance with an unresponsive agent instead of erroring"`
 	SkipDrain               []boshdir.SkipDrain `long:"skip-drain" value-name:"INSTANCE-GROUP"  description:"Skip running drain and pre-stop scripts for specific instance groups" optional:"true" optional-value:"*"`
 
-	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`
-	MaxInFlight string `long:"max-in-flight" description:"Override manifest values for max_in_flight"`
+	Canaries    string `long:"canaries" description:"Deprecated: Override manifest values for canaries"`
+	MaxInFlight string `long:"max-in-flight" description:"Deprecated: Override manifest values for max_in_flight"`
 
 	DryRun bool `long:"dry-run" description:"Renders job templates without altering deployment"`
 

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -1505,7 +1505,7 @@ var _ = Describe("Opts", func() {
 		Describe("Canaries", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Canaries", opts)).To(Equal(
-					`long:"canaries" description:"Override manifest values for canaries"`,
+					`long:"canaries" description:"Deprecated: Override manifest values for canaries"`,
 				))
 			})
 		})
@@ -1513,7 +1513,7 @@ var _ = Describe("Opts", func() {
 		Describe("MaxInFlight", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("MaxInFlight", opts)).To(Equal(
-					`long:"max-in-flight" description:"Override manifest values for max_in_flight"`,
+					`long:"max-in-flight" description:"Deprecated: Override manifest values for max_in_flight"`,
 				))
 			})
 		})


### PR DESCRIPTION
cloudfoundry/bosh/issues/2193

[#166906143](https://www.pivotaltracker.com/story/show/166906143)

Co-authored-by: Florian Nachtigall <florian.nachtigall@sap.com>