### PR TITLE
Allow tab completion to be more accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 - [https://bosh.io/docs/cli-v2-install/](https://bosh.io/docs/cli-v2-install/)
 
+## Adding tab completion to bash
+
+```sh
+$ eval "$(bosh completion --export)"
+```
+
 ## Client Library
 
 This project includes [`director`](director/interfaces.go) and [`uaa`](uaa/interfaces.go) packages meant to be used in your project for programmatic access to the Director API.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -447,6 +447,9 @@ func (c Cmd) Execute() (cmdErr error) {
 	case *VariablesOpts:
 		return NewVariablesCmd(deps.UI, c.deployment()).Run(*opts)
 
+	case *CompletionOpts:
+		return NewCompletionCmd().Run(*opts)
+
 	default:
 		return fmt.Errorf("Unhandled command: %#v", c.Opts)
 	}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "fmt"
+
+const script = `_bosh ()
+{
+  args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+  local IFS=$'\n'
+
+  COMPREPLY=($(GO_FLAGS_COMPLETION=verbose ${COMP_WORDS[0]} "${args[@]}"))
+  return 0
+}
+
+complete -d -F _bosh bosh
+`
+
+type CompletionCmd struct{}
+
+func NewCompletionCmd() CompletionCmd {
+	return CompletionCmd{}
+}
+
+func (c CompletionCmd) Run(opts CompletionOpts) error {
+	fmt.Println(script)
+
+	return nil
+}

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -176,6 +176,8 @@ type BoshOpts struct {
 	UploadBlobs UploadBlobsOpts `command:"upload-blobs" description:"Upload blobs"`
 
 	Variables VariablesOpts `command:"variables" alias:"vars" description:"List variables"`
+
+	Completion CompletionOpts `command:"completion" description:"Print shell completion text"`
 }
 
 type HelpOpts struct {
@@ -1102,6 +1104,11 @@ type MessageOpts struct {
 
 type VariablesOpts struct {
 	Deployment string
+	cmd
+}
+
+type CompletionOpts struct {
+	Export bool `long:"export" description:"Print the completion script meant to be sourced by the shell"`
 	cmd
 }
 


### PR DESCRIPTION
Users can enable tab completion for the CLI by running:

```
$ eval "$(bosh completion --export)"
```

This utilizes support from the current flag parsing library, go-flags.
The script source can be viewed from go-flags' documentation page:
https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion

Note that this currently only supports bash as the shell.