### PR TITLE
Fix typo in description text

### DIFF
--- a/cmd/create_release_test.go
+++ b/cmd/create_release_test.go
@@ -151,7 +151,7 @@ var _ = Describe("CreateReleaseCmd", func() {
 					Expect(content).To(Equal("release content blah"))
 				})
 
-				It("interpolates release archive destionation path with ((name)) and ((version))", func() {
+				It("interpolates release archive destination path with ((name)) and ((version))", func() {
 					opts.Tarball = FileArg{ExpandedPath: "/tarball-destination-((name))-((version)).tgz"}
 
 					fakeWriter.WriteStub = func(rel boshrel.Release, skipPkgs []string) (string, error) {


### PR DESCRIPTION
I was trying to understand the release creation process more deeply and I found this typo.

Feel free to ignore.