### PR TITLE
Feature "take-out"; ready bosh release for offline deployment

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -132,6 +132,9 @@ func (c Cmd) Execute() (cmdErr error) {
 	case *DeleteDeploymentOpts:
 		return NewDeleteDeploymentCmd(deps.UI, c.deployment()).Run(*opts)
 
+	case *TakeOutOpts:
+		return NewTakeOutCmd(deps.UI).Run(*opts)
+
 	case *ReleasesOpts:
 		return NewReleasesCmd(deps.UI, c.director()).Run()
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/cloudfoundry/bosh-cli/takeout"
 	"path/filepath"
 
 	"github.com/cppforlife/go-patch/patch"
@@ -133,7 +134,7 @@ func (c Cmd) Execute() (cmdErr error) {
 		return NewDeleteDeploymentCmd(deps.UI, c.deployment()).Run(*opts)
 
 	case *TakeOutOpts:
-		return NewTakeOutCmd(deps.UI).Run(*opts)
+		return NewTakeOutCmd(deps.UI, takeout.RealUtensils{}).Run(*opts)
 
 	case *ReleasesOpts:
 		return NewReleasesCmd(deps.UI, c.director()).Run()

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Factory", func() {
 			"stop":                   []string{"slug"},
 			"sync-blobs":             []string{},
 			"take-snapshot":          []string{"group/id"},
-			"take-out":				  []string{filepath.Join("/", "file")},
+			"take-out":               []string{filepath.Join("/", "file2"), filepath.Join("/", "file")},
 			"task":                   []string{"1234"},
 			"tasks":                  []string{},
 			"update-cloud-config":    []string{filepath.Join("/", "file")},
@@ -381,6 +381,7 @@ var _ = Describe("Factory", func() {
 			boshOpts.UploadBlobs = UploadBlobsOpts{}
 			boshOpts.SSH = SSHOpts{}
 			boshOpts.SCP = SCPOpts{}
+			boshOpts.TakeOut = TakeOutOpts{}
 			boshOpts.Deploy = DeployOpts{}
 			boshOpts.UpdateRuntimeConfig = UpdateRuntimeConfigOpts{}
 			boshOpts.VMs = VMsOpts{}

--- a/cmd/factory_test.go
+++ b/cmd/factory_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Factory", func() {
 			"stop":                   []string{"slug"},
 			"sync-blobs":             []string{},
 			"take-snapshot":          []string{"group/id"},
+			"take-out":				  []string{filepath.Join("/", "file")},
 			"task":                   []string{"1234"},
 			"tasks":                  []string{},
 			"update-cloud-config":    []string{filepath.Join("/", "file")},

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -318,6 +318,7 @@ type InterpolateArgs struct {
 type TakeOutOpts struct {
 	Args         TakeOutArgs `positional-args:"true" required:"true"`
 	MirrorPrefix string      `long:"mirror-prefix" short:"m" description:"Mirror prefix" optional:"true" default:"file:"`
+	StemcellType string      `long:"stemcell-type" short:"t" description:"Stemcell type" optional:"true" default:"vsphere-esxi"`
 
 	VarFlags
 	OpsFlags

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -329,6 +329,8 @@ type TakeOutOpts struct {
 }
 
 type TakeOutArgs struct {
+	Name string `positional-arg-name:"NAME" description:"file name of ops file"`
+
 	Manifest FileBytesArg `positional-arg-name:"PATH" description:"Path to a template that will be interpolated"`
 }
 // Config

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -89,6 +89,7 @@ type BoshOpts struct {
 	Manifest ManifestOpts `command:"manifest" alias:"man" description:"Show deployment manifest"`
 
 	Interpolate InterpolateOpts `command:"interpolate" alias:"int" description:"Interpolates variables into a manifest"`
+	TakeOut TakeOutOpts `command:"take-out" description:"prepares dependencies for offline use"`
 
 	// Events
 	Events EventsOpts `command:"events" description:"List events"`
@@ -314,6 +315,22 @@ type InterpolateArgs struct {
 	Manifest FileBytesArg `positional-arg-name:"PATH" description:"Path to a template that will be interpolated"`
 }
 
+type TakeOutOpts struct {
+	Args TakeOutArgs `positional-args:"true" required:"true"`
+
+	VarFlags
+	OpsFlags
+
+	Path            patch.Pointer `long:"path" value-name:"OP-PATH" description:"Extract value out of template (e.g.: /private_key)"`
+	VarErrors       bool          `long:"var-errs"                  description:"Expect all variables to be found, otherwise error"`
+	VarErrorsUnused bool          `long:"var-errs-unused"           description:"Expect all variables to be used, otherwise error"`
+
+	cmd
+}
+
+type TakeOutArgs struct {
+	Manifest FileBytesArg `positional-arg-name:"PATH" description:"Path to a template that will be interpolated"`
+}
 // Config
 
 type ConfigOpts struct {

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -89,7 +89,7 @@ type BoshOpts struct {
 	Manifest ManifestOpts `command:"manifest" alias:"man" description:"Show deployment manifest"`
 
 	Interpolate InterpolateOpts `command:"interpolate" alias:"int" description:"Interpolates variables into a manifest"`
-	TakeOut TakeOutOpts `command:"take-out" description:"prepares dependencies for offline use"`
+	TakeOut     TakeOutOpts     `command:"take-out" description:"prepares dependencies for offline use"`
 
 	// Events
 	Events EventsOpts `command:"events" description:"List events"`
@@ -316,23 +316,23 @@ type InterpolateArgs struct {
 }
 
 type TakeOutOpts struct {
-	Args TakeOutArgs `positional-args:"true" required:"true"`
+	Args         TakeOutArgs `positional-args:"true" required:"true"`
+	MirrorPrefix string      `long:"mirror-prefix" short:"m" description:"Mirror prefix" optional:"true" default:"file:"`
 
 	VarFlags
 	OpsFlags
 
-	Path            patch.Pointer `long:"path" value-name:"OP-PATH" description:"Extract value out of template (e.g.: /private_key)"`
-	VarErrors       bool          `long:"var-errs"                  description:"Expect all variables to be found, otherwise error"`
-	VarErrorsUnused bool          `long:"var-errs-unused"           description:"Expect all variables to be used, otherwise error"`
+	VarErrors       bool `long:"var-errs"                  description:"Expect all variables to be found, otherwise error"`
+	VarErrorsUnused bool `long:"var-errs-unused"           description:"Expect all variables to be used, otherwise error"`
 
 	cmd
 }
 
 type TakeOutArgs struct {
-	Name string `positional-arg-name:"NAME" description:"file name of ops file"`
-
-	Manifest FileBytesArg `positional-arg-name:"PATH" description:"Path to a template that will be interpolated"`
+	Name     string       `positional-arg-name:"NAME" description:"file name of ops file"`
+	Manifest FileBytesArg `positional-arg-name:"PATH" description:"Path to a template for take_out"`
 }
+
 // Config
 
 type ConfigOpts struct {

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -1301,6 +1301,60 @@ var _ = Describe("Opts", func() {
 		})
 	})
 
+	Describe("TakeOutOpts", func() {
+		var opts TakeOutOpts
+
+		It("has Args", func() {
+			Expect(getStructTagForName("Args", &opts)).To(Equal(`positional-args:"true" required:"true"`))
+		})
+
+		Describe("MirrorPrefix", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("MirrorPrefix", &opts)).To(Equal(
+					`long:"mirror-prefix" short:"m" description:"Mirror prefix" optional:"true" default:"file:"`,
+				))
+			})
+		})
+
+		It("has VarErrors", func() {
+			Expect(getStructTagForName("VarErrors", &opts)).To(Equal(
+				`long:"var-errs" description:"Expect all variables to be found, otherwise error"`,
+			))
+		})
+
+		It("has VarErrorsUnused", func() {
+			Expect(getStructTagForName("VarErrorsUnused", &opts)).To(Equal(
+				`long:"var-errs-unused" description:"Expect all variables to be used, otherwise error"`,
+			))
+		})
+
+	})
+
+	Describe("TakeOutArgs", func() {
+		var opts *TakeOutArgs
+
+		BeforeEach(func() {
+			opts = &TakeOutArgs{}
+		})
+
+		Describe("Name", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("Name", opts)).To(Equal(
+					`positional-arg-name:"NAME" description:"file name of ops file"`,
+				))
+			})
+		})
+
+		Describe("Manifest", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("Manifest", opts)).To(Equal(
+					`positional-arg-name:"PATH" description:"Path to a template for take_out"`,
+				))
+			})
+		})
+
+	})
+
 	Describe("UpdateCloudConfigOpts", func() {
 		var opts *UpdateCloudConfigOpts
 

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -36,6 +36,9 @@ func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 	if err != nil {
 		return bosherr.WrapErrorf(err, "Evaluating manifest")
 	}
+	if _, err := os.Stat(opts.Args.Name); os.IsExist(err) {
+		return bosherr.WrapErrorf(err, "Takeout op name exists")
+	}
 
 	manifest, err := boshdir.NewManifestFromBytes(bytes)
 	fmt.Println("Processing releases for offline use")
@@ -47,7 +50,7 @@ func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 
 	y, _ := yaml.Marshal(releaseChanges)
 	fmt.Println("Writing take-out operation")
-	takeoutOp, err := os.Create("takeout.yml")
+	takeoutOp, err := os.Create(opts.Args.Name)
 	if err != nil{
 		return err
 	}

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -1,34 +1,40 @@
 package cmd
 
 import (
-	"crypto/sha1"
-	"fmt"
 	boshdir "github.com/cloudfoundry/bosh-cli/director"
 	boshtpl "github.com/cloudfoundry/bosh-cli/director/template"
+	"github.com/cloudfoundry/bosh-cli/takeout"
 	boshui "github.com/cloudfoundry/bosh-cli/ui"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"gopkg.in/yaml.v2"
-	"io"
-	"net/http"
 	"os"
-	"regexp"
 )
-
-var BadChar = regexp.MustCompile("[?=\"]")
-
-type OpEntry struct {
-	Type  string `json:"type" yaml:"type"`
-	Path  string `json:"path" yaml:"path"`
-	Value string `json:"value" yaml:"value"`
-}
 
 type TakeOutCmd struct {
 	ui boshui.UI
+	to takeout.Utensils
 }
 
-func NewTakeOutCmd(ui boshui.UI) TakeOutCmd {
-	return TakeOutCmd{ui: ui}
+func NewTakeOutCmd(ui boshui.UI, d takeout.Utensils) TakeOutCmd {
+	return TakeOutCmd{ui: ui, to: d}
 }
+
+// idea: take_out could export to fully constructed template instead of just the modifications
+
+/*
+
+mkdir take_out-cf
+cd ..
+
+git clone --mirror cf-deploy
+git clone cf-deploy
+
+bosh take_out cf-6-offline.yml cf-deployment/manifest.yml
+
+7z -v300m take_out-cf.7z take_out-cf/
+
+
+*/
 
 func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 	tpl := boshtpl.NewTemplate(opts.Args.Manifest.Bytes)
@@ -43,17 +49,22 @@ func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 
 	manifest, err := boshdir.NewManifestFromBytes(bytes)
 	c.ui.PrintLinef("Processing releases for offline use")
-	var releaseChanges []OpEntry
+	var releaseChanges []takeout.OpEntry
 	for _, r := range manifest.Releases {
-		o, err := TakeOutRelease(r, c.ui)
-		if err != nil {
-			return err
+		if r.URL == "" {
+			c.ui.PrintLinef("Release does not have a URL for take_out; Name: %s / %s", r.Name, r.Version)
+			return bosherr.WrapErrorf(nil, "Provide an opsfile that has a URL or removes this release") // TODO
+		} else {
+			o, err := c.to.TakeOutRelease(r, c.ui, opts.MirrorPrefix)
+			if err != nil {
+				return err
+			}
+			releaseChanges = append(releaseChanges, o)
 		}
-		releaseChanges = append(releaseChanges, o)
 	}
 
 	y, _ := yaml.Marshal(releaseChanges)
-	c.ui.PrintLinef("Writing take-out operation to file: " + opts.Args.Name)
+	c.ui.PrintLinef("Writing take_out operation to file: " + opts.Args.Name)
 	takeoutOp, err := os.Create(opts.Args.Name)
 	if err != nil {
 		return err
@@ -62,54 +73,4 @@ func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 	takeoutOp.WriteString("---\n")
 	takeoutOp.WriteString(string(y))
 	return nil
-}
-func TakeOutRelease(r boshdir.ManifestRelease, ui boshui.UI) (entry OpEntry, err error) {
-
-	// generate a local file name that's safe
-	localFileName := BadChar.ReplaceAllString(fmt.Sprintf("%s_v%s.tgz", r.Name, r.Version), "_")
-
-	if _, err := os.Stat(localFileName); os.IsNotExist(err) {
-		err = RetrieveRelease(r, ui, localFileName)
-		if err != nil {
-			return OpEntry{}, err
-		}
-	} else {
-		ui.PrintLinef("Release present: %s / %s -> %s", r.Name, r.Version, localFileName)
-	}
-	if len(r.Name) > 0 {
-		path := fmt.Sprintf("/releases/name=%s/url", r.Name)
-		localFile := fmt.Sprintf("file://%s", localFileName)
-		entry = OpEntry{Type: "replace", Path: path, Value: localFile}
-	}
-	return entry, err
-}
-func RetrieveRelease(r boshdir.ManifestRelease, ui boshui.UI, localFileName string) (err error) {
-	ui.PrintLinef("Downloading release: %s / %s -> %s", r.Name, r.Version, localFileName)
-
-	resp, err := http.Get(r.URL)
-	if err != nil {
-		return
-	}
-	defer resp.Body.Close()
-
-	// Create the file
-	out, err := os.Create(localFileName)
-	if err != nil {
-		return
-	}
-	defer out.Close()
-
-	// Write the body to file
-	hash := sha1.New()
-	_, err = io.Copy(out, io.TeeReader(resp.Body, hash))
-	actualSha1 := fmt.Sprintf("%x", hash.Sum(nil))
-	if err != nil {
-		return
-	}
-	if len(r.SHA1) == 40 {
-		if actualSha1 != r.SHA1 {
-			return bosherr.Errorf("sha1 mismatch %s (a:%s, e:%s)", localFileName, actualSha1, r.SHA1)
-		}
-	}
-	return
 }

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -74,12 +74,7 @@ func TakeOutRelease(r boshdir.ManifestRelease, ui boshui.UI) (entry OpEntry, err
 			return OpEntry{}, err
 		}
 	} else {
-		ui.PrintLinef("Released already downloaded (name/version): %s / %s -> %s", r.Name, r.Version, localFileName)
-		readH, err := os.Open(localFileName)
-		defer readH.Close()
-		if err != nil {
-			return entry, err
-		}
+		ui.PrintLinef("Released already downloaded: %s / %s -> %s", r.Name, r.Version, localFileName)
 	}
 	if len(r.Name) > 0 {
 		path := fmt.Sprintf("/releases/name=%s/url", r.Name)
@@ -89,7 +84,7 @@ func TakeOutRelease(r boshdir.ManifestRelease, ui boshui.UI) (entry OpEntry, err
 	return entry, err
 }
 func RetrieveRelease(r boshdir.ManifestRelease, ui boshui.UI, localFileName string) (err error) {
-	ui.PrintLinef("Downloading release (name/version): %s / %s -> %s", r.Name, r.Version, localFileName)
+	ui.PrintLinef("Downloading release: %s / %s -> %s", r.Name, r.Version, localFileName)
 
 	resp, err := http.Get(r.URL)
 	if err != nil {

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"crypto/sha1"
 	"fmt"
 	boshdir "github.com/cloudfoundry/bosh-cli/director"
 	boshtpl "github.com/cloudfoundry/bosh-cli/director/template"
@@ -55,6 +56,7 @@ func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 		return err
 	}
 	defer takeoutOp.Close()
+	takeoutOp.WriteString("---\n")
 	takeoutOp.WriteString(string(y))
 	return nil
 }
@@ -62,6 +64,10 @@ func DownloadFile(r boshdir.ManifestRelease) (entry OpEntry, err error) {
 
 	// generate a local file name
 	filepath := BadChar.ReplaceAllString(path.Base(r.URL),"_")
+
+	expectedSha1 := r.SHA1
+	actualSha1 := ""
+	sha1 := sha1.New()
 
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		fmt.Println("Downloading release: " + r.Name + " " + r.Version)
@@ -80,17 +86,37 @@ func DownloadFile(r boshdir.ManifestRelease) (entry OpEntry, err error) {
 		defer out.Close()
 
 		// Write the body to file
-		_, err = io.Copy(out, resp.Body)
+		_, err = io.Copy(out, io.TeeReader(resp.Body, sha1))
+		actualSha1 = fmt.Sprintf("%x", sha1.Sum(nil))
 		if err != nil {
 			return entry, err
 		}
 	} else {
 		fmt.Println("Release already downloaded: " + r.Name + " " + r.Version)
-	}
-	path := fmt.Sprintf("/releases/name=%s/url", r.Name)
-	localFile := fmt.Sprintf("file://%s", filepath)
-	entry = OpEntry{Type: "replace", Path: path, Value: localFile}
+		readH, err := os.Open(filepath)
+		defer readH.Close()
+		if err != nil {
+			return entry, err
+		}
+		_, err = io.Copy(sha1, readH)
 
+		actualSha1 = fmt.Sprintf("%x", sha1.Sum(nil))
+	}
+
+	if len(r.SHA1) == 40 {
+		fmt.Println("Checking hash")
+
+		if actualSha1 != expectedSha1 {
+			fmt.Println("Bad download, invalid sha1 " + filepath)
+			panic("")
+		}
+	}
+
+	if len(r.Name) > 0 {
+		path := fmt.Sprintf("/releases/name=%s/url", r.Name)
+		localFile := fmt.Sprintf("file://%s", filepath)
+		entry = OpEntry{Type: "replace", Path: path, Value: localFile}
+	}
 	return entry, err
 }
 

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -19,23 +19,6 @@ func NewTakeOutCmd(ui boshui.UI, d takeout.Utensils) TakeOutCmd {
 	return TakeOutCmd{ui: ui, to: d}
 }
 
-// idea: take_out could export to fully constructed template instead of just the modifications
-
-/*
-
-mkdir take_out-cf
-cd ..
-
-git clone --mirror cf-deploy
-git clone cf-deploy
-
-bosh take_out cf-6-offline.yml cf-deployment/manifest.yml
-
-7z -v300m take_out-cf.7z take_out-cf/
-
-
-*/
-
 func (c TakeOutCmd) Run(opts TakeOutOpts) error {
 	tpl := boshtpl.NewTemplate(opts.Args.Manifest.Bytes)
 

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -84,7 +84,7 @@ func DownloadFile(r boshdir.ManifestRelease) (entry OpEntry, err error) {
 	} else {
 		fmt.Println("Release already downloaded: " + r.Name + " " + r.Version)
 	}
-	path := fmt.Sprintf("/releases/%s/url", r.Name)
+	path := fmt.Sprintf("/releases/name=%s/url", r.Name)
 	localFile := fmt.Sprintf("file://%s", filepath)
 	entry = OpEntry{Type: "replace", Path: path, Value: localFile}
 

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -74,7 +74,7 @@ func TakeOutRelease(r boshdir.ManifestRelease, ui boshui.UI) (entry OpEntry, err
 			return OpEntry{}, err
 		}
 	} else {
-		ui.PrintLinef("Released already downloaded: %s / %s -> %s", r.Name, r.Version, localFileName)
+		ui.PrintLinef("Release present: %s / %s -> %s", r.Name, r.Version, localFileName)
 	}
 	if len(r.Name) > 0 {
 		path := fmt.Sprintf("/releases/name=%s/url", r.Name)

--- a/cmd/take_out.go
+++ b/cmd/take_out.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	boshtpl "github.com/cloudfoundry/bosh-cli/director/template"
+	boshui "github.com/cloudfoundry/bosh-cli/ui"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"gopkg.in/yaml.v2"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"regexp"
+)
+var BadChar = regexp.MustCompile("[?=]")
+
+type OpEntry struct {
+	Type string `json:"type" yaml:"type"`
+	Path string `json:"path" yaml:"path"`
+	Value string `json:"value" yaml:"value"`
+}
+
+type TakeOutCmd struct {
+	ui              boshui.UI
+}
+
+func NewTakeOutCmd(ui boshui.UI) TakeOutCmd {
+	return TakeOutCmd{ui: ui}
+}
+
+func (c TakeOutCmd) Run(opts TakeOutOpts) error {
+	tpl := boshtpl.NewTemplate(opts.Args.Manifest.Bytes)
+
+	bytes, err := tpl.Evaluate(opts.VarFlags.AsVariables(), opts.OpsFlags.AsOp(), boshtpl.EvaluateOpts{})
+	if err != nil {
+		return bosherr.WrapErrorf(err, "Evaluating manifest")
+	}
+
+	manifest, err := boshdir.NewManifestFromBytes(bytes)
+	fmt.Println("Processing releases for offline use")
+	var releaseChanges []OpEntry
+	for _, r := range manifest.Releases {
+		o, _ := DownloadFile(r)
+		releaseChanges = append(releaseChanges, o)
+	}
+
+	y, _ := yaml.Marshal(releaseChanges)
+	fmt.Println("Writing take-out operation")
+	takeoutOp, err := os.Create("takeout.yml")
+	if err != nil{
+		return err
+	}
+	defer takeoutOp.Close()
+	takeoutOp.WriteString(string(y))
+	return nil
+}
+func DownloadFile(r boshdir.ManifestRelease) (entry OpEntry, err error) {
+
+	// generate a local file name
+	filepath := BadChar.ReplaceAllString(path.Base(r.URL),"_")
+
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		fmt.Println("Downloading release: " + r.Name + " " + r.Version)
+
+		resp, err := http.Get(r.URL)
+		if err != nil {
+			return entry, err
+		}
+		defer resp.Body.Close()
+
+		// Create the file
+		out, err := os.Create(filepath)
+		if err != nil {
+			return entry, err
+		}
+		defer out.Close()
+
+		// Write the body to file
+		_, err = io.Copy(out, resp.Body)
+		if err != nil {
+			return entry, err
+		}
+	} else {
+		fmt.Println("Release already downloaded: " + r.Name + " " + r.Version)
+	}
+	path := fmt.Sprintf("/releases/%s/url", r.Name)
+	localFile := fmt.Sprintf("file://%s", filepath)
+	entry = OpEntry{Type: "replace", Path: path, Value: localFile}
+
+	return entry, err
+}
+

--- a/cmd/take_out_test.go
+++ b/cmd/take_out_test.go
@@ -1,0 +1,256 @@
+package cmd_test
+
+import (
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-cli/cmd"
+	fakeout "github.com/cloudfoundry/bosh-cli/takeout/takeoutfakes"
+	fakeui "github.com/cloudfoundry/bosh-cli/ui/fakes"
+)
+
+// bosh take_out cf-6-offline-sources.yml manifest.yml -o use-compiled-release.yml
+var _ = Describe("TakeOutCmd", func() {
+	var (
+		ui      *fakeui.FakeUI
+		command TakeOutCmd
+		fs      *fakesys.FakeFileSystem
+	)
+
+	BeforeEach(func() {
+		ui = &fakeui.FakeUI{}
+
+		fs = fakesys.NewFakeFileSystem()
+
+		command = NewTakeOutCmd(ui, fakeout.FakeUtensils{})
+	})
+
+	Describe("Run", func() {
+		var (
+			opts TakeOutOpts
+		)
+
+		BeforeEach(func() {
+			file, err := fs.TempFile("take-out")
+			if err != nil {
+				panic(err)
+			}
+
+			opts = TakeOutOpts{
+				Args: TakeOutArgs{
+					Name:     file.Name(),
+					Manifest: FileBytesArg{Bytes: []byte("name: dep")},
+				},
+			}
+
+		})
+
+		act := func() error { return command.Run(opts) }
+
+		It("manifest", func() {
+			err := act()
+			Expect(err).ToNot(HaveOccurred())
+
+			//Expect(deployment.UpdateCallCount()).To(Equal(1))
+
+			//bytes, updateOpts := deployment.UpdateArgsForCall(0)
+			//Expect(bytes).To(Equal([]byte("name: dep\n")))
+			//Expect(updateOpts).To(Equal(boshdir.UpdateOpts{}))
+		})
+		//
+		//		It("deploys manifest allowing to recreate, recreate persistent disks, fix, and skip drain", func() {
+		//			opts.RecreatePersistentDisks = true
+		//			opts.Recreate = true
+		//			opts.Fix = true
+		//			opts.SkipDrain = boshdir.SkipDrains{boshdir.SkipDrain{All: true}}
+		//
+		//			err := act()
+		//			Expect(err).ToNot(HaveOccurred())
+		//
+		//			Expect(deployment.UpdateCallCount()).To(Equal(1))
+		//
+		//			bytes, updateOpts := deployment.UpdateArgsForCall(0)
+		//			Expect(bytes).To(Equal([]byte("name: dep\n")))
+		//			Expect(updateOpts).To(Equal(boshdir.UpdateOpts{
+		//				RecreatePersistentDisks: true,
+		//				Recreate:                true,
+		//				Fix:                     true,
+		//				SkipDrain:               boshdir.SkipDrains{boshdir.SkipDrain{All: true}},
+		//			}))
+		//		})
+		//
+		//		It("deploys manifest allowing to dry_run", func() {
+		//			opts.DryRun = true
+		//
+		//			err := act()
+		//			Expect(err).ToNot(HaveOccurred())
+		//
+		//			Expect(deployment.UpdateCallCount()).To(Equal(1))
+		//
+		//			bytes, updateOpts := deployment.UpdateArgsForCall(0)
+		//			Expect(bytes).To(Equal([]byte("name: dep\n")))
+		//			Expect(updateOpts).To(Equal(boshdir.UpdateOpts{
+		//				DryRun: true,
+		//			}))
+		//		})
+		//
+		//		It("deploys templated manifest", func() {
+		//			opts.Args.Manifest = FileBytesArg{
+		//				Bytes: []byte("name: dep\nname1: ((name1))\nname2: ((name2))\n"),
+		//			}
+		//
+		//			opts.VarKVs = []boshtpl.VarKV{
+		//				{Name: "name1", Value: "val1-from-kv"},
+		//			}
+		//
+		//			opts.VarsFiles = []boshtpl.VarsFileArg{
+		//				{Vars: boshtpl.StaticVariables(map[string]interface{}{"name1": "val1-from-file"})},
+		//				{Vars: boshtpl.StaticVariables(map[string]interface{}{"name2": "val2-from-file"})},
+		//			}
+		//
+		//			opts.OpsFiles = []OpsFileArg{
+		//				{
+		//					Ops: patch.Ops([]patch.Op{
+		//						patch.ReplaceOp{Path: patch.MustNewPointerFromString("/xyz?"), Value: "val"},
+		//					}),
+		//				},
+		//			}
+		//
+		//			err := act()
+		//			Expect(err).ToNot(HaveOccurred())
+		//
+		//			Expect(deployment.UpdateCallCount()).To(Equal(1))
+		//
+		//			bytes, _ := deployment.UpdateArgsForCall(0)
+		//			Expect(bytes).To(Equal([]byte("name: dep\nname1: val1-from-kv\nname2: val2-from-file\nxyz: val\n")))
+		//		})
+		//
+		//		It("does not deploy if name specified in the manifest does not match deployment's name", func() {
+		//			opts.Args.Manifest = FileBytesArg{
+		//				Bytes: []byte("name: other-name"),
+		//			}
+		//
+		//			err := act()
+		//			Expect(err).To(HaveOccurred())
+		//			Expect(err.Error()).To(Equal(
+		//				"Expected manifest to specify deployment name 'dep' but was 'other-name'"))
+		//
+		//			Expect(deployment.UpdateCallCount()).To(Equal(0))
+		//		})
+		//
+		//		It("uploads releases provided in the manifest after manifest has been interpolated", func() {
+		//			opts.Args.Manifest = FileBytesArg{
+		//				Bytes: []byte("name: dep\nbefore-upload-manifest: ((key))"),
+		//			}
+		//
+		//			opts.VarKVs = []boshtpl.VarKV{
+		//				{Name: "key", Value: "key-val"},
+		//			}
+		//
+		//			releaseUploader.UploadReleasesReturns([]byte("after-upload-manifest"), nil)
+		//
+		//			err := act()
+		//			Expect(err).ToNot(HaveOccurred())
+		//
+		//			bytes := releaseUploader.UploadReleasesArgsForCall(0)
+		//			Expect(bytes).To(Equal([]byte("before-upload-manifest: key-val\nname: dep\n")))
+		//
+		//			Expect(deployment.UpdateCallCount()).To(Equal(1))
+		//
+		//			bytes, _ = deployment.UpdateArgsForCall(0)
+		//			Expect(bytes).To(Equal([]byte("after-upload-manifest")))
+		//		})
+		//
+		//		It("returns error and does not deploy if uploading releases fails", func() {
+		//			opts.Args.Manifest = FileBytesArg{
+		//				Bytes: []byte(`
+		//name: dep
+		//releases:
+		//- name: capi
+		//  sha1: capi-sha1
+		//  url: https://capi-url
+		//  version: 1+capi
+		//`),
+		//			}
+		//
+		//			releaseUploader.UploadReleasesReturns(nil, errors.New("fake-err"))
+		//
+		//			err := act()
+		//			Expect(err).To(HaveOccurred())
+		//			Expect(err.Error()).To(ContainSubstring("fake-err"))
+		//
+		//			Expect(deployment.UpdateCallCount()).To(Equal(0))
+		//		})
+		//
+		//		It("uploads releases but does not deploy if confirmation is rejected", func() {
+		//			opts.Args.Manifest = FileBytesArg{
+		//				Bytes: []byte(`
+		//name: dep
+		//releases:
+		//- name: capi
+		//  sha1: capi-sha1
+		//  url: /capi-url
+		//  version: create
+		//`),
+		//			}
+		//
+		//			ui.AskedConfirmationErr = errors.New("stop")
+		//
+		//			err := act()
+		//			Expect(err).To(HaveOccurred())
+		//			Expect(err.Error()).To(ContainSubstring("stop"))
+		//
+		//			Expect(releaseUploader.UploadReleasesCallCount()).To(Equal(1))
+		//			Expect(deployment.UpdateCallCount()).To(Equal(0))
+		//		})
+		//
+		//		It("returns an error if diffing failed", func() {
+		//			deployment.DiffReturns(boshdir.DeploymentDiff{}, errors.New("Fetching diff result"))
+		//
+		//			err := act()
+		//			Expect(err).To(HaveOccurred())
+		//		})
+		//
+		//		It("gets the diff from the deployment", func() {
+		//			diff := [][]interface{}{
+		//				[]interface{}{"some line that stayed", nil},
+		//				[]interface{}{"some line that was added", "added"},
+		//				[]interface{}{"some line that was removed", "removed"},
+		//			}
+		//
+		//			expectedDiff := boshdir.NewDeploymentDiff(diff, nil)
+		//			deployment.DiffReturns(expectedDiff, nil)
+		//			err := act()
+		//			Expect(err).ToNot(HaveOccurred())
+		//			Expect(deployment.DiffCallCount()).To(Equal(1))
+		//			Expect(ui.Said).To(ContainElement("  some line that stayed\n"))
+		//			Expect(ui.Said).To(ContainElement("+ some line that was added\n"))
+		//			Expect(ui.Said).To(ContainElement("- some line that was removed\n"))
+		//		})
+		//
+		//		It("deploys manifest with diff context", func() {
+		//			context := map[string]interface{}{
+		//				"cloud_config_id":   2,
+		//				"runtime_config_id": 3,
+		//			}
+		//			expectedDiff := boshdir.NewDeploymentDiff(nil, context)
+		//
+		//			deployment.DiffReturns(expectedDiff, nil)
+		//			err := act()
+		//			Expect(err).ToNot(HaveOccurred())
+		//			Expect(deployment.DiffCallCount()).To(Equal(1))
+		//
+		//			_, updateOptions := deployment.UpdateArgsForCall(0)
+		//			Expect(updateOptions.Diff).To(Equal(expectedDiff))
+		//		})
+		//
+		//		It("returns error if deploying failed", func() {
+		//			deployment.UpdateReturns(errors.New("fake-err"))
+		//
+		//			err := act()
+		//			Expect(err).To(HaveOccurred())
+		//			Expect(err.Error()).To(ContainSubstring("fake-err"))
+		//		})
+	})
+})

--- a/takeout/interfaces.go
+++ b/takeout/interfaces.go
@@ -6,12 +6,28 @@ import (
 )
 
 type Utensils interface {
+	DeploymentReader
 	ReleaseDownloader
 	OpFileGenerator
+	StemcellDownloader
+}
+type Manifest struct {
+	Name string
+
+	Releases  []boshdir.ManifestRelease
+	Stemcells []boshdir.ManifestReleaseStemcell
+}
+
+type DeploymentReader interface {
+	ParseDeployment(bytes []byte) (Manifest, error)
 }
 
 type ReleaseDownloader interface {
 	RetrieveRelease(r boshdir.ManifestRelease, ui boshui.UI, localFileName string) (err error)
+}
+
+type StemcellDownloader interface {
+	RetrieveStemcell(s boshdir.ManifestReleaseStemcell, ui boshui.UI, stemCellType string) (err error)
 }
 
 type OpFileGenerator interface {

--- a/takeout/interfaces.go
+++ b/takeout/interfaces.go
@@ -1,0 +1,19 @@
+package takeout
+
+import (
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	boshui "github.com/cloudfoundry/bosh-cli/ui"
+)
+
+type Utensils interface {
+	ReleaseDownloader
+	OpFileGenerator
+}
+
+type ReleaseDownloader interface {
+	RetrieveRelease(r boshdir.ManifestRelease, ui boshui.UI, localFileName string) (err error)
+}
+
+type OpFileGenerator interface {
+	TakeOutRelease(r boshdir.ManifestRelease, ui boshui.UI, mirrorPrefix string) (entry OpEntry, err error)
+}

--- a/takeout/opentry.go
+++ b/takeout/opentry.go
@@ -1,0 +1,7 @@
+package takeout
+
+type OpEntry struct {
+	Type  string
+	Path  string
+	Value string
+}

--- a/takeout/takeoutfakes/takeoutfakes.go
+++ b/takeout/takeoutfakes/takeoutfakes.go
@@ -1,0 +1,26 @@
+package takeoutfakes
+
+import (
+	"errors"
+	"fmt"
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	"github.com/cloudfoundry/bosh-cli/takeout"
+	boshui "github.com/cloudfoundry/bosh-cli/ui"
+)
+
+type FakeUtensils struct {
+	takeout.RealUtensils
+	RetrieveMap map[boshdir.ManifestRelease]string
+}
+
+func (c FakeUtensils) Reset() {
+	c.RetrieveMap = make(map[boshdir.ManifestRelease]string)
+}
+
+func (c FakeUtensils) RetrieveRelease(r boshdir.ManifestRelease, ui boshui.UI, localFileName string) (err error) {
+	if val, ok := c.RetrieveMap[r]; ok {
+		return errors.New(fmt.Sprintf("Release already in download map: %s", val))
+	}
+	c.RetrieveMap[r] = localFileName
+	return
+}

--- a/takeout/takeoutrelease.go
+++ b/takeout/takeoutrelease.go
@@ -1,0 +1,74 @@
+package takeout
+
+import (
+	"crypto/sha1"
+	"fmt"
+	boshdir "github.com/cloudfoundry/bosh-cli/director"
+	boshui "github.com/cloudfoundry/bosh-cli/ui"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+)
+
+var BadChar = regexp.MustCompile("[?=\"]")
+
+type RealUtensils struct {
+}
+
+func (c RealUtensils) RetrieveRelease(r boshdir.ManifestRelease, ui boshui.UI, localFileName string) (err error) {
+	ui.PrintLinef("Downloading release: %s / %s -> %s", r.Name, r.Version, localFileName)
+
+	resp, err := http.Get(r.URL)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(localFileName)
+	if err != nil {
+		return
+	}
+	defer out.Close()
+
+	// Write the body to file
+	hash := sha1.New()
+	_, err = io.Copy(out, io.TeeReader(resp.Body, hash))
+	actualSha1 := fmt.Sprintf("%x", hash.Sum(nil))
+	if err != nil {
+		return
+	}
+	if len(r.SHA1) == 40 {
+		if actualSha1 != r.SHA1 {
+			return bosherr.Errorf("sha1 mismatch %s (a:%s, e:%s)", localFileName, actualSha1, r.SHA1)
+		}
+	}
+	return
+}
+
+func (c RealUtensils) TakeOutRelease(r boshdir.ManifestRelease, ui boshui.UI, mirrorPrefix string) (entry OpEntry, err error) {
+
+	// generate a local file name that's safe
+	localFileName := BadChar.ReplaceAllString(fmt.Sprintf("%s_v%s.tgz", r.Name, r.Version), "_")
+
+	if _, err := os.Stat(localFileName); os.IsNotExist(err) {
+		err = c.RetrieveRelease(r, ui, localFileName)
+		if err != nil {
+			return OpEntry{}, err
+		}
+	} else {
+		ui.PrintLinef("Release present: %s / %s -> %s", r.Name, r.Version, localFileName)
+	}
+	if len(r.Name) > 0 {
+		path := fmt.Sprintf("/releases/name=%s/url", r.Name)
+		localFile := fmt.Sprintf("%s%s", mirrorPrefix, localFileName)
+		entry = OpEntry{Type: "replace", Path: path, Value: localFile}
+	}
+	return entry, err
+}
+
+func TakeOutUtensils() (utensils Utensils) {
+	return RealUtensils{}
+}

--- a/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go
+++ b/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go
@@ -168,7 +168,7 @@ func generateCertTemplate(cParams certParams) (x509.Certificate, error) {
 	}
 
 	now := time.Now()
-	notAfter := now.Add(365 * 24 * time.Hour)
+	notAfter := now.Add(3650 * 24 * time.Hour)
 	var organizations []string
 	if cParams.Organization == "" {
 		organizations = []string{"Cloud Foundry"}

--- a/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go
+++ b/vendor/github.com/cloudfoundry/config-server/types/certificate_generator.go
@@ -168,7 +168,7 @@ func generateCertTemplate(cParams certParams) (x509.Certificate, error) {
 	}
 
 	now := time.Now()
-	notAfter := now.Add(3650 * 24 * time.Hour)
+	notAfter := now.Add(365 * 24 * time.Hour)
 	var organizations []string
 	if cParams.Organization == "" {
 		organizations = []string{"Cloud Foundry"}


### PR DESCRIPTION
This is a feature I've been using for a while. I was hoping I would get the testing sorted out, but I haven't quite gotten there.

Basically, you can give it a complex release like cf-deployment.yml with several operations and it will:

1. Download and verify each release
2. Download the stemcell
3. Generate an opsfile to substitute the release location

The feature works, but it's short on testing. It's missing support for the newer digests and I am not sure about the stemcell retrieval logic for anything other than vsphere.
[take-out-example-output.txt](https://github.com/cloudfoundry/bosh-cli/files/3903466/take-out-example-output.txt)
[takeout.yml.txt](https://github.com/cloudfoundry/bosh-cli/files/3903469/takeout.yml.txt)


