### PR TITLE
support array index when reference a bosh interpolated value

### DIFF
--- a/director/template/template.go
+++ b/director/template/template.go
@@ -172,23 +172,30 @@ func (l varsLookup) Get(name string) (interface{}, bool, error) {
 	}
 
 	if len(splitName) > 1 {
-		tokens := []patch.Token{patch.RootToken{}}
-
-		for _, token := range splitName[1:] {
-			tokens = append(tokens, patch.KeyToken{Key: token})
-		}
-
-		findOp := patch.FindOp{
-			Path: patch.NewPointer(tokens),
-		}
-
-		val, err = findOp.Apply(val)
+		pointer, err := patch.NewPointerFromString("/" + strings.Join(splitName[1:], "/"))
 		if err != nil {
 			return nil, false, err
+		}
+
+		val, found, err = processPatchPointer(pointer, val)
+		if err != nil {
+			return val, found, err
 		}
 	}
 
 	return val, true, err
+}
+
+func processPatchPointer(pointer patch.Pointer, val interface{}) (interface{}, bool, error) {
+	findOp := patch.FindOp{
+		Path: pointer,
+	}
+
+	newVal, err := findOp.Apply(val)
+	if err != nil {
+		return val, false, err
+	}
+	return newVal, false, nil
 }
 
 type varsTracker struct {

--- a/director/template/template_test.go
+++ b/director/template/template_test.go
@@ -21,6 +21,33 @@ var _ = Describe("Template", func() {
 		Expect(result).To(Equal([]byte("foo\n")))
 	})
 
+	It("can interpolate a specific indexed value of an variable that is an array", func() {
+		template := NewTemplate([]byte("((key)): ((value.1))"))
+		vars := StaticVariables{
+			"key":   "foo",
+			"value": []interface{}{"bar", "baz"},
+		}
+
+		result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]byte("foo: baz\n")))
+	})
+
+	It("can interpolate a specific indexed value of an variable that is an hash", func() {
+		template := NewTemplate([]byte("((key)): ((value.1))"))
+		vars := StaticVariables{
+			"key":   "foo",
+			"value": map[interface{}]interface{}{
+				"0": "bar",
+				"1": "baz",
+			},
+		}
+
+		result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]byte("foo: baz\n")))
+	})
+
 	It("can interpolate values with leading slash into a struct with byte slice", func() {
 		template := NewTemplate([]byte("((/key/foo))"))
 		vars := StaticVariables{"/key/foo": "foo"}


### PR DESCRIPTION
This is a PR related to this issue:  https://github.com/cloudfoundry/bosh-cli/issues/549

Talked to @xtreme-conor-nosal about this feature.