### PR TITLE
Prefix exported release file with the provided jobs

### DIFF
--- a/cmd/export_release.go
+++ b/cmd/export_release.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	. "github.com/cloudfoundry/bosh-cli/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/director"
@@ -34,6 +35,10 @@ func (c ExportReleaseCmd) Run(opts ExportReleaseOpts) error {
 	}
 
 	prefix := fmt.Sprintf("%s-%s-%s-%s", rel.Name(), rel.Version(), os.OS(), os.Version())
+	if len(jobs) != 0 {
+		sort.Strings(jobs)
+		prefix = fmt.Sprintf("%s-%s", strings.Join(jobs, "-"), prefix)
+	}
 
 	err = c.downloader.Download(
 		result.BlobstoreID,

--- a/cmd/export_release_test.go
+++ b/cmd/export_release_test.go
@@ -94,7 +94,7 @@ var _ = Describe("ExportReleaseCmd", func() {
 			blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
 			Expect(blobID).To(Equal("blob-id"))
 			Expect(sha1).To(Equal("sha1"))
-			Expect(prefix).To(Equal("rel-rel-ver-os-os-ver"))
+			Expect(prefix).To(Equal("fake-job-rel-rel-ver-os-os-ver"))
 			Expect(dstDirPath).To(Equal("/fake-dir"))
 		})
 


### PR DESCRIPTION
This PR adds support for prefixing release export files with the provided job names.
It implements the feature as proposed in: https://www.pivotaltracker.com/n/projects/956238/stories/168852218