### PR TITLE
Add --fix-releases flag to the deploy command

### DIFF
--- a/cmd/cmdfakes/fake_release_uploader.go
+++ b/cmd/cmdfakes/fake_release_uploader.go
@@ -21,6 +21,19 @@ type FakeReleaseUploader struct {
 		result1 []byte
 		result2 error
 	}
+	UploadReleasesWithFixStub        func([]byte) ([]byte, error)
+	uploadReleasesWithFixMutex       sync.RWMutex
+	uploadReleasesWithFixArgsForCall []struct {
+		arg1 []byte
+	}
+	uploadReleasesWithFixReturns struct {
+		result1 []byte
+		result2 error
+	}
+	uploadReleasesWithFixReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -44,7 +57,8 @@ func (fake *FakeReleaseUploader) UploadReleases(arg1 []byte) ([]byte, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.uploadReleasesReturns.result1, fake.uploadReleasesReturns.result2
+	fakeReturns := fake.uploadReleasesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeReleaseUploader) UploadReleasesCallCount() int {
@@ -53,13 +67,22 @@ func (fake *FakeReleaseUploader) UploadReleasesCallCount() int {
 	return len(fake.uploadReleasesArgsForCall)
 }
 
+func (fake *FakeReleaseUploader) UploadReleasesCalls(stub func([]byte) ([]byte, error)) {
+	fake.uploadReleasesMutex.Lock()
+	defer fake.uploadReleasesMutex.Unlock()
+	fake.UploadReleasesStub = stub
+}
+
 func (fake *FakeReleaseUploader) UploadReleasesArgsForCall(i int) []byte {
 	fake.uploadReleasesMutex.RLock()
 	defer fake.uploadReleasesMutex.RUnlock()
-	return fake.uploadReleasesArgsForCall[i].arg1
+	argsForCall := fake.uploadReleasesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeReleaseUploader) UploadReleasesReturns(result1 []byte, result2 error) {
+	fake.uploadReleasesMutex.Lock()
+	defer fake.uploadReleasesMutex.Unlock()
 	fake.UploadReleasesStub = nil
 	fake.uploadReleasesReturns = struct {
 		result1 []byte
@@ -68,6 +91,8 @@ func (fake *FakeReleaseUploader) UploadReleasesReturns(result1 []byte, result2 e
 }
 
 func (fake *FakeReleaseUploader) UploadReleasesReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.uploadReleasesMutex.Lock()
+	defer fake.uploadReleasesMutex.Unlock()
 	fake.UploadReleasesStub = nil
 	if fake.uploadReleasesReturnsOnCall == nil {
 		fake.uploadReleasesReturnsOnCall = make(map[int]struct {
@@ -81,12 +106,86 @@ func (fake *FakeReleaseUploader) UploadReleasesReturnsOnCall(i int, result1 []by
 	}{result1, result2}
 }
 
+func (fake *FakeReleaseUploader) UploadReleasesWithFix(arg1 []byte) ([]byte, error) {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.uploadReleasesWithFixMutex.Lock()
+	ret, specificReturn := fake.uploadReleasesWithFixReturnsOnCall[len(fake.uploadReleasesWithFixArgsForCall)]
+	fake.uploadReleasesWithFixArgsForCall = append(fake.uploadReleasesWithFixArgsForCall, struct {
+		arg1 []byte
+	}{arg1Copy})
+	fake.recordInvocation("UploadReleasesWithFix", []interface{}{arg1Copy})
+	fake.uploadReleasesWithFixMutex.Unlock()
+	if fake.UploadReleasesWithFixStub != nil {
+		return fake.UploadReleasesWithFixStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.uploadReleasesWithFixReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeReleaseUploader) UploadReleasesWithFixCallCount() int {
+	fake.uploadReleasesWithFixMutex.RLock()
+	defer fake.uploadReleasesWithFixMutex.RUnlock()
+	return len(fake.uploadReleasesWithFixArgsForCall)
+}
+
+func (fake *FakeReleaseUploader) UploadReleasesWithFixCalls(stub func([]byte) ([]byte, error)) {
+	fake.uploadReleasesWithFixMutex.Lock()
+	defer fake.uploadReleasesWithFixMutex.Unlock()
+	fake.UploadReleasesWithFixStub = stub
+}
+
+func (fake *FakeReleaseUploader) UploadReleasesWithFixArgsForCall(i int) []byte {
+	fake.uploadReleasesWithFixMutex.RLock()
+	defer fake.uploadReleasesWithFixMutex.RUnlock()
+	argsForCall := fake.uploadReleasesWithFixArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeReleaseUploader) UploadReleasesWithFixReturns(result1 []byte, result2 error) {
+	fake.uploadReleasesWithFixMutex.Lock()
+	defer fake.uploadReleasesWithFixMutex.Unlock()
+	fake.UploadReleasesWithFixStub = nil
+	fake.uploadReleasesWithFixReturns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeReleaseUploader) UploadReleasesWithFixReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.uploadReleasesWithFixMutex.Lock()
+	defer fake.uploadReleasesWithFixMutex.Unlock()
+	fake.UploadReleasesWithFixStub = nil
+	if fake.uploadReleasesWithFixReturnsOnCall == nil {
+		fake.uploadReleasesWithFixReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.uploadReleasesWithFixReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeReleaseUploader) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.uploadReleasesMutex.RLock()
 	defer fake.uploadReleasesMutex.RUnlock()
-	return fake.invocations
+	fake.uploadReleasesWithFixMutex.RLock()
+	defer fake.uploadReleasesWithFixMutex.RUnlock()
+	copiedInvocations := map[string][][]interface{}{}
+	for key, value := range fake.invocations {
+		copiedInvocations[key] = value
+	}
+	return copiedInvocations
 }
 
 func (fake *FakeReleaseUploader) recordInvocation(key string, args []interface{}) {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,6 +17,7 @@ type DeployCmd struct {
 
 type ReleaseUploader interface {
 	UploadReleases([]byte) ([]byte, error)
+	UploadReleasesWithFix([]byte) ([]byte, error)
 }
 
 func NewDeployCmd(
@@ -40,7 +41,11 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 		return err
 	}
 
-	bytes, err = c.releaseUploader.UploadReleases(bytes)
+	if opts.FixReleases {
+		bytes, err = c.releaseUploader.UploadReleasesWithFix(bytes)
+	} else {
+		bytes, err = c.releaseUploader.UploadReleases(bytes)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -469,7 +469,7 @@ type DeployOpts struct {
 	Recreate                bool                `long:"recreate"                                description:"Recreate all VMs in deployment"`
 	RecreatePersistentDisks bool                `long:"recreate-persistent-disks"               description:"Recreate all persistent disks in deployment"`
 	Fix                     bool                `long:"fix"                                     description:"Recreate an instance with an unresponsive agent instead of erroring"`
-	FixReleases             bool                `long:"fix-releases"                            description:"Reuploads the releases from the deployment manifest releases section and replaces corrupt and missing jobs and packages"`
+	FixReleases             bool                `long:"fix-releases"                            description:"Reupload releases in manifest and replace corrupt or missing jobs/packages"`
 	SkipDrain               []boshdir.SkipDrain `long:"skip-drain" value-name:"[INSTANCE-GROUP[/INSTANCE-ID]]"  description:"Skip running drain and pre-stop scripts for specific instance groups" optional:"true" optional-value:"*"`
 
 	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -469,6 +469,7 @@ type DeployOpts struct {
 	Recreate                bool                `long:"recreate"                                description:"Recreate all VMs in deployment"`
 	RecreatePersistentDisks bool                `long:"recreate-persistent-disks"               description:"Recreate all persistent disks in deployment"`
 	Fix                     bool                `long:"fix"                                     description:"Recreate an instance with an unresponsive agent instead of erroring"`
+	FixReleases             bool                `long:"fix-releases"                            description:"Reuploads the releases from the deployment manifest releases section and replaces corrupt and missing jobs and packages"`
 	SkipDrain               []boshdir.SkipDrain `long:"skip-drain" value-name:"[INSTANCE-GROUP[/INSTANCE-ID]]"  description:"Skip running drain and pre-stop scripts for specific instance groups" optional:"true" optional-value:"*"`
 
 	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -1523,6 +1523,14 @@ var _ = Describe("Opts", func() {
 				))
 			})
 		})
+
+		Describe("FixReleases", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("FixReleases", opts)).To(Equal(
+					`long:"fix-releases" description:"Reuploads the releases from the deployment manifest releases section and replaces corrupt and missing jobs and packages"`,
+				))
+			})
+		})
 	})
 
 	Describe("DeployArgs", func() {

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -1527,7 +1527,7 @@ var _ = Describe("Opts", func() {
 		Describe("FixReleases", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("FixReleases", opts)).To(Equal(
-					`long:"fix-releases" description:"Reuploads the releases from the deployment manifest releases section and replaces corrupt and missing jobs and packages"`,
+					`long:"fix-releases" description:"Reupload releases in manifest and replace corrupt or missing jobs/packages"`,
 				))
 			})
 		})

--- a/cmd/release_manager.go
+++ b/cmd/release_manager.go
@@ -16,6 +16,7 @@ type ReleaseManager struct {
 	createReleaseCmd ReleaseCreatingCmd
 	uploadReleaseCmd ReleaseUploadingCmd
 	parallelThreads  int
+	uploadWithFix    bool
 }
 
 type ReleaseUploadingCmd interface {
@@ -31,7 +32,12 @@ func NewReleaseManager(
 	uploadReleaseCmd ReleaseUploadingCmd,
 	parallelThreads int,
 ) ReleaseManager {
-	return ReleaseManager{createReleaseCmd, uploadReleaseCmd, parallelThreads}
+	return ReleaseManager{createReleaseCmd, uploadReleaseCmd, parallelThreads, false}
+}
+
+func (m ReleaseManager) UploadReleasesWithFix(bytes []byte) ([]byte, error) {
+	m.uploadWithFix = true
+	return m.UploadReleases(bytes)
 }
 
 func (m ReleaseManager) UploadReleases(bytes []byte) ([]byte, error) {
@@ -106,6 +112,7 @@ func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (pat
 
 		Args: UploadReleaseArgs{URL: URLArg(rel.URL)},
 		SHA1: rel.SHA1,
+		Fix:  m.uploadWithFix,
 	}
 
 	if len(rel.Stemcell.OS) > 0 {


### PR DESCRIPTION
Using the new flag `--fix-releases` during deploy will trigger a reupload of all releases form the `releases` section in manifest, which provide an `url`. The reupload will replace the existing releases and is equivalent to the `bosh upload-release --fix` command. This is useful when:
- the upload of a release produced corrupted artifacts in the blobstore
- director blobstore got corrupted
- you need to migrate to a different blobstore