### PR TITLE
Add --fix-releases flag to the update-runtime-config command

### DIFF
--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -438,8 +438,9 @@ type UpdateRuntimeConfigOpts struct {
 	VarFlags
 	OpsFlags
 
-	NoRedact bool   `long:"no-redact" description:"Show non-redacted manifest diff"`
-	Name     string `long:"name" description:"Runtime-Config name (default: '')" default:""`
+	NoRedact    bool   `long:"no-redact" description:"Show non-redacted manifest diff"`
+	Name        string `long:"name" description:"Runtime-Config name (default: '')" default:""`
+	FixReleases bool   `long:"fix-releases" description:"Reupload releases in config and replace corrupt or missing jobs/packages"`
 
 	cmd
 }

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -1437,6 +1437,12 @@ var _ = Describe("Opts", func() {
 				Expect(getStructTagForName("NoRedact", opts)).To(Equal(`long:"no-redact" description:"Show non-redacted manifest diff"`))
 			})
 		})
+
+		Describe("FixReleases", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("FixReleases", opts)).To(Equal(`long:"fix-releases" description:"Reupload releases in config and replace corrupt or missing jobs/packages"`))
+			})
+		})
 	})
 
 	Describe("UpdateRuntimeConfigArgs", func() {

--- a/cmd/update_runtime_config.go
+++ b/cmd/update_runtime_config.go
@@ -35,7 +35,12 @@ func (c UpdateRuntimeConfigCmd) Run(opts UpdateRuntimeConfigOpts) error {
 	diff := NewDiff(configDiff.Diff)
 	diff.Print(c.ui)
 
-	bytes, err = c.releaseUploader.UploadReleases(bytes)
+	if opts.FixReleases {
+		bytes, err = c.releaseUploader.UploadReleasesWithFix(bytes)
+	} else {
+		bytes, err = c.releaseUploader.UploadReleases(bytes)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Following the pull-request for the deploy command #559 this is adding the new flag --fix-releases to the `update-runtime-config` command. During runtime config upload this flag will trigger a reupload of all releases fr.m the releases section in the runtime-config, which provide an url. The reupload will replace the existing releases and is equivalent to the bosh upload-release --fix command. 