### PR TITLE
Update Curl test for bosh-util bump with optional keepalive

### DIFF
--- a/cmd/curl_test.go
+++ b/cmd/curl_test.go
@@ -29,7 +29,7 @@ var _ = Describe("CurlCmd", func() {
 		logger := boshlog.NewLogger(boshlog.LevelNone)
 		command = NewCurlCmd(ui, boshdir.NewClientRequest(
 			server.URL(),
-			boshhttp.NewHTTPClient(boshhttp.CreateDefaultClient(nil), logger),
+			boshhttp.NewHTTPClient(boshhttp.CreateKeepAliveDefaultClient(nil), logger),
 			boshdir.NewNoopFileReporter(),
 			logger,
 		))


### PR DESCRIPTION
Pipeline fails in the unit tests when bumping bosh-util to the updated version

```
  Expected

      <[]string | len:2, cap:2>: [

          "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 9\r\nContent-Type: text/plain; charset=utf-8\r\nDate: date\r\nHeader1: header1-val\r\nHeader2: header2-val1\r\nHeader2: header2-val2\r\n\r\n",

          "resp-body",

      ]

  to equal

      <[]string | len:2, cap:2>: [

          "HTTP/1.1 200 OK\r\nContent-Length: 9\r\nContent-Type: text/plain; charset=utf-8\r\nDate: date\r\nHeader1: header1-val\r\nHeader2: header2-val1\r\nHeader2: header2-val2\r\n\r\n",

          "resp-body",

      ]
```

Update the BeforeEach to use the renamed KeepAlive version to match previous tests.
 
[#173690103](https://www.pivotaltracker.com/story/show/173690103)