### PR TITLE
Fix disk NeedsMigration to correclty detect differences in Cloud Properties

### DIFF
--- a/deployment/disk/disk_test.go
+++ b/deployment/disk/disk_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Disk", func() {
 	BeforeEach(func() {
 		diskCloudProperties = biproperty.Map{
 			"fake-cloud-property-key": "fake-cloud-property-value",
+			"list-property":           []interface{}{"list-item"},
 		}
 		fakeCloud = fakebicloud.NewFakeCloud()
 
@@ -51,7 +52,8 @@ var _ = Describe("Disk", func() {
 	Describe("NeedsMigration", func() {
 		Context("when size is different", func() {
 			It("returns true", func() {
-				needsMigration := disk.NeedsMigration(2048, diskCloudProperties)
+				needsMigration, err := disk.NeedsMigration(2048, diskCloudProperties)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(needsMigration).To(BeTrue())
 			})
 		})
@@ -62,21 +64,28 @@ var _ = Describe("Disk", func() {
 					"fake-cloud-property-key": "new-fake-cloud-property-value",
 				}
 
-				needsMigration := disk.NeedsMigration(1024, newDiskCloudProperties)
+				needsMigration, err := disk.NeedsMigration(1024, newDiskCloudProperties)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(needsMigration).To(BeTrue())
 			})
 		})
 
 		Context("when cloud properties are nil", func() {
 			It("returns true", func() {
-				needsMigration := disk.NeedsMigration(1024, nil)
+				needsMigration, err := disk.NeedsMigration(1024, nil)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(needsMigration).To(BeTrue())
 			})
 		})
 
 		Context("when size and cloud properties are the same", func() {
 			It("returns false", func() {
-				needsMigration := disk.NeedsMigration(1024, diskCloudProperties)
+				newCloudProperties := biproperty.Map{
+					"fake-cloud-property-key": "fake-cloud-property-value",
+					"list-property":           biproperty.List{"list-item"},
+				}
+				needsMigration, err := disk.NeedsMigration(1024, newCloudProperties)
+				Expect(err).ToNot(HaveOccurred())
 				Expect(needsMigration).To(BeFalse())
 			})
 		})

--- a/deployment/disk/fakes/fake_disk.go
+++ b/deployment/disk/fakes/fake_disk.go
@@ -34,13 +34,13 @@ func (d *FakeDisk) CID() string {
 	return d.cid
 }
 
-func (d *FakeDisk) NeedsMigration(size int, cloudProperties biproperty.Map) bool {
+func (d *FakeDisk) NeedsMigration(size int, cloudProperties biproperty.Map) (bool, error) {
 	d.NeedsMigrationInputs = append(d.NeedsMigrationInputs, NeedsMigrationInput{
 		Size:            size,
 		CloudProperties: cloudProperties,
 	})
 
-	return d.needsMigrationOutput.needsMigration
+	return d.needsMigrationOutput.needsMigration, nil
 }
 
 func (d *FakeDisk) Delete() error {

--- a/deployment/vm/disk_deployer.go
+++ b/deployment/vm/disk_deployer.go
@@ -83,7 +83,11 @@ func (d *diskDeployer) deployExistingDisk(disk bidisk.Disk, diskPool bideplmanif
 		return disks, err
 	}
 
-	if d.recreatePersistentDisk || disk.NeedsMigration(diskPool.DiskSize, diskPool.CloudProperties) {
+	diskNeedsMigration, err := disk.NeedsMigration(diskPool.DiskSize, diskPool.CloudProperties)
+	if err != nil {
+		return disks, err
+	}
+	if d.recreatePersistentDisk || diskNeedsMigration {
 		disk, err = d.migrateDisk(disk, diskPool, vm, stage)
 		if err != nil {
 			return disks, err


### PR DESCRIPTION
The parsing of cloud properties from bosh state json and the deployment manifest
yaml end up giving different object types for slices stored in cloud properties.

It's also likely that numbers might be parsed differently as floats vs ints
