### PR TITLE
fix: create-env on ubuntu running in windows wsl2 with virtualbox cpi

### DIFF
--- a/cloud/cpi_cmd_runner_test.go
+++ b/cloud/cpi_cmd_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"os"
 
 	. "github.com/cloudfoundry/bosh-cli/cloud"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
@@ -87,6 +88,41 @@ var _ = Describe("CpiCmdRunner", func() {
 				apiVersion = 2
 			})
 
+			AfterEach(func() {
+				os.Unsetenv("BOSH_CPI_USE_ISOLATED_ENV")
+			})
+			It("creates correct command with UseIsolatedEnv false if BOSH_CPI_USE_ISOLATED_ENV is set", func() {
+				os.Setenv("BOSH_CPI_USE_ISOLATED_ENV", "false")
+				cmdOutput := CmdOutput{}
+				outputBytes, err := json.Marshal(cmdOutput)
+				Expect(err).NotTo(HaveOccurred())
+
+				result := fakesys.FakeCmdResult{
+					Stdout:     string(outputBytes),
+					ExitStatus: 0,
+				}
+				cmdRunner.AddCmdResult("/jobs/cpi/bin/cpi", result)
+				_, err = cpiCmdRunner.Run(context, "fake-method", apiVersion, "fake-argument-1", "fake-argument-2")
+				Expect(err).NotTo(HaveOccurred())
+				actualCmd := cmdRunner.RunComplexCommands[0]
+				Expect(actualCmd.UseIsolatedEnv).To(BeFalse())
+
+			})
+			It("throws helpful error if the value of BOSH_CPI_USE_ISOLATED_ENV cannot be parsed into a bool", func() {
+				os.Setenv("BOSH_CPI_USE_ISOLATED_ENV", "falasdse")
+				cmdOutput := CmdOutput{}
+				outputBytes, err := json.Marshal(cmdOutput)
+				Expect(err).NotTo(HaveOccurred())
+
+				result := fakesys.FakeCmdResult{
+					Stdout:     string(outputBytes),
+					ExitStatus: 0,
+				}
+				cmdRunner.AddCmdResult("/jobs/cpi/bin/cpi", result)
+				_, err = cpiCmdRunner.Run(context, "fake-method", apiVersion, "fake-argument-1", "fake-argument-2")
+				Expect(err).To(HaveOccurred())
+				Expect(MatchRegexp("BOSH_CPI_USE_ISOLATED_ENV cannot be parsed", err))
+			})
 			It("creates correct command with stemcell api_version in context", func() {
 				cmdOutput := CmdOutput{}
 				outputBytes, err := json.Marshal(cmdOutput)


### PR DESCRIPTION
If using wsl2 virtualbox cant be installed on the linux vm itself

It needs to run on the windows host. The create env would fail because:
The Command Structs UseIsolatedEnv field was hardcoded to true and prevented access to binaries outside the hardcoded PATH. That means that the Windows Native VBoxManage binary could not be accessed by the CPI. This introduces an ENV Var to be able to override the value for UseIsolatedEnv on CPI calls.

For the feature to fully work it requires an additional PR to the vbox cpi. The CPI shells out to the VBoxManage Binary to create a network and uses a "name" parameter. On Windows that value would contain " "(spaces), thus the call failed with too many parameters error on the VBoxManage Binary.

These PRs fix these issues and allow running the virtualbox cpi on wsl2