### PR TITLE
Remove compiled_package_cache from bosh env output

### DIFF
--- a/director/info.go
+++ b/director/info.go
@@ -17,10 +17,6 @@ import (
     "snapshots": {
       "status": false
     },
-    "compiled_package_cache": {
-      "extras": { "provider": null },
-      "status": false
-    },
     "dns": {
       "extras": { "domain_name": "bosh" },
       "status": false

--- a/director/info_test.go
+++ b/director/info_test.go
@@ -93,10 +93,6 @@ var _ = Describe("Director", func() {
     "snapshots": {
       "status": false
     },
-    "compiled_package_cache": {
-      "extras": { "provider": null },
-      "status": true
-    },
     "dns": {
       "extras": { "domain_name": "bosh" },
       "status": false
@@ -126,9 +122,8 @@ var _ = Describe("Director", func() {
 				},
 
 				Features: map[string]bool{
-					"snapshots":              false,
-					"compiled_package_cache": true,
-					"dns":                    false,
+					"snapshots": false,
+					"dns":       false,
 				},
 
 				CPI: "cpi",


### PR DESCRIPTION
compiled_package_cache is going to get removed once
https://github.com/cloudfoundry/bosh/pull/233
is merged. This PR Updates the bosh env output to remove mentions of compiled_package_cache.