### PR TITLE
Permit --var values to contain newlines.

### DIFF
--- a/director/template/var_kv.go
+++ b/director/template/var_kv.go
@@ -33,7 +33,11 @@ func (a *VarKV) UnmarshalFlag(data string) error {
 		return bosherr.WrapErrorf(err, "Deserializing variables '%s'", data)
 	}
 
-	*a = VarKV{Name: pieces[0], Value: vars}
+	if _, ok := vars.(string); ok {
+		*a = VarKV{Name: pieces[0], Value: pieces[1]}
+	} else {
+		*a = VarKV{Name: pieces[0], Value: vars}
+	}
 
 	return nil
 }

--- a/director/template/var_kv.go
+++ b/director/template/var_kv.go
@@ -33,6 +33,8 @@ func (a *VarKV) UnmarshalFlag(data string) error {
 		return bosherr.WrapErrorf(err, "Deserializing variables '%s'", data)
 	}
 
+	//yaml.Unmarshal returns a string if the input is not valid yaml.
+	//in that case, we pass through the string itself as the Unmarshal process strips newlines.
 	if _, ok := vars.(string); ok {
 		*a = VarKV{Name: pieces[0], Value: pieces[1]}
 	} else {

--- a/director/template/var_kv_test.go
+++ b/director/template/var_kv_test.go
@@ -57,7 +57,7 @@ var _ = Describe("VarKV", func() {
 			})
 		})
 
-		Context("When key/value has newlines", func() {
+		Context("When value has newlines, and the string is not valid yaml", func() {
 			It("works", func() {
 				err := (&arg).UnmarshalFlag("name=one\ntwo\nthree")
 				Expect(err).ToNot(HaveOccurred())

--- a/director/template/var_kv_test.go
+++ b/director/template/var_kv_test.go
@@ -56,5 +56,13 @@ var _ = Describe("VarKV", func() {
 				Expect(val3).To(Equal(map[interface{}]interface{}{"key31": "str"}))
 			})
 		})
+
+		Context("When key/value has newlines", func() {
+			It("works", func() {
+				err := (&arg).UnmarshalFlag("name=one\ntwo\nthree")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(arg).To(Equal(VarKV{Name: "name", Value: "one\ntwo\nthree"}))
+			})
+		})
 	})
 })


### PR DESCRIPTION
- yaml.Unmarshall mangles newlines in non-yaml partials. This commit
  checks the return value type and, if string (what appears to be
  returned by yaml.Unmarshal for invalid YAML input), simply passes
  through the original string value.
- Although this is a behavior change, it is not expected that any
  user would be depending on this behavior.

[#180138088]

Signed-off-by: Rajan Agaskar <ragaskar@vmware.com>