### PR TITLE
Adding tags to create_vm

### DIFF
--- a/deployment/vm/manager.go
+++ b/deployment/vm/manager.go
@@ -105,6 +105,15 @@ func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest b
 		return nil, bosherr.WrapError(err, "Generating agent ID")
 	}
 
+	if len(deploymentManifest.Tags) > 0 {
+		if _, ok := resourcePool.Env["bosh"]; ok {
+			resourcePool.Env["bosh"].(biproperty.Map)["tags"] = deploymentManifest.Tags
+		} else {
+			resourcePool.Env["bosh"] = biproperty.Map{
+				"tags": deploymentManifest.Tags,
+			}
+		}
+	}
 	cid, err := m.createAndRecordVM(agentID, stemcell, resourcePool, networkInterfaces)
 	if err != nil {
 		return nil, err

--- a/deployment/vm/manager_test.go
+++ b/deployment/vm/manager_test.go
@@ -162,7 +162,6 @@ var _ = Describe("Manager", func() {
 		It("sets the vm metadata", func() {
 			_, err := manager.Create(stemcell, deploymentManifest)
 			Expect(err).ToNot(HaveOccurred())
-
 			Expect(fakeCloud.SetVMMetadataCid).To(Equal("fake-vm-cid"))
 			Expect(fakeCloud.SetVMMetadataMetadata).To(Equal(cloud.VMMetadata{
 				"deployment":     "fake-deployment",
@@ -182,8 +181,28 @@ var _ = Describe("Manager", func() {
 					"key1":   "value1",
 				}
 
+				expectedEnv = biproperty.Map{
+					"fake-env-key": "fake-env-value",
+					"bosh": biproperty.Map{
+						"tags": map[string]string{
+							"empty1": "",
+							"key1":   "value1",
+						},
+					},
+				}
+
 				_, err := manager.Create(stemcell, deploymentManifest)
 				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeCloud.CreateVMInput).To(Equal(
+					fakebicloud.CreateVMInput{
+						AgentID:            "fake-uuid-0",
+						StemcellCID:        "fake-stemcell-cid",
+						CloudProperties:    expectedCloudProperties,
+						NetworksInterfaces: expectedNetworkInterfaces,
+						Env:                expectedEnv,
+					},
+				))
 
 				Expect(fakeCloud.SetVMMetadataMetadata).To(Equal(cloud.VMMetadata{
 					"deployment":     "fake-deployment",


### PR DESCRIPTION
BOSH director does [this](<https://github.com/cloudfoundry/bosh/blob/f363d90c8a7c555a21c12dda0a6817583b619330/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb#L113>) but create_env doesn't do this on creation of vm, still keeping behavior of tags being set in update_metadata

Signed-off-by: Konstantin Kiess <kkiess@vmware.com>