### PR TITLE
Unify upload release handling to always check if skippable

### DIFF
--- a/cmd/upload_release.go
+++ b/cmd/upload_release.go
@@ -49,7 +49,7 @@ func NewUploadReleaseCmd(
 func (c UploadReleaseCmd) Run(opts UploadReleaseOpts) error {
 	switch {
 	case opts.Release != nil:
-		return c.uploadRelease(opts.Release, opts)
+		return c.uploadIfNecessary(opts, c.uploadFile)
 	case opts.Args.URL.IsRemote():
 		return c.uploadIfNecessary(opts, c.uploadRemote)
 	case opts.Args.URL.IsGit():

--- a/cmd/upload_release.go
+++ b/cmd/upload_release.go
@@ -55,7 +55,7 @@ func (c UploadReleaseCmd) Run(opts UploadReleaseOpts) error {
 	case opts.Args.URL.IsGit():
 		return c.uploadIfNecessary(opts, c.uploadGit)
 	default:
-		return c.uploadFile(opts)
+		return c.uploadIfNecessary(opts, c.uploadFile)
 	}
 }
 

--- a/integration/upload_release_test.go
+++ b/integration/upload_release_test.go
@@ -241,6 +241,10 @@ blobstore:
 					ghttp.RespondWith(http.StatusOK, `{"user_authentication":{"type":"basic","options":{}}}`),
 				),
 				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/releases"),
+					ghttp.RespondWith(http.StatusOK, "[]"),
+				),
+				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/packages/matches"),
 					ghttp.RespondWith(http.StatusOK, "[]"),
 				),


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180980049

To improve deployment times we looked into the upload release
section for local tarballs. we skipped the existing checks (that were 
used for http/git urls
for tarballs and opted to always reupload. This PR changes
this behaviour

The new behaviour will skip uploading releases IF the specified
name and version are available within the director.

`--fix` will still this override this behaviour

within the cli subcommand (unlike when triggered through manifests)
this will only be triggered if the --name and --version flags
are specified.

```shell
ubuntu@lighttaupe-ops-manager:~$ bosh upload-release file:///var/tempest/releases/pxc-0.39.0-ubuntu-xenial-621.192.tgz
Using environment '10.0.0.5' as client 'ops_manager'

[-----------------------------------------------------------------] 100.00%   0s
Task 125

Task 125 | 15:14:26 | Extracting release: Extracting release (00:00:00)
Task 125 | 15:14:26 | Verifying manifest: Verifying manifest (00:00:00)
Task 125 | 15:14:26 | Resolving package dependencies: Resolving package dependencies (00:00:00)
Task 125 | 15:14:26 | Processing 8 existing jobs: Processing 8 existing jobs (00:00:00)
Task 125 | 15:14:26 | Compiled Release has been created: pxc/0.39.0 (00:00:00)

Task 125 Started  Tue Jan 25 15:14:26 UTC 2022
Task 125 Finished Tue Jan 25 15:14:26 UTC 2022
Task 125 Duration 00:00:00
Task 125 done

Succeeded
ubuntu@lighttaupe-ops-manager:~$ bosh upload-release file:///var/tempest/releases/pxc-0.39.0-ubuntu-xenial-621.192.tgz --version 0.39.0 --name pxc
Using environment '10.0.0.5' as client 'ops_manager'

Release 'pxc/0.39.0' already exists.

Succeeded
```


we ran the full test suite.

