### PR TITLE
Fix/add handling for exported_releases in cli

### DIFF
--- a/cmd/release_manager.go
+++ b/cmd/release_manager.go
@@ -114,7 +114,10 @@ func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (pat
 		SHA1: rel.SHA1,
 		Fix:  m.uploadWithFix,
 	}
-
+	if len(rel.ExportedFrom) > 0 {
+		// https://bosh.io/docs/locking-compiled-releases/#why-an-array It is an array but we only use the first item.
+		uploadOpts.Stemcell = boshdir.NewOSVersionSlug(rel.ExportedFrom[0].OS, rel.ExportedFrom[0].Version)
+	}
 	if len(rel.Stemcell.OS) > 0 {
 		uploadOpts.Stemcell = boshdir.NewOSVersionSlug(rel.Stemcell.OS, rel.Stemcell.Version)
 	}

--- a/cmd/upload_release.go
+++ b/cmd/upload_release.go
@@ -48,8 +48,6 @@ func NewUploadReleaseCmd(
 
 func (c UploadReleaseCmd) Run(opts UploadReleaseOpts) error {
 	switch {
-	case opts.Release != nil:
-		return c.uploadRelease(opts.Release, opts)
 	case opts.Args.URL.IsRemote():
 		return c.uploadIfNecessary(opts, c.uploadRemote)
 	case opts.Args.URL.IsGit():
@@ -161,7 +159,6 @@ func (c UploadReleaseCmd) needToUpload(opts UploadReleaseOpts) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-
 	if found {
 		if opts.Stemcell.IsProvided() {
 			c.ui.PrintLinef("Release '%s/%s' for stemcell '%s' already exists.", opts.Name, version, opts.Stemcell)

--- a/director/directorfakes/fake_director.go
+++ b/director/directorfakes/fake_director.go
@@ -554,6 +554,20 @@ type FakeDirector struct {
 		result1 []director.Task
 		result2 error
 	}
+	ReleaseHasCompiledPackageStub        func(director.ReleaseSlug, director.OSVersionSlug) (bool, error)
+	releaseHasCompiledPackageMutex       sync.RWMutex
+	releaseHasCompiledPackageArgsForCall []struct {
+		arg1 director.ReleaseSlug
+		arg2 director.OSVersionSlug
+	}
+	releaseHasCompiledPackageReturns struct {
+		result1 bool
+		result2 error
+	}
+	releaseHasCompiledPackageReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	ReleasesStub        func() ([]director.Release, error)
 	releasesMutex       sync.RWMutex
 	releasesArgsForCall []struct {
@@ -3344,6 +3358,71 @@ func (fake *FakeDirector) RecentTasksReturnsOnCall(i int, result1 []director.Tas
 	}{result1, result2}
 }
 
+func (fake *FakeDirector) ReleaseHasCompiledPackage(arg1 director.ReleaseSlug, arg2 director.OSVersionSlug) (bool, error) {
+	fake.releaseHasCompiledPackageMutex.Lock()
+	ret, specificReturn := fake.releaseHasCompiledPackageReturnsOnCall[len(fake.releaseHasCompiledPackageArgsForCall)]
+	fake.releaseHasCompiledPackageArgsForCall = append(fake.releaseHasCompiledPackageArgsForCall, struct {
+		arg1 director.ReleaseSlug
+		arg2 director.OSVersionSlug
+	}{arg1, arg2})
+	stub := fake.ReleaseHasCompiledPackageStub
+	fakeReturns := fake.releaseHasCompiledPackageReturns
+	fake.recordInvocation("ReleaseHasCompiledPackage", []interface{}{arg1, arg2})
+	fake.releaseHasCompiledPackageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeDirector) ReleaseHasCompiledPackageCallCount() int {
+	fake.releaseHasCompiledPackageMutex.RLock()
+	defer fake.releaseHasCompiledPackageMutex.RUnlock()
+	return len(fake.releaseHasCompiledPackageArgsForCall)
+}
+
+func (fake *FakeDirector) ReleaseHasCompiledPackageCalls(stub func(director.ReleaseSlug, director.OSVersionSlug) (bool, error)) {
+	fake.releaseHasCompiledPackageMutex.Lock()
+	defer fake.releaseHasCompiledPackageMutex.Unlock()
+	fake.ReleaseHasCompiledPackageStub = stub
+}
+
+func (fake *FakeDirector) ReleaseHasCompiledPackageArgsForCall(i int) (director.ReleaseSlug, director.OSVersionSlug) {
+	fake.releaseHasCompiledPackageMutex.RLock()
+	defer fake.releaseHasCompiledPackageMutex.RUnlock()
+	argsForCall := fake.releaseHasCompiledPackageArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeDirector) ReleaseHasCompiledPackageReturns(result1 bool, result2 error) {
+	fake.releaseHasCompiledPackageMutex.Lock()
+	defer fake.releaseHasCompiledPackageMutex.Unlock()
+	fake.ReleaseHasCompiledPackageStub = nil
+	fake.releaseHasCompiledPackageReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDirector) ReleaseHasCompiledPackageReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.releaseHasCompiledPackageMutex.Lock()
+	defer fake.releaseHasCompiledPackageMutex.Unlock()
+	fake.ReleaseHasCompiledPackageStub = nil
+	if fake.releaseHasCompiledPackageReturnsOnCall == nil {
+		fake.releaseHasCompiledPackageReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.releaseHasCompiledPackageReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDirector) Releases() ([]director.Release, error) {
 	fake.releasesMutex.Lock()
 	ret, specificReturn := fake.releasesReturnsOnCall[len(fake.releasesArgsForCall)]
@@ -4191,6 +4270,8 @@ func (fake *FakeDirector) Invocations() map[string][][]interface{} {
 	defer fake.orphanedVMsMutex.RUnlock()
 	fake.recentTasksMutex.RLock()
 	defer fake.recentTasksMutex.RUnlock()
+	fake.releaseHasCompiledPackageMutex.RLock()
+	defer fake.releaseHasCompiledPackageMutex.RUnlock()
 	fake.releasesMutex.RLock()
 	defer fake.releasesMutex.RUnlock()
 	fake.stemcellNeedsUploadMutex.RLock()

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -38,6 +38,7 @@ type Director interface {
 
 	Releases() ([]Release, error)
 	HasRelease(name, version string, stemcell OSVersionSlug) (bool, error)
+	ReleaseHasCompiledPackage(releaseSlug ReleaseSlug, osVersionSlug OSVersionSlug) (bool, error)
 	FindRelease(ReleaseSlug) (Release, error)
 	FindReleaseSeries(ReleaseSeriesSlug) (ReleaseSeries, error)
 	UploadReleaseURL(url, sha1 string, rebase, fix bool) error

--- a/director/manifest.go
+++ b/director/manifest.go
@@ -12,6 +12,9 @@ name: some-deployment
 releases:
 - name: release
   version: ver
+  exported_from:
+  - os: ...
+    version: ...
   stemcell:
     os: ...
     version: ...
@@ -30,7 +33,8 @@ type ManifestRelease struct {
 	URL  string
 	SHA1 string
 
-	Stemcell ManifestReleaseStemcell
+	Stemcell     ManifestReleaseStemcell
+	ExportedFrom []ManifestReleaseStemcell `yaml:"exported_from,omitempty"`
 }
 
 type ManifestReleaseStemcell struct {


### PR DESCRIPTION
This fixes a bug (and somewhat refactors the code) that
was triggered by:
- e75f6a62532e0cea44d60f375fdf168b0bc9c73c
- 0ebe93a21cee221862dadb7ccbdc3b2ae63ba60e

Previously File Urls would always be reuplaoded. Now it will
skip the upload if a name and version in the director match.

that triggered an issue with releases like:

```yaml
- name: example
  url: file:///path.to.tg
  exported_from:
  - os: some
    version: 1.2.3
```

the code to check whether a compiled release needs to be updated
sourced the Stemcell-version for UploadReleaseOpts from the
`ManifestRelease` struct.

The struct unmarshaled the `release: { stemcell: {}}` attribute
in a manifest.

To fix exported_from file releases parsing got added and the
Stemcell Field is populated with the data. This is happening before
parsing of `stemcell`  itself to keep downstream compability

While the manifest item is a list, the docs explicitly state that
we currently only over use the first item and for sake of simplicity
the code to handle this is not introduced with this commit.

Added tests for the behaviour and exposed another interface for more
precise testing.