### PR TITLE
Bugfix for implied create-release via Manifest

### DIFF
--- a/cmd/release_manager.go
+++ b/cmd/release_manager.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cppforlife/go-patch/patch"
 	semver "github.com/cppforlife/go-semi-semantic/version"
 
-	. "github.com/cloudfoundry/bosh-cli/cmd/opts"
+	cmdopts "github.com/cloudfoundry/bosh-cli/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/director"
 	boshtpl "github.com/cloudfoundry/bosh-cli/director/template"
 	boshrel "github.com/cloudfoundry/bosh-cli/release"
@@ -20,11 +20,11 @@ type ReleaseManager struct {
 }
 
 type ReleaseUploadingCmd interface {
-	Run(UploadReleaseOpts) error
+	Run(cmdopts.UploadReleaseOpts) error
 }
 
 type ReleaseCreatingCmd interface {
-	Run(CreateReleaseOpts) (boshrel.Release, error)
+	Run(cmdopts.CreateReleaseOpts) (boshrel.Release, error)
 }
 
 func NewReleaseManager(
@@ -106,11 +106,11 @@ func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (pat
 		return nil, err
 	}
 
-	uploadOpts := UploadReleaseOpts{
+	uploadOpts := cmdopts.UploadReleaseOpts{
 		Name:    rel.Name,
-		Version: VersionArg(ver),
+		Version: cmdopts.VersionArg(ver),
 
-		Args: UploadReleaseArgs{URL: URLArg(rel.URL)},
+		Args: cmdopts.UploadReleaseArgs{URL: cmdopts.URLArg(rel.URL)},
 		SHA1: rel.SHA1,
 		Fix:  m.uploadWithFix,
 	}
@@ -123,9 +123,9 @@ func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (pat
 	}
 
 	if rel.Version == "create" {
-		createOpts := CreateReleaseOpts{
+		createOpts := cmdopts.CreateReleaseOpts{
 			Name:             rel.Name,
-			Directory:        DirOrCWDArg{Path: uploadOpts.Args.URL.FilePath()},
+			Directory:        cmdopts.DirOrCWDArg{Path: uploadOpts.Args.URL.FilePath()},
 			TimestampVersion: true,
 			Force:            true,
 		}
@@ -135,7 +135,8 @@ func (m ReleaseManager) createAndUploadRelease(rel boshdir.ManifestRelease) (pat
 			return nil, bosherr.WrapErrorf(err, "Processing release '%s/%s'", rel.Name, rel.Version)
 		}
 
-		uploadOpts = UploadReleaseOpts{Release: release}
+		uploadOpts = cmdopts.UploadReleaseOpts{Release: release, Version: cmdopts.VersionArg{}, Name: rel.Name}
+		uploadOpts.Version.UnmarshalFlag(rel.Version)
 
 		replaceOp := patch.ReplaceOp{
 			// equivalent to /releases/name=?/version

--- a/cmd/upload_release.go
+++ b/cmd/upload_release.go
@@ -85,6 +85,7 @@ func (c UploadReleaseCmd) uploadGit(opts UploadReleaseOpts) error {
 }
 
 func (c UploadReleaseCmd) uploadFile(opts UploadReleaseOpts) error {
+
 	if c.releaseDirFactory == nil {
 		return bosherr.Errorf("Cannot upload non-remote release")
 	}
@@ -140,11 +141,13 @@ func (c UploadReleaseCmd) uploadRelease(release boshrel.Release, opts UploadRele
 }
 
 func (c UploadReleaseCmd) uploadIfNecessary(opts UploadReleaseOpts, uploadFunc func(UploadReleaseOpts) error) error {
+	if opts.Release != nil {
+		return c.uploadRelease(opts.Release, opts)
+	}
 	necessary, err := c.needToUpload(opts)
 	if err != nil || !necessary {
 		return err
 	}
-
 	return uploadFunc(opts)
 }
 


### PR DESCRIPTION
f7ce81b7c99b140716fa1b1fa313942ddb8d5d46

overlooked a case where a release is implicitly created via a bosh deploy.
the test used a release where the name matched the directory in `url: `

For that case the upload will appear to work but actually upload a wrong (previously)
created version.