### PR TITLE
Update go.mod with new module path to support releases 6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudfoundry/bosh-cli
+module github.com/cloudfoundry/bosh-cli/v6
 
 go 1.17
 


### PR DESCRIPTION
In a project of ours we are consuming this go module directly for the bosh-cli. After implementing an automation for updating this package I noticed that this go module does not follow the Golang convention. Currently the latest release is version 6.4.17 which should be consumed via: `require github.com/cloudfoundry/bosh-cli/v6 v6.4.17`.

According to the official documentation the module-path needs to be adjusted for all versions higher than version 2:
```
module-path
  The module's module path, usually the repository location from which the module can be downloaded by Go tools.
  For module versions v2 and later, this value must end with the major version number, such as /v2.
```
Taken from: https://go.dev/doc/modules/gomod-ref#module

I had a look at the coding but did not understand why this wasn't changed already as everyone consuming this package directly in Go must have implemented some workaround instead of fixing it. So I propose to change this with this PR according to the official Golang guidance.