### PR TITLE
Add name parameter to cloud configs commands

### DIFF
--- a/cmd/cloud_config.go
+++ b/cmd/cloud_config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	boshui "github.com/cloudfoundry/bosh-cli/v7/ui"
 )
@@ -14,8 +15,8 @@ func NewCloudConfigCmd(ui boshui.UI, director boshdir.Director) CloudConfigCmd {
 	return CloudConfigCmd{ui: ui, director: director}
 }
 
-func (c CloudConfigCmd) Run() error {
-	cloudConfig, err := c.director.LatestCloudConfig()
+func (c CloudConfigCmd) Run(opts CloudConfigOpts) error {
+	cloudConfig, err := c.director.LatestCloudConfig(opts.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/cloud_config_test.go
+++ b/cmd/cloud_config_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd"
+	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/v7/director/directorfakes"
 	fakeui "github.com/cloudfoundry/bosh-cli/v7/ui/fakes"
@@ -26,7 +27,11 @@ var _ = Describe("CloudConfigCmd", func() {
 	})
 
 	Describe("Run", func() {
-		act := func() error { return command.Run() }
+		var (
+			opts CloudConfigOpts
+		)
+
+		act := func() error { return command.Run(opts) }
 
 		It("shows cloud config", func() {
 			cloudConfig := boshdir.CloudConfig{

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -277,7 +277,7 @@ func (c Cmd) Execute() (cmdErr error) {
 		return NewDeleteConfigCmd(deps.UI, c.director()).Run(*opts)
 
 	case *CloudConfigOpts:
-		return NewCloudConfigCmd(deps.UI, c.director()).Run()
+		return NewCloudConfigCmd(deps.UI, c.director()).Run(*opts)
 
 	case *UpdateCloudConfigOpts:
 		return NewUpdateCloudConfigCmd(deps.UI, c.director()).Run(*opts)

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -417,6 +417,7 @@ type DeleteConfigArgs struct {
 // Cloud config
 
 type CloudConfigOpts struct {
+	Name string `long:"name" description:"Cloud-Config name (default: '')" default:""`
 	cmd
 }
 
@@ -424,6 +425,9 @@ type UpdateCloudConfigOpts struct {
 	Args UpdateCloudConfigArgs `positional-args:"true" required:"true"`
 	VarFlags
 	OpsFlags
+
+	Name string `long:"name" description:"Cloud-Config name (default: '')" default:""`
+
 	cmd
 }
 

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -1448,6 +1448,20 @@ var _ = Describe("Opts", func() {
 		})
 	})
 
+	Describe("CloudConfigOpts", func() {
+		var opts *CloudConfigOpts
+
+		BeforeEach(func() {
+			opts = &CloudConfigOpts{}
+		})
+
+		Describe("Name", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("Name", opts)).To(Equal(`long:"name" description:"Cloud-Config name (default: '')" default:""`))
+			})
+		})
+	})
+
 	Describe("UpdateCloudConfigOpts", func() {
 		var opts *UpdateCloudConfigOpts
 
@@ -1458,6 +1472,12 @@ var _ = Describe("Opts", func() {
 		Describe("Args", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Args", opts)).To(Equal(`positional-args:"true" required:"true"`))
+			})
+		})
+
+		Describe("Name", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("Name", opts)).To(Equal(`long:"name" description:"Cloud-Config name (default: '')" default:""`))
 			})
 		})
 	})

--- a/cmd/update_cloud_config.go
+++ b/cmd/update_cloud_config.go
@@ -26,7 +26,7 @@ func (c UpdateCloudConfigCmd) Run(opts UpdateCloudConfigOpts) error {
 		return bosherr.WrapErrorf(err, "Evaluating cloud config")
 	}
 
-	cloudConfigDiff, err := c.director.DiffCloudConfig(bytes)
+	cloudConfigDiff, err := c.director.DiffCloudConfig(opts.Name, bytes)
 	if err != nil {
 		return err
 	}
@@ -39,5 +39,5 @@ func (c UpdateCloudConfigCmd) Run(opts UpdateCloudConfigOpts) error {
 		return err
 	}
 
-	return c.director.UpdateCloudConfig(bytes)
+	return c.director.UpdateCloudConfig(opts.Name, bytes)
 }

--- a/cmd/update_cloud_config_test.go
+++ b/cmd/update_cloud_config_test.go
@@ -38,6 +38,7 @@ var _ = Describe("UpdateCloudConfigCmd", func() {
 				Args: UpdateCloudConfigArgs{
 					CloudConfig: FileBytesArg{Bytes: []byte("cloud-config")},
 				},
+				Name: "angry-smurf",
 			}
 		})
 
@@ -49,7 +50,8 @@ var _ = Describe("UpdateCloudConfigCmd", func() {
 
 			Expect(director.UpdateCloudConfigCallCount()).To(Equal(1))
 
-			bytes := director.UpdateCloudConfigArgsForCall(0)
+			name, bytes := director.UpdateCloudConfigArgsForCall(0)
+			Expect(name).To(Equal("angry-smurf"))
 			Expect(bytes).To(Equal([]byte("cloud-config\n")))
 		})
 
@@ -80,7 +82,8 @@ var _ = Describe("UpdateCloudConfigCmd", func() {
 
 			Expect(director.UpdateCloudConfigCallCount()).To(Equal(1))
 
-			bytes := director.UpdateCloudConfigArgsForCall(0)
+			name, bytes := director.UpdateCloudConfigArgsForCall(0)
+			Expect(name).To(Equal("angry-smurf"))
 			Expect(bytes).To(Equal([]byte("name1: val1-from-kv\nname2: val2-from-file\nxyz: val\n")))
 		})
 

--- a/director/directorfakes/fake_director.go
+++ b/director/directorfakes/fake_director.go
@@ -113,10 +113,11 @@ type FakeDirector struct {
 		result1 director.ConfigDiff
 		result2 error
 	}
-	DiffCloudConfigStub        func([]byte) (director.ConfigDiff, error)
+	DiffCloudConfigStub        func(string, []byte) (director.ConfigDiff, error)
 	diffCloudConfigMutex       sync.RWMutex
 	diffCloudConfigArgsForCall []struct {
-		arg1 []byte
+		arg1 string
+		arg2 []byte
 	}
 	diffCloudConfigReturns struct {
 		result1 director.ConfigDiff
@@ -376,9 +377,10 @@ type FakeDirector struct {
 		result1 director.CPIConfig
 		result2 error
 	}
-	LatestCloudConfigStub        func() (director.CloudConfig, error)
+	LatestCloudConfigStub        func(string) (director.CloudConfig, error)
 	latestCloudConfigMutex       sync.RWMutex
 	latestCloudConfigArgsForCall []struct {
+		arg1 string
 	}
 	latestCloudConfigReturns struct {
 		result1 director.CloudConfig
@@ -616,10 +618,11 @@ type FakeDirector struct {
 	updateCPIConfigReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateCloudConfigStub        func([]byte) error
+	UpdateCloudConfigStub        func(string, []byte) error
 	updateCloudConfigMutex       sync.RWMutex
 	updateCloudConfigArgsForCall []struct {
-		arg1 []byte
+		arg1 string
+		arg2 []byte
 	}
 	updateCloudConfigReturns struct {
 		result1 error
@@ -1224,23 +1227,24 @@ func (fake *FakeDirector) DiffCPIConfigReturnsOnCall(i int, result1 director.Con
 	}{result1, result2}
 }
 
-func (fake *FakeDirector) DiffCloudConfig(arg1 []byte) (director.ConfigDiff, error) {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeDirector) DiffCloudConfig(arg1 string, arg2 []byte) (director.ConfigDiff, error) {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.diffCloudConfigMutex.Lock()
 	ret, specificReturn := fake.diffCloudConfigReturnsOnCall[len(fake.diffCloudConfigArgsForCall)]
 	fake.diffCloudConfigArgsForCall = append(fake.diffCloudConfigArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 string
+		arg2 []byte
+	}{arg1, arg2Copy})
 	stub := fake.DiffCloudConfigStub
 	fakeReturns := fake.diffCloudConfigReturns
-	fake.recordInvocation("DiffCloudConfig", []interface{}{arg1Copy})
+	fake.recordInvocation("DiffCloudConfig", []interface{}{arg1, arg2Copy})
 	fake.diffCloudConfigMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1254,17 +1258,17 @@ func (fake *FakeDirector) DiffCloudConfigCallCount() int {
 	return len(fake.diffCloudConfigArgsForCall)
 }
 
-func (fake *FakeDirector) DiffCloudConfigCalls(stub func([]byte) (director.ConfigDiff, error)) {
+func (fake *FakeDirector) DiffCloudConfigCalls(stub func(string, []byte) (director.ConfigDiff, error)) {
 	fake.diffCloudConfigMutex.Lock()
 	defer fake.diffCloudConfigMutex.Unlock()
 	fake.DiffCloudConfigStub = stub
 }
 
-func (fake *FakeDirector) DiffCloudConfigArgsForCall(i int) []byte {
+func (fake *FakeDirector) DiffCloudConfigArgsForCall(i int) (string, []byte) {
 	fake.diffCloudConfigMutex.RLock()
 	defer fake.diffCloudConfigMutex.RUnlock()
 	argsForCall := fake.diffCloudConfigArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeDirector) DiffCloudConfigReturns(result1 director.ConfigDiff, result2 error) {
@@ -2509,17 +2513,18 @@ func (fake *FakeDirector) LatestCPIConfigReturnsOnCall(i int, result1 director.C
 	}{result1, result2}
 }
 
-func (fake *FakeDirector) LatestCloudConfig() (director.CloudConfig, error) {
+func (fake *FakeDirector) LatestCloudConfig(arg1 string) (director.CloudConfig, error) {
 	fake.latestCloudConfigMutex.Lock()
 	ret, specificReturn := fake.latestCloudConfigReturnsOnCall[len(fake.latestCloudConfigArgsForCall)]
 	fake.latestCloudConfigArgsForCall = append(fake.latestCloudConfigArgsForCall, struct {
-	}{})
+		arg1 string
+	}{arg1})
 	stub := fake.LatestCloudConfigStub
 	fakeReturns := fake.latestCloudConfigReturns
-	fake.recordInvocation("LatestCloudConfig", []interface{}{})
+	fake.recordInvocation("LatestCloudConfig", []interface{}{arg1})
 	fake.latestCloudConfigMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -2533,10 +2538,17 @@ func (fake *FakeDirector) LatestCloudConfigCallCount() int {
 	return len(fake.latestCloudConfigArgsForCall)
 }
 
-func (fake *FakeDirector) LatestCloudConfigCalls(stub func() (director.CloudConfig, error)) {
+func (fake *FakeDirector) LatestCloudConfigCalls(stub func(string) (director.CloudConfig, error)) {
 	fake.latestCloudConfigMutex.Lock()
 	defer fake.latestCloudConfigMutex.Unlock()
 	fake.LatestCloudConfigStub = stub
+}
+
+func (fake *FakeDirector) LatestCloudConfigArgsForCall(i int) string {
+	fake.latestCloudConfigMutex.RLock()
+	defer fake.latestCloudConfigMutex.RUnlock()
+	argsForCall := fake.latestCloudConfigArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeDirector) LatestCloudConfigReturns(result1 director.CloudConfig, result2 error) {
@@ -3665,23 +3677,24 @@ func (fake *FakeDirector) UpdateCPIConfigReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeDirector) UpdateCloudConfig(arg1 []byte) error {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeDirector) UpdateCloudConfig(arg1 string, arg2 []byte) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.updateCloudConfigMutex.Lock()
 	ret, specificReturn := fake.updateCloudConfigReturnsOnCall[len(fake.updateCloudConfigArgsForCall)]
 	fake.updateCloudConfigArgsForCall = append(fake.updateCloudConfigArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 string
+		arg2 []byte
+	}{arg1, arg2Copy})
 	stub := fake.UpdateCloudConfigStub
 	fakeReturns := fake.updateCloudConfigReturns
-	fake.recordInvocation("UpdateCloudConfig", []interface{}{arg1Copy})
+	fake.recordInvocation("UpdateCloudConfig", []interface{}{arg1, arg2Copy})
 	fake.updateCloudConfigMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -3695,17 +3708,17 @@ func (fake *FakeDirector) UpdateCloudConfigCallCount() int {
 	return len(fake.updateCloudConfigArgsForCall)
 }
 
-func (fake *FakeDirector) UpdateCloudConfigCalls(stub func([]byte) error) {
+func (fake *FakeDirector) UpdateCloudConfigCalls(stub func(string, []byte) error) {
 	fake.updateCloudConfigMutex.Lock()
 	defer fake.updateCloudConfigMutex.Unlock()
 	fake.UpdateCloudConfigStub = stub
 }
 
-func (fake *FakeDirector) UpdateCloudConfigArgsForCall(i int) []byte {
+func (fake *FakeDirector) UpdateCloudConfigArgsForCall(i int) (string, []byte) {
 	fake.updateCloudConfigMutex.RLock()
 	defer fake.updateCloudConfigMutex.RUnlock()
 	argsForCall := fake.updateCloudConfigArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeDirector) UpdateCloudConfigReturns(result1 error) {

--- a/director/factory_test.go
+++ b/director/factory_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Factory", func() {
 					),
 				)
 
-				_, err = director.LatestCloudConfig()
+				_, err = director.LatestCloudConfig("")
 				Expect(err).To(HaveOccurred())
 
 				debugMsgs := make([]interface{}, 0)

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -60,9 +60,9 @@ type Director interface {
 	DiffConfig(configType string, name string, manifest []byte) (ConfigDiff, error)
 	DiffConfigByIDOrContent(fromID string, fromContent []byte, toID string, toContent []byte) (ConfigDiff, error)
 
-	LatestCloudConfig() (CloudConfig, error)
-	UpdateCloudConfig([]byte) error
-	DiffCloudConfig(manifest []byte) (ConfigDiff, error)
+	LatestCloudConfig(name string) (CloudConfig, error)
+	UpdateCloudConfig(name string, manifest []byte) error
+	DiffCloudConfig(name string, manifest []byte) (ConfigDiff, error)
 
 	LatestCPIConfig() (CPIConfig, error)
 	UpdateCPIConfig([]byte) error


### PR DESCRIPTION
### What is this change about?

This change add a `name` parameter to the commands `update-cloud-config` and `cloud-config`.
This is required to the fix https://github.com/cloudfoundry/bosh-cli/issues/542

In general this solves a inconsistency between the options of command `update-runtime-config` and `update-cloud-config`
This PR depends on: https://github.com/cloudfoundry/bosh/pull/2390

### Please provide contextual information.

https://github.com/cloudfoundry/bosh-cli/issues/542

### What tests have you run against this PR?

I ran the cli unit tests

### How should this change be described in bosh release notes?

The commands `update-cloud-config` and `cloud-config`  offer a `--name` parameter to upload and retrieve a named cloud config

### Does this PR introduce a breaking change?

no

### Tag your pair, your PM, and/or team!
PO: @friegger