### PR TITLE
add the ability to set a prefix for vendored packages

### DIFF
--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -1019,6 +1019,7 @@ type VendorPackageOpts struct {
 	Args VendorPackageArgs `positional-args:"true" required:"true"`
 
 	Directory DirOrCWDArg `long:"dir" description:"Release directory path if not current working directory" default:"."`
+	Prefix    string      `long:"prefix" description:"Prefix to add to the package name" default:""`
 
 	cmd
 }

--- a/cmd/vendor_package.go
+++ b/cmd/vendor_package.go
@@ -33,7 +33,7 @@ func (c VendorPackageCmd) Run(opts VendorPackageOpts) error {
 
 	for _, pkg := range srcRelease.Packages() {
 		if pkg.Name() == opts.Args.PackageName {
-			return dstReleaseDir.VendorPackage(pkg)
+			return dstReleaseDir.VendorPackage(pkg, opts.Prefix)
 		}
 	}
 

--- a/release/pkg/package.go
+++ b/release/pkg/package.go
@@ -17,6 +17,7 @@ func (a ByName) Less(i, j int) bool { return a[i].Name() < a[j].Name() }
 
 type Package struct {
 	resource Resource
+	prefix   string
 
 	Dependencies    []*Package
 	dependencyNames []string
@@ -63,7 +64,10 @@ func (p *Package) RehashWithCalculator(calculator crypto.DigestCalculator, archi
 }
 
 func (p *Package) Build(dev, final ArchiveIndex) error { return p.resource.Build(dev, final) }
-func (p *Package) Finalize(final ArchiveIndex) error   { return p.resource.Finalize(final) }
+func (p *Package) Finalize(final ArchiveIndex) error {
+	p.resource.Prefix(p.prefix)
+	return p.resource.Finalize(final)
+}
 
 func (p *Package) AttachDependencies(packages []*Package) error {
 	for _, pkgName := range p.dependencyNames {
@@ -99,7 +103,9 @@ func (p *Package) Deps() []Compilable {
 func (p *Package) IsCompiled() bool { return false }
 
 func (p *Package) ExtractedPath() string { return p.extractedPath }
-
+func (p *Package) Prefix(prefix string) {
+	p.prefix = prefix
+}
 func (p *Package) CleanUp() error {
 	if p.fs != nil && len(p.extractedPath) > 0 {
 		return p.fs.RemoveAll(p.extractedPath)

--- a/release/resource/interfaces.go
+++ b/release/resource/interfaces.go
@@ -36,6 +36,7 @@ type ArchiveIndex interface {
 
 type Resource interface {
 	Name() string
+	Prefix(prefix string)
 	Fingerprint() string
 
 	ArchivePath() string

--- a/release/resource/resourcefakes/fake_resource.go
+++ b/release/resource/resourcefakes/fake_resource.go
@@ -73,6 +73,11 @@ type FakeResource struct {
 	nameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	PrefixStub        func(string)
+	prefixMutex       sync.RWMutex
+	prefixArgsForCall []struct {
+		arg1 string
+	}
 	RehashWithCalculatorStub        func(crypto.DigestCalculator, cryptoa.ArchiveDigestFilePathReader) (resource.Resource, error)
 	rehashWithCalculatorMutex       sync.RWMutex
 	rehashWithCalculatorArgsForCall []struct {
@@ -426,6 +431,38 @@ func (fake *FakeResource) NameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeResource) Prefix(arg1 string) {
+	fake.prefixMutex.Lock()
+	fake.prefixArgsForCall = append(fake.prefixArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.PrefixStub
+	fake.recordInvocation("Prefix", []interface{}{arg1})
+	fake.prefixMutex.Unlock()
+	if stub != nil {
+		fake.PrefixStub(arg1)
+	}
+}
+
+func (fake *FakeResource) PrefixCallCount() int {
+	fake.prefixMutex.RLock()
+	defer fake.prefixMutex.RUnlock()
+	return len(fake.prefixArgsForCall)
+}
+
+func (fake *FakeResource) PrefixCalls(stub func(string)) {
+	fake.prefixMutex.Lock()
+	defer fake.prefixMutex.Unlock()
+	fake.PrefixStub = stub
+}
+
+func (fake *FakeResource) PrefixArgsForCall(i int) string {
+	fake.prefixMutex.RLock()
+	defer fake.prefixMutex.RUnlock()
+	argsForCall := fake.prefixArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeResource) RehashWithCalculator(arg1 crypto.DigestCalculator, arg2 cryptoa.ArchiveDigestFilePathReader) (resource.Resource, error) {
 	fake.rehashWithCalculatorMutex.Lock()
 	ret, specificReturn := fake.rehashWithCalculatorReturnsOnCall[len(fake.rehashWithCalculatorArgsForCall)]
@@ -506,6 +543,8 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.fingerprintMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
+	fake.prefixMutex.RLock()
+	defer fake.prefixMutex.RUnlock()
 	fake.rehashWithCalculatorMutex.RLock()
 	defer fake.rehashWithCalculatorMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/releasedir/fs_release_dir.go
+++ b/releasedir/fs_release_dir.go
@@ -236,13 +236,14 @@ func (d FSReleaseDir) BuildRelease(name string, version semver.Version, force bo
 	return release, nil
 }
 
-func (d FSReleaseDir) VendorPackage(pkg *boshpkg.Package) error {
+func (d FSReleaseDir) VendorPackage(pkg *boshpkg.Package, prefix string) error {
 	allInterestingPkgs := map[*boshpkg.Package]struct{}{}
-
 	d.collectDependentPackages(pkg, allInterestingPkgs)
 
 	for pkg2 := range allInterestingPkgs {
+		pkg2.Prefix(prefix)
 		err := pkg2.Finalize(d.finalIndicies.Packages)
+
 		if err != nil {
 			return bosherr.WrapErrorf(err, "Finalizing vendored package")
 		}

--- a/releasedir/interfaces.go
+++ b/releasedir/interfaces.go
@@ -38,7 +38,7 @@ type ReleaseDir interface {
 	// BuildRelease builds a new version of the Release
 	// from the release directory by looking at jobs, packages, etc. directories.
 	BuildRelease(name string, version semver.Version, force bool) (boshrel.Release, error)
-	VendorPackage(*boshpkg.Package) error
+	VendorPackage(pkg *boshpkg.Package, prefix string) error
 
 	// FinalizeRelease adds the Release to the final list so that it's consumable by others.
 	FinalizeRelease(release boshrel.Release, force bool) error

--- a/releasedir/releasedirfakes/fake_release_dir.go
+++ b/releasedir/releasedirfakes/fake_release_dir.go
@@ -134,10 +134,11 @@ type FakeReleaseDir struct {
 	resetReturnsOnCall map[int]struct {
 		result1 error
 	}
-	VendorPackageStub        func(*pkg.Package) error
+	VendorPackageStub        func(*pkg.Package, string) error
 	vendorPackageMutex       sync.RWMutex
 	vendorPackageArgsForCall []struct {
 		arg1 *pkg.Package
+		arg2 string
 	}
 	vendorPackageReturns struct {
 		result1 error
@@ -763,18 +764,19 @@ func (fake *FakeReleaseDir) ResetReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeReleaseDir) VendorPackage(arg1 *pkg.Package) error {
+func (fake *FakeReleaseDir) VendorPackage(arg1 *pkg.Package, arg2 string) error {
 	fake.vendorPackageMutex.Lock()
 	ret, specificReturn := fake.vendorPackageReturnsOnCall[len(fake.vendorPackageArgsForCall)]
 	fake.vendorPackageArgsForCall = append(fake.vendorPackageArgsForCall, struct {
 		arg1 *pkg.Package
-	}{arg1})
+		arg2 string
+	}{arg1, arg2})
 	stub := fake.VendorPackageStub
 	fakeReturns := fake.vendorPackageReturns
-	fake.recordInvocation("VendorPackage", []interface{}{arg1})
+	fake.recordInvocation("VendorPackage", []interface{}{arg1, arg2})
 	fake.vendorPackageMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -788,17 +790,17 @@ func (fake *FakeReleaseDir) VendorPackageCallCount() int {
 	return len(fake.vendorPackageArgsForCall)
 }
 
-func (fake *FakeReleaseDir) VendorPackageCalls(stub func(*pkg.Package) error) {
+func (fake *FakeReleaseDir) VendorPackageCalls(stub func(*pkg.Package, string) error) {
 	fake.vendorPackageMutex.Lock()
 	defer fake.vendorPackageMutex.Unlock()
 	fake.VendorPackageStub = stub
 }
 
-func (fake *FakeReleaseDir) VendorPackageArgsForCall(i int) *pkg.Package {
+func (fake *FakeReleaseDir) VendorPackageArgsForCall(i int) (*pkg.Package, string) {
 	fake.vendorPackageMutex.RLock()
 	defer fake.vendorPackageMutex.RUnlock()
 	argsForCall := fake.vendorPackageArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeReleaseDir) VendorPackageReturns(result1 error) {


### PR DESCRIPTION
this is a temporary solution to solve https://github.com/cloudfoundry/bosh/issues/2400

as we can now add the following to aws cpi for example
`bosh vendor-package ruby-3.1 ~/workspace/bosh/bosh-packages/ruby-release --prefix aws`
this would mean that the vendored package is now available as `aws-ruby-3.1`
so it will not cause any collision with older or newer ruby-3.1 packed for example used by the bosh-director