### PR TITLE
fix inconsistent vendor package behaviour

### DIFF
--- a/releasedir/fs_release_dir.go
+++ b/releasedir/fs_release_dir.go
@@ -247,8 +247,10 @@ func (d FSReleaseDir) VendorPackage(pkg *boshpkg.Package, prefix string) error {
 		if err != nil {
 			return bosherr.WrapErrorf(err, "Finalizing vendored package")
 		}
+	}
 
-		err = d.writeVendoredPackage(pkg2)
+	for pkg2 := range allInterestingPkgs {
+		err := d.writeVendoredPackage(pkg2)
 		if err != nil {
 			return bosherr.WrapErrorf(err, "Writing vendored package")
 		}


### PR DESCRIPTION
when we introduced the prefixed vendored package behaviour we overlooked a case that could lead to inconstistent writes of the spec.lock for a prefixed package.

The issue was described in https://github.com/cloudfoundry/bosh-cli/issues/606

The underlying cause was the ordering of `allInterestingPkgs` https://github.com/cloudfoundry/bosh-cli/pull/603/files#diff-420d09437c4bf08b4407d39b5956c6209df3519cde36b121a856085e372d2c92R240-R241

As setup in the added test, we have 3 packages. The top level package `pkg-1` and the two dependencies it pulls in `pkg-2,pkg-3`

The ordering of the map `allInterestingPkgs` is inconsistent and the test will fail for every case where pkg-1 isn't the last item in `allInterestingPkgs`. That is because we end up calling writeVendoredPackage on pkg-1, which in turn will iterate over the dependencies.

At this point we didn't yet call .Prefix and .Finalize on the objects for `pkg-2` and `pkg-3`. Though this is required so they can return their prefixed name via Name().

This is addressed by duplicating the loop. The first pass will ensure all objects in the dependency tree are prefixed and finalized before the spec.lock is written to disk.