### PR TITLE
Add ability to use logs, ssh, and scp commands with BOSH directors

### DIFF
--- a/agentclient/mocks/mocks.go
+++ b/agentclient/mocks/mocks.go
@@ -5,37 +5,36 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	agentclient "github.com/cloudfoundry/bosh-agent/agentclient"
 	applyspec "github.com/cloudfoundry/bosh-agent/agentclient/applyspec"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockAgentClient is a mock of AgentClient interface.
+// MockAgentClient is a mock of AgentClient interface
 type MockAgentClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockAgentClientMockRecorder
 }
 
-// MockAgentClientMockRecorder is the mock recorder for MockAgentClient.
+// MockAgentClientMockRecorder is the mock recorder for MockAgentClient
 type MockAgentClientMockRecorder struct {
 	mock *MockAgentClient
 }
 
-// NewMockAgentClient creates a new mock instance.
+// NewMockAgentClient creates a new mock instance
 func NewMockAgentClient(ctrl *gomock.Controller) *MockAgentClient {
 	mock := &MockAgentClient{ctrl: ctrl}
 	mock.recorder = &MockAgentClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAgentClient) EXPECT() *MockAgentClientMockRecorder {
 	return m.recorder
 }
 
-// AddPersistentDisk mocks base method.
+// AddPersistentDisk mocks base method
 func (m *MockAgentClient) AddPersistentDisk(arg0 string, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPersistentDisk", arg0, arg1)
@@ -43,13 +42,13 @@ func (m *MockAgentClient) AddPersistentDisk(arg0 string, arg1 interface{}) error
 	return ret0
 }
 
-// AddPersistentDisk indicates an expected call of AddPersistentDisk.
+// AddPersistentDisk indicates an expected call of AddPersistentDisk
 func (mr *MockAgentClientMockRecorder) AddPersistentDisk(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPersistentDisk", reflect.TypeOf((*MockAgentClient)(nil).AddPersistentDisk), arg0, arg1)
 }
 
-// Apply mocks base method.
+// Apply mocks base method
 func (m *MockAgentClient) Apply(arg0 applyspec.ApplySpec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", arg0)
@@ -57,13 +56,43 @@ func (m *MockAgentClient) Apply(arg0 applyspec.ApplySpec) error {
 	return ret0
 }
 
-// Apply indicates an expected call of Apply.
+// Apply indicates an expected call of Apply
 func (mr *MockAgentClientMockRecorder) Apply(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockAgentClient)(nil).Apply), arg0)
 }
 
-// CompilePackage mocks base method.
+// BundleLogs mocks base method
+func (m *MockAgentClient) BundleLogs(arg0, arg1 string, arg2 []string) (agentclient.BundleLogsResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BundleLogs", arg0, arg1, arg2)
+	ret0, _ := ret[0].(agentclient.BundleLogsResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BundleLogs indicates an expected call of BundleLogs
+func (mr *MockAgentClientMockRecorder) BundleLogs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BundleLogs", reflect.TypeOf((*MockAgentClient)(nil).BundleLogs), arg0, arg1, arg2)
+}
+
+// CleanUpSSH mocks base method
+func (m *MockAgentClient) CleanUpSSH(arg0 string) (agentclient.SSHResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanUpSSH", arg0)
+	ret0, _ := ret[0].(agentclient.SSHResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanUpSSH indicates an expected call of CleanUpSSH
+func (mr *MockAgentClientMockRecorder) CleanUpSSH(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanUpSSH", reflect.TypeOf((*MockAgentClient)(nil).CleanUpSSH), arg0)
+}
+
+// CompilePackage mocks base method
 func (m *MockAgentClient) CompilePackage(arg0 agentclient.BlobRef, arg1 []agentclient.BlobRef) (agentclient.BlobRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompilePackage", arg0, arg1)
@@ -72,13 +101,13 @@ func (m *MockAgentClient) CompilePackage(arg0 agentclient.BlobRef, arg1 []agentc
 	return ret0, ret1
 }
 
-// CompilePackage indicates an expected call of CompilePackage.
+// CompilePackage indicates an expected call of CompilePackage
 func (mr *MockAgentClientMockRecorder) CompilePackage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompilePackage", reflect.TypeOf((*MockAgentClient)(nil).CompilePackage), arg0, arg1)
 }
 
-// DeleteARPEntries mocks base method.
+// DeleteARPEntries mocks base method
 func (m *MockAgentClient) DeleteARPEntries(arg0 []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteARPEntries", arg0)
@@ -86,13 +115,13 @@ func (m *MockAgentClient) DeleteARPEntries(arg0 []string) error {
 	return ret0
 }
 
-// DeleteARPEntries indicates an expected call of DeleteARPEntries.
+// DeleteARPEntries indicates an expected call of DeleteARPEntries
 func (mr *MockAgentClientMockRecorder) DeleteARPEntries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteARPEntries", reflect.TypeOf((*MockAgentClient)(nil).DeleteARPEntries), arg0)
 }
 
-// Drain mocks base method.
+// Drain mocks base method
 func (m *MockAgentClient) Drain(arg0 string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Drain", arg0)
@@ -101,13 +130,13 @@ func (m *MockAgentClient) Drain(arg0 string) (int64, error) {
 	return ret0, ret1
 }
 
-// Drain indicates an expected call of Drain.
+// Drain indicates an expected call of Drain
 func (mr *MockAgentClientMockRecorder) Drain(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Drain", reflect.TypeOf((*MockAgentClient)(nil).Drain), arg0)
 }
 
-// GetState mocks base method.
+// GetState mocks base method
 func (m *MockAgentClient) GetState() (agentclient.AgentState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetState")
@@ -116,13 +145,13 @@ func (m *MockAgentClient) GetState() (agentclient.AgentState, error) {
 	return ret0, ret1
 }
 
-// GetState indicates an expected call of GetState.
+// GetState indicates an expected call of GetState
 func (mr *MockAgentClientMockRecorder) GetState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockAgentClient)(nil).GetState))
 }
 
-// ListDisk mocks base method.
+// ListDisk mocks base method
 func (m *MockAgentClient) ListDisk() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDisk")
@@ -131,13 +160,13 @@ func (m *MockAgentClient) ListDisk() ([]string, error) {
 	return ret0, ret1
 }
 
-// ListDisk indicates an expected call of ListDisk.
+// ListDisk indicates an expected call of ListDisk
 func (mr *MockAgentClientMockRecorder) ListDisk() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDisk", reflect.TypeOf((*MockAgentClient)(nil).ListDisk))
 }
 
-// MigrateDisk mocks base method.
+// MigrateDisk mocks base method
 func (m *MockAgentClient) MigrateDisk() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MigrateDisk")
@@ -145,13 +174,13 @@ func (m *MockAgentClient) MigrateDisk() error {
 	return ret0
 }
 
-// MigrateDisk indicates an expected call of MigrateDisk.
+// MigrateDisk indicates an expected call of MigrateDisk
 func (mr *MockAgentClientMockRecorder) MigrateDisk() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateDisk", reflect.TypeOf((*MockAgentClient)(nil).MigrateDisk))
 }
 
-// MountDisk mocks base method.
+// MountDisk mocks base method
 func (m *MockAgentClient) MountDisk(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MountDisk", arg0)
@@ -159,13 +188,13 @@ func (m *MockAgentClient) MountDisk(arg0 string) error {
 	return ret0
 }
 
-// MountDisk indicates an expected call of MountDisk.
+// MountDisk indicates an expected call of MountDisk
 func (mr *MockAgentClientMockRecorder) MountDisk(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountDisk", reflect.TypeOf((*MockAgentClient)(nil).MountDisk), arg0)
 }
 
-// Ping mocks base method.
+// Ping mocks base method
 func (m *MockAgentClient) Ping() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping")
@@ -174,13 +203,27 @@ func (m *MockAgentClient) Ping() (string, error) {
 	return ret0, ret1
 }
 
-// Ping indicates an expected call of Ping.
+// Ping indicates an expected call of Ping
 func (mr *MockAgentClientMockRecorder) Ping() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockAgentClient)(nil).Ping))
 }
 
-// RemovePersistentDisk mocks base method.
+// RemoveFile mocks base method
+func (m *MockAgentClient) RemoveFile(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveFile", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveFile indicates an expected call of RemoveFile
+func (mr *MockAgentClientMockRecorder) RemoveFile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFile", reflect.TypeOf((*MockAgentClient)(nil).RemoveFile), arg0)
+}
+
+// RemovePersistentDisk mocks base method
 func (m *MockAgentClient) RemovePersistentDisk(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemovePersistentDisk", arg0)
@@ -188,13 +231,13 @@ func (m *MockAgentClient) RemovePersistentDisk(arg0 string) error {
 	return ret0
 }
 
-// RemovePersistentDisk indicates an expected call of RemovePersistentDisk.
+// RemovePersistentDisk indicates an expected call of RemovePersistentDisk
 func (mr *MockAgentClientMockRecorder) RemovePersistentDisk(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePersistentDisk", reflect.TypeOf((*MockAgentClient)(nil).RemovePersistentDisk), arg0)
 }
 
-// RunScript mocks base method.
+// RunScript mocks base method
 func (m *MockAgentClient) RunScript(arg0 string, arg1 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunScript", arg0, arg1)
@@ -202,13 +245,28 @@ func (m *MockAgentClient) RunScript(arg0 string, arg1 map[string]interface{}) er
 	return ret0
 }
 
-// RunScript indicates an expected call of RunScript.
+// RunScript indicates an expected call of RunScript
 func (mr *MockAgentClientMockRecorder) RunScript(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunScript", reflect.TypeOf((*MockAgentClient)(nil).RunScript), arg0, arg1)
 }
 
-// Start mocks base method.
+// SetUpSSH mocks base method
+func (m *MockAgentClient) SetUpSSH(arg0, arg1 string) (agentclient.SSHResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetUpSSH", arg0, arg1)
+	ret0, _ := ret[0].(agentclient.SSHResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetUpSSH indicates an expected call of SetUpSSH
+func (mr *MockAgentClientMockRecorder) SetUpSSH(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpSSH", reflect.TypeOf((*MockAgentClient)(nil).SetUpSSH), arg0, arg1)
+}
+
+// Start mocks base method
 func (m *MockAgentClient) Start() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start")
@@ -216,13 +274,13 @@ func (m *MockAgentClient) Start() error {
 	return ret0
 }
 
-// Start indicates an expected call of Start.
+// Start indicates an expected call of Start
 func (mr *MockAgentClientMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockAgentClient)(nil).Start))
 }
 
-// Stop mocks base method.
+// Stop mocks base method
 func (m *MockAgentClient) Stop() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
@@ -230,13 +288,13 @@ func (m *MockAgentClient) Stop() error {
 	return ret0
 }
 
-// Stop indicates an expected call of Stop.
+// Stop indicates an expected call of Stop
 func (mr *MockAgentClientMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockAgentClient)(nil).Stop))
 }
 
-// SyncDNS mocks base method.
+// SyncDNS mocks base method
 func (m *MockAgentClient) SyncDNS(arg0, arg1 string, arg2 uint64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SyncDNS", arg0, arg1, arg2)
@@ -245,13 +303,13 @@ func (m *MockAgentClient) SyncDNS(arg0, arg1 string, arg2 uint64) (string, error
 	return ret0, ret1
 }
 
-// SyncDNS indicates an expected call of SyncDNS.
+// SyncDNS indicates an expected call of SyncDNS
 func (mr *MockAgentClientMockRecorder) SyncDNS(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncDNS", reflect.TypeOf((*MockAgentClient)(nil).SyncDNS), arg0, arg1, arg2)
 }
 
-// UnmountDisk mocks base method.
+// UnmountDisk mocks base method
 func (m *MockAgentClient) UnmountDisk(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmountDisk", arg0)
@@ -259,7 +317,7 @@ func (m *MockAgentClient) UnmountDisk(arg0 string) error {
 	return ret0
 }
 
-// UnmountDisk indicates an expected call of UnmountDisk.
+// UnmountDisk indicates an expected call of UnmountDisk
 func (mr *MockAgentClientMockRecorder) UnmountDisk(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmountDisk", reflect.TypeOf((*MockAgentClient)(nil).UnmountDisk), arg0)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
+	bihttpagent "github.com/cloudfoundry/bosh-agent/agentclient/http"
 	"github.com/cppforlife/go-patch/patch"
 
 	cmdconf "github.com/cloudfoundry/bosh-cli/v7/cmd/config"
@@ -17,10 +19,11 @@ import (
 	boshui "github.com/cloudfoundry/bosh-cli/v7/ui"
 	boshuit "github.com/cloudfoundry/bosh-cli/v7/ui/task"
 
-	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
-	boshtbl "github.com/cloudfoundry/bosh-cli/v7/ui/table"
 	boshcrypto "github.com/cloudfoundry/bosh-utils/crypto"
 	boshfu "github.com/cloudfoundry/bosh-utils/fileutil"
+
+	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
+	boshtbl "github.com/cloudfoundry/bosh-cli/v7/ui/table"
 )
 
 type Cmd struct {
@@ -358,11 +361,18 @@ func (c Cmd) Execute() (cmdErr error) {
 		return NewCleanUpCmd(deps.UI, c.director()).Run(*opts)
 
 	case *LogsOpts:
-		director, deployment := c.directorAndDeployment()
-		downloader := NewUIDownloader(director, deps.Time, deps.FS, deps.UI)
 		sshProvider := boshssh.NewProvider(deps.CmdRunner, deps.FS, deps.UI, deps.Logger)
 		nonIntSSHRunner := sshProvider.NewSSHRunner(false)
-		return NewLogsCmd(deployment, downloader, deps.UUIDGen, nonIntSSHRunner).Run(*opts)
+
+		if opts.TargetDirector {
+			agentClientFactory := bihttpagent.NewAgentClientFactory(1*time.Second, deps.Logger)
+			scpRunner := sshProvider.NewSCPRunner()
+			return NewEnvLogsCmd(agentClientFactory, nonIntSSHRunner, scpRunner, deps.FS, deps.Time, deps.UI).Run(*opts)
+		} else {
+			director, deployment := c.directorAndDeployment()
+			downloader := NewUIDownloader(director, deps.Time, deps.FS, deps.UI)
+			return NewLogsCmd(deployment, downloader, deps.UUIDGen, nonIntSSHRunner).Run(*opts)
+		}
 
 	case *SSHOpts:
 		sshProvider := boshssh.NewProvider(deps.CmdRunner, deps.FS, deps.UI, deps.Logger)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -379,8 +379,14 @@ func (c Cmd) Execute() (cmdErr error) {
 		intSSHRunner := sshProvider.NewSSHRunner(true)
 		nonIntSSHRunner := sshProvider.NewSSHRunner(false)
 		resultsSSHRunner := sshProvider.NewResultsSSHRunner(false)
-		sshHostBuilder := boshssh.NewHostBuilder()
-		return NewSSHCmd(deps.UUIDGen, intSSHRunner, nonIntSSHRunner, resultsSSHRunner, deps.UI, sshHostBuilder).Run(*opts, c.getDeployment)
+
+		if opts.TargetDirector {
+			agentClientFactory := bihttpagent.NewAgentClientFactory(1*time.Second, deps.Logger)
+			return NewEnvSSHCmd(agentClientFactory, intSSHRunner, nonIntSSHRunner, resultsSSHRunner, deps.UI).Run(*opts)
+		} else {
+			sshHostBuilder := boshssh.NewHostBuilder()
+			return NewSSHCmd(intSSHRunner, nonIntSSHRunner, resultsSSHRunner, deps.UI, sshHostBuilder).Run(*opts, c.getDeployment)
+		}
 
 	case *SCPOpts:
 		sshProvider := boshssh.NewProvider(deps.CmdRunner, deps.FS, deps.UI, deps.Logger)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -391,8 +391,14 @@ func (c Cmd) Execute() (cmdErr error) {
 	case *SCPOpts:
 		sshProvider := boshssh.NewProvider(deps.CmdRunner, deps.FS, deps.UI, deps.Logger)
 		scpRunner := sshProvider.NewSCPRunner()
-		sshHostBuilder := boshssh.NewHostBuilder()
-		return NewSCPCmd(deps.UUIDGen, scpRunner, deps.UI, sshHostBuilder).Run(*opts, c.getDeployment)
+
+		if opts.TargetDirector {
+			agentClientFactory := bihttpagent.NewAgentClientFactory(1*time.Second, deps.Logger)
+			return NewEnvSCPCmd(agentClientFactory, scpRunner).Run(*opts)
+		} else {
+			sshHostBuilder := boshssh.NewHostBuilder()
+			return NewSCPCmd(scpRunner, sshHostBuilder).Run(*opts, c.getDeployment)
+		}
 
 	case *ExportReleaseOpts:
 		director, deployment := c.directorAndDeployment()

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -186,6 +187,10 @@ func NewEnvLogsCmd(
 }
 
 func (c EnvLogsCmd) Run(opts LogsOpts) error {
+	if opts.Endpoint == "" || opts.Certificate == "" {
+		return errors.New("the --director flag requires both the --agent-endpoint and --agent-certificate flags to be set")
+	}
+
 	agentClient, err := c.agentClientFactory.NewAgentClient("bosh-cli", opts.Endpoint, opts.Certificate)
 	if err != nil {
 		return err

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -79,12 +79,12 @@ var _ = Describe("Logs", func() {
 
 					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
-				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
-				Expect(filters).To(BeEmpty())
-				Expect(agent).To(BeFalse())
-				Expect(system).To(BeFalse())
-				Expect(all).To(BeFalse())
+					slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
+					Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+					Expect(filters).To(BeEmpty())
+					Expect(agent).To(BeFalse())
+					Expect(system).To(BeFalse())
+					Expect(all).To(BeFalse())
 
 					Expect(downloader.DownloadCallCount()).To(Equal(1))
 
@@ -106,51 +106,51 @@ var _ = Describe("Logs", func() {
 
 					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
-				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
-				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
-				Expect(agent).To(BeTrue())
-				Expect(system).To(BeFalse())
-				Expect(all).To(BeFalse())
-			})
+					slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
+					Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+					Expect(filters).To(Equal([]string{"filter1", "filter2"}))
+					Expect(agent).To(BeTrue())
+					Expect(system).To(BeFalse())
+					Expect(all).To(BeFalse())
+				})
 
-			It("fetches system logs and allows custom filters", func() {
-				opts.Filters = []string{"filter1", "filter2"}
-				opts.System = true
+				It("fetches system logs and allows custom filters", func() {
+					opts.Filters = []string{"filter1", "filter2"}
+					opts.System = true
 
-				deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
+					deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
 
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
-				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
-				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
-				Expect(agent).To(BeFalse())
-				Expect(system).To(BeTrue())
-				Expect(all).To(BeFalse())
-			})
+					slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
+					Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+					Expect(filters).To(Equal([]string{"filter1", "filter2"}))
+					Expect(agent).To(BeFalse())
+					Expect(system).To(BeTrue())
+					Expect(all).To(BeFalse())
+				})
 
-			It("fetches all logs and allows custom filters", func() {
-				opts.Filters = []string{"filter1", "filter2"}
-				opts.All = true
+				It("fetches all logs and allows custom filters", func() {
+					opts.Filters = []string{"filter1", "filter2"}
+					opts.All = true
 
-				deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
+					deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
 
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
-				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
-				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
-				Expect(agent).To(BeFalse())
-				Expect(system).To(BeFalse())
-				Expect(all).To(BeTrue())
-			})
+					slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
+					Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+					Expect(filters).To(Equal([]string{"filter1", "filter2"}))
+					Expect(agent).To(BeFalse())
+					Expect(system).To(BeFalse())
+					Expect(all).To(BeTrue())
+				})
 
 				It("fetches logs for more than one instance", func() {
 					opts.Args.Slug = boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")
@@ -405,359 +405,405 @@ var _ = Describe("Logs", func() {
 				opts LogsOpts
 			)
 
-			BeforeEach(func() {
-				opts = LogsOpts{
-					CreateEnvAuthFlags: CreateEnvAuthFlags{
-						TargetDirector: true,
-						Endpoint:       "https:///foo:bar@10.0.0.5",
-						Certificate:    "some-cert",
-					},
-					GatewayFlags: GatewayFlags{UUIDGen: uuidGen},
-				}
-
-				uuidGen.GeneratedUUID = UUID
-
-				agentClientFactory.EXPECT().NewAgentClient(
-					gomock.Eq("bosh-cli"),
-					gomock.Eq("https:///foo:bar@10.0.0.5"),
-					gomock.Eq("some-cert"),
-				).Return(agentClient, nil).Times(1)
-			})
-
-			It("returns an error if generating SSH options fails", func() {
-				uuidGen.GenerateError = errors.New("fake-err")
-
-				err := command.Run(opts)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
-
-			It("returns an error if setting up SSH access fails", func() {
-				agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, errors.New("fake-ssh-err"))
-
-				err := command.Run(opts)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-ssh-err"))
-			})
-
-			Context("tailing logs", func() {
+			Context("neither the endpoint or certificate flag is set", func() {
 				BeforeEach(func() {
-					opts.Follow = true
+					opts = LogsOpts{
+						CreateEnvAuthFlags: CreateEnvAuthFlags{
+							TargetDirector: true,
+						},
+					}
 				})
 
-				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
-					nonIntSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
-						agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(0)
-						return nil
+				It("errors", func() {
+					Expect(command.Run(opts)).To(MatchError("the --director flag requires both the --agent-endpoint and --agent-certificate flags to be set"))
+				})
+			})
+
+			Context("only the endpoint flag is set", func() {
+				BeforeEach(func() {
+					opts = LogsOpts{
+						CreateEnvAuthFlags: CreateEnvAuthFlags{
+							TargetDirector: true,
+							Endpoint:       "https:///foo:bar@10.0.0.5",
+						},
+					}
+				})
+
+				It("errors", func() {
+					Expect(command.Run(opts)).To(MatchError("the --director flag requires both the --agent-endpoint and --agent-certificate flags to be set"))
+				})
+			})
+
+			Context("only the certificate flag is set", func() {
+				BeforeEach(func() {
+					opts = LogsOpts{
+						CreateEnvAuthFlags: CreateEnvAuthFlags{
+							TargetDirector: true,
+							Certificate:    "some-cert",
+						},
+					}
+				})
+
+				It("errors", func() {
+					Expect(command.Run(opts)).To(MatchError("the --director flag requires both the --agent-endpoint and --agent-certificate flags to be set"))
+				})
+			})
+
+			Context("the endpoint and certificate flags are set", func() {
+				BeforeEach(func() {
+					opts = LogsOpts{
+						CreateEnvAuthFlags: CreateEnvAuthFlags{
+							TargetDirector: true,
+							Endpoint:       "https:///foo:bar@10.0.0.5",
+							Certificate:    "some-cert",
+						},
+						GatewayFlags: GatewayFlags{UUIDGen: uuidGen},
 					}
 
-					agentClient.EXPECT().SetUpSSH(gomock.Eq(ExpUsername), mocks.GomegaMock(ContainSubstring("ssh-rsa AAAA"))).
-						Times(1)
-					agentClient.EXPECT().CleanUpSSH(gomock.Eq(ExpUsername)).
-						Times(1)
+					uuidGen.GeneratedUUID = UUID
 
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+					agentClientFactory.EXPECT().NewAgentClient(
+						gomock.Eq("bosh-cli"),
+						gomock.Eq("https:///foo:bar@10.0.0.5"),
+						gomock.Eq("some-cert"),
+					).Return(agentClient, nil).Times(1)
 				})
 
-				It("runs non-interactive SSH session with flags, and basic tail -f command that tails all logs", func() {
-					result := agentclient.SSHResult{
-						Command:       "setup",
-						Status:        "success",
-						Ip:            "10.0.0.5",
-						HostPublicKey: "some-public-key",
-					}
-					agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(result, nil)
-					agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+				It("returns an error if generating SSH options fails", func() {
+					uuidGen.GenerateError = errors.New("fake-err")
 
-					opts.GatewayFlags.Disable = true
-					opts.GatewayFlags.Username = "gw-username"
-					opts.GatewayFlags.Host = "gw-host"
-					opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
-					opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
-
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
-
-					runConnOpts, runResult, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-					Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
-					Expect(runConnOpts.GatewayDisable).To(Equal(true))
-					Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
-					Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
-					Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
-					Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
-					Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Username: ExpUsername, Host: "10.0.0.5", HostPublicKey: "some-public-key", Job: "create-env-vm", IndexOrID: "0"}}}))
-					Expect(runCommand).To(Equal([]string{"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
 				})
 
-				Context("tail options", func() {
+				It("returns an error if setting up SSH access fails", func() {
+					agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, errors.New("fake-ssh-err"))
+
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-ssh-err"))
+				})
+
+				Context("tailing logs", func() {
+					BeforeEach(func() {
+						opts.Follow = true
+					})
+
+					It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+						nonIntSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
+							agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(0)
+							return nil
+						}
+
+						agentClient.EXPECT().SetUpSSH(gomock.Eq(ExpUsername), mocks.GomegaMock(ContainSubstring("ssh-rsa AAAA"))).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Eq(ExpUsername)).
+							Times(1)
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+					})
+
+					It("runs non-interactive SSH session with flags, and basic tail -f command that tails all logs", func() {
+						result := agentclient.SSHResult{
+							Command:       "setup",
+							Status:        "success",
+							Ip:            "10.0.0.5",
+							HostPublicKey: "some-public-key",
+						}
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(result, nil)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+
+						opts.GatewayFlags.Disable = true
+						opts.GatewayFlags.Username = "gw-username"
+						opts.GatewayFlags.Host = "gw-host"
+						opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+						opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+
+						runConnOpts, runResult, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+						Expect(runConnOpts.GatewayDisable).To(Equal(true))
+						Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+						Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+						Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+						Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
+						Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Username: ExpUsername, Host: "10.0.0.5", HostPublicKey: "some-public-key", Job: "create-env-vm", IndexOrID: "0"}}}))
+						Expect(runCommand).To(Equal([]string{"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+					})
+
+					Context("tail options", func() {
+						BeforeEach(func() {
+							agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, nil).Times(1)
+							agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+						})
+
+						It("runs tail command with specified number of lines and quiet option", func() {
+							opts.Num = 10
+							opts.Quiet = true
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+							_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+							Expect(runCommand).To(Equal([]string{
+								"sudo", "bash", "-c", "'exec tail -F -n 10 -q /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+						})
+
+						It("runs tail command with specified number of lines even if following is not requested", func() {
+							opts.Follow = false
+							opts.Num = 10
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+							_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+							Expect(runCommand).To(Equal([]string{
+								"sudo", "bash", "-c", "'exec tail -n 10 /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+						})
+
+						It("runs tail command for the agent log if agent is specified", func() {
+							opts.Agent = true
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+							_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+							Expect(runCommand).To(Equal([]string{
+								"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current'"}))
+						})
+
+						It("runs tail command with jobs filters if specified", func() {
+							opts.Jobs = []string{"job1", "job2"}
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+							_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+							Expect(runCommand).To(Equal([]string{
+								"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/job1/*.log /var/vcap/sys/log/job2/*.log'"}))
+						})
+
+						It("runs tail command with custom filters if specified", func() {
+							opts.Filters = []string{"other/*.log", "**/*.log"}
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+							_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+							Expect(runCommand).To(Equal([]string{
+								"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
+						})
+
+						It("runs tail command with agent log, and custom filters", func() {
+							opts.Agent = true
+							opts.Filters = []string{"other/*.log", "**/*.log"}
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+							_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+							Expect(runCommand).To(Equal([]string{
+								"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
+						})
+
+						It("returns error if non-interactive SSH session errors", func() {
+							nonIntSSHRunner.RunReturns(errors.New("fake-err"))
+
+							err := command.Run(opts)
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-err"))
+						})
+
+						It("does not try to fetch logs", func() {
+							agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
+						})
+					})
+				})
+
+				Context("fetching logs", func() {
+					const emptyFileSHA512 string = "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+					var (
+						bundleResult agentclient.BundleLogsResult
+					)
+
 					BeforeEach(func() {
 						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, nil).Times(1)
 						agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+
+						bundleResult = agentclient.BundleLogsResult{
+							LogsTarPath:  "/foo/bar",
+							SHA512Digest: emptyFileSHA512,
+						}
 					})
 
-					It("runs tail command with specified number of lines and quiet option", func() {
-						opts.Num = 10
-						opts.Quiet = true
+					It("bundles logs for jobs by default", func() {
+						agentClient.EXPECT().BundleLogs(
+							gomock.Eq(ExpUsername),
+							gomock.Eq("job"),
+							mocks.GomegaMock(HaveLen(0)),
+						).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
 						Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-						Expect(runCommand).To(Equal([]string{
-							"sudo", "bash", "-c", "'exec tail -F -n 10 -q /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
 					})
 
-					It("runs tail command with specified number of lines even if following is not requested", func() {
-						opts.Follow = false
-						opts.Num = 10
-
-						Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-						Expect(runCommand).To(Equal([]string{
-							"sudo", "bash", "-c", "'exec tail -n 10 /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
-					})
-
-					It("runs tail command for the agent log if agent is specified", func() {
+					It("bundles agent logs and allows custom filters", func() {
+						opts.Filters = []string{"filter1", "filter2"}
 						opts.Agent = true
 
-						Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-						Expect(runCommand).To(Equal([]string{
-							"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current'"}))
-					})
-
-					It("runs tail command with jobs filters if specified", func() {
-						opts.Jobs = []string{"job1", "job2"}
-
-						Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-						Expect(runCommand).To(Equal([]string{
-							"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/job1/*.log /var/vcap/sys/log/job2/*.log'"}))
-					})
-
-					It("runs tail command with custom filters if specified", func() {
-						opts.Filters = []string{"other/*.log", "**/*.log"}
+						agentClient.EXPECT().BundleLogs(
+							gomock.Eq(ExpUsername),
+							gomock.Eq("agent"),
+							gomock.Eq([]string{"filter1", "filter2"}),
+						).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
 						Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-						Expect(runCommand).To(Equal([]string{
-							"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
 					})
 
-					It("runs tail command with agent log, and custom filters", func() {
-						opts.Agent = true
-						opts.Filters = []string{"other/*.log", "**/*.log"}
-
-						Expect(command.Run(opts)).ToNot(HaveOccurred())
-
-						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-						Expect(runCommand).To(Equal([]string{
-							"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
-					})
-
-					It("returns error if non-interactive SSH session errors", func() {
-						nonIntSSHRunner.RunReturns(errors.New("fake-err"))
+					It("returns error if bundling logs failed", func() {
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).Return(agentclient.BundleLogsResult{}, errors.New("fake-logs-err"))
 
 						err := command.Run(opts)
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring("fake-err"))
+						Expect(err.Error()).To(ContainSubstring("fake-logs-err"))
 					})
 
-					It("does not try to fetch logs", func() {
-						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+					It("uses scp to download the log bundle", func() {
+						fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
+						fs.ReturnTempFile = fakeFile
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
 						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(scpRunner.RunCallCount()).To(Equal(1))
+						_, _, scpArgs := scpRunner.RunArgsForCall(0)
+						slug, err := scpArgs.AllOrInstanceGroupOrInstanceSlug()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(slug.String()).To(Equal("create-env-vm/0"))
+						scpHost := boshdir.Host{Username: ExpUsername, Host: "10.0.0.5", Job: "create-env-vm", IndexOrID: "0"}
+						Expect(scpArgs.ForHost(scpHost)).To(HaveExactElements(fmt.Sprintf("%s@10.0.0.5:/foo/bar", ExpUsername), "/tmp/baz"))
+
+						Expect(ui.Said).To(ContainElement("Downloading create-env-vm/0 logs to 'create-env-vm-logs-20091110-230102-000000333.tgz'..."))
 					})
-				})
-			})
 
-			Context("fetching logs", func() {
-				const emptyFileSHA512 string = "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
-				var (
-					bundleResult agentclient.BundleLogsResult
-				)
+					It("returns error if scp fails", func() {
+						scpRunner.RunReturns(errors.New("fake-scp-error"))
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
-				BeforeEach(func() {
-					agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, nil).Times(1)
-					agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+						err := command.Run(opts)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("Running SCP"))
+						Expect(err.Error()).To(ContainSubstring("fake-scp-err"))
+					})
 
-					bundleResult = agentclient.BundleLogsResult{
-						LogsTarPath:  "/foo/bar",
-						SHA512Digest: emptyFileSHA512,
-					}
-				})
+					It("returns error if parsing the sha fails", func() {
+						bundleResult.SHA512Digest = "garbage can"
 
-				It("bundles logs for jobs by default", func() {
-					agentClient.EXPECT().BundleLogs(
-						gomock.Eq(ExpUsername),
-						gomock.Eq("job"),
-						mocks.GomegaMock(HaveLen(0)),
-					).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
-				})
+						err := command.Run(opts)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("Unable to parse digest string"))
+					})
 
-				It("bundles agent logs and allows custom filters", func() {
-					opts.Filters = []string{"filter1", "filter2"}
-					opts.Agent = true
+					It("returns error if verifying the log file sha fails", func() {
+						fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
+						fakeFile.Write([]byte("not empty anymore!")) //nolint:errcheck
+						fs.ReturnTempFile = fakeFile
 
-					agentClient.EXPECT().BundleLogs(
-						gomock.Eq(ExpUsername),
-						gomock.Eq("agent"),
-						gomock.Eq([]string{"filter1", "filter2"}),
-					).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
-				})
+						err := command.Run(opts)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("Expected stream to have digest"))
+					})
 
-				It("returns error if bundling logs failed", func() {
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).Return(agentclient.BundleLogsResult{}, errors.New("fake-logs-err"))
+					It("Respects the path arg", func() {
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
+						opts.Directory.Path = "/hey/hello"
+						fs.MkdirAll("/hey/hello", os.FileMode(0777)) //nolint:errcheck
+						fs.ReturnTempFilesByPrefix = map[string]boshsys.File{
+							"bosh-cli-scp-download": fakes.NewFakeFile("/tmp/baz", fs),
+						}
+						fs.RenameStub = func(oldPath, newPath string) error {
+							Expect(oldPath).To(Equal("/tmp/baz"))
+							Expect(newPath).To(Equal("/hey/hello/create-env-vm-logs-20091110-230102-000000333.tgz"))
 
-					err := command.Run(opts)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-logs-err"))
-				})
+							return nil
+						}
 
-				It("uses scp to download the log bundle", func() {
-					fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
-					fs.ReturnTempFile = fakeFile
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+						Expect(ui.Said).To(ContainElement("Downloading create-env-vm/0 logs to '/hey/hello/create-env-vm-logs-20091110-230102-000000333.tgz'..."))
+					})
 
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
+					It("returns error if closing temp file fails", func() {
+						fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
+						fakeFile.CloseErr = errors.New("fake-close-error")
+						fs.ReturnTempFile = fakeFile
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
-					Expect(scpRunner.RunCallCount()).To(Equal(1))
-					_, _, scpArgs := scpRunner.RunArgsForCall(0)
-					slug, err := scpArgs.AllOrInstanceGroupOrInstanceSlug()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(slug.String()).To(Equal("create-env-vm/0"))
-					scpHost := boshdir.Host{Username: ExpUsername, Host: "10.0.0.5", Job: "create-env-vm", IndexOrID: "0"}
-					Expect(scpArgs.ForHost(scpHost)).To(HaveExactElements(fmt.Sprintf("%s@10.0.0.5:/foo/bar", ExpUsername), "/tmp/baz"))
+						err := command.Run(opts)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-close-err"))
+					})
 
-					Expect(ui.Said).To(ContainElement("Downloading create-env-vm/0 logs to 'create-env-vm-logs-20091110-230102-000000333.tgz'..."))
-				})
+					It("returns error if moving file fails", func() {
+						fs.RenameError = errors.New("fake-rename-error")
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
-				It("returns error if scp fails", func() {
-					scpRunner.RunReturns(errors.New("fake-scp-error"))
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
+						err := command.Run(opts)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("Moving to final destination"))
+						Expect(err.Error()).To(ContainSubstring("fake-rename-err"))
+					})
 
-					err := command.Run(opts)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("Running SCP"))
-					Expect(err.Error()).To(ContainSubstring("fake-scp-err"))
-				})
+					It("does not try to tail logs", func() {
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(bundleResult, nil).
+							Times(1)
+						agentClient.EXPECT().RemoveFile(gomock.Any()).
+							Times(1)
 
-				It("returns error if parsing the sha fails", func() {
-					bundleResult.SHA512Digest = "garbage can"
-
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
-
-					err := command.Run(opts)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("Unable to parse digest string"))
-				})
-
-				It("returns error if verifying the log file sha fails", func() {
-					fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
-					fakeFile.Write([]byte("not empty anymore!")) //nolint:errcheck
-					fs.ReturnTempFile = fakeFile
-
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
-
-					err := command.Run(opts)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("Expected stream to have digest"))
-				})
-
-				It("Respects the path arg", func() {
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
-					opts.Directory.Path = "/hey/hello"
-					fs.MkdirAll("/hey/hello", os.FileMode(0777)) //nolint:errcheck
-					fs.ReturnTempFilesByPrefix = map[string]boshsys.File{
-						"bosh-cli-scp-download": fakes.NewFakeFile("/tmp/baz", fs),
-					}
-					fs.RenameStub = func(oldPath, newPath string) error {
-						Expect(oldPath).To(Equal("/tmp/baz"))
-						Expect(newPath).To(Equal("/hey/hello/create-env-vm-logs-20091110-230102-000000333.tgz"))
-
-						return nil
-					}
-
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
-					Expect(ui.Said).To(ContainElement("Downloading create-env-vm/0 logs to '/hey/hello/create-env-vm-logs-20091110-230102-000000333.tgz'..."))
-				})
-
-				It("returns error if closing temp file fails", func() {
-					fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
-					fakeFile.CloseErr = errors.New("fake-close-error")
-					fs.ReturnTempFile = fakeFile
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
-
-					err := command.Run(opts)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-close-err"))
-				})
-
-				It("returns error if moving file fails", func() {
-					fs.RenameError = errors.New("fake-rename-error")
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
-
-					err := command.Run(opts)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("Moving to final destination"))
-					Expect(err.Error()).To(ContainSubstring("fake-rename-err"))
-				})
-
-				It("does not try to tail logs", func() {
-					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(bundleResult, nil).
-						Times(1)
-					agentClient.EXPECT().RemoveFile(gomock.Any()).
-						Times(1)
-
-					Expect(command.Run(opts)).ToNot(HaveOccurred())
-					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+					})
 				})
 			})
 		})

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -2,69 +2,82 @@ package cmd_test
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"time"
 
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/clock/fakeclock"
+	"github.com/cloudfoundry/bosh-agent/agentclient"
+	mockhttpagent "github.com/cloudfoundry/bosh-agent/agentclient/http/mocks"
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
+	"github.com/cloudfoundry/bosh-utils/system/fakes"
 	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mockagentclient "github.com/cloudfoundry/bosh-cli/v7/agentclient/mocks"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd"
 	fakecmd "github.com/cloudfoundry/bosh-cli/v7/cmd/cmdfakes"
+	"github.com/cloudfoundry/bosh-cli/v7/cmd/mocks"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/v7/director/directorfakes"
 	boshssh "github.com/cloudfoundry/bosh-cli/v7/ssh"
 	fakessh "github.com/cloudfoundry/bosh-cli/v7/ssh/sshfakes"
+	fakeui "github.com/cloudfoundry/bosh-cli/v7/ui/fakes"
 )
 
-var _ = Describe("LogsCmd", func() {
+var _ = Describe("Logs", func() {
 	const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
 	const ExpUsername = "bosh_8c5ff117957245c"
 
-	var (
-		deployment      *fakedir.FakeDeployment
-		downloader      *fakecmd.FakeDownloader
-		uuidGen         *fakeuuid.FakeGenerator
-		nonIntSSHRunner *fakessh.FakeRunner
-		command         LogsCmd
-	)
-
-	BeforeEach(func() {
-		deployment = &fakedir.FakeDeployment{
-			NameStub: func() string { return "dep" },
-		}
-		downloader = &fakecmd.FakeDownloader{}
-		uuidGen = &fakeuuid.FakeGenerator{}
-		nonIntSSHRunner = &fakessh.FakeRunner{}
-		command = NewLogsCmd(deployment, downloader, uuidGen, nonIntSSHRunner)
-	})
-
-	Describe("Run", func() {
-
+	Describe("LogsCmd", func() {
 		var (
-			opts LogsOpts
+			deployment      *fakedir.FakeDeployment
+			downloader      *fakecmd.FakeDownloader
+			uuidGen         *fakeuuid.FakeGenerator
+			nonIntSSHRunner *fakessh.FakeRunner
+			command         LogsCmd
 		)
 
 		BeforeEach(func() {
-			opts = LogsOpts{
-				Args: AllOrInstanceGroupOrInstanceSlugArgs{
-					Slug: boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index"),
-				},
-
-				Directory: DirOrCWDArg{Path: "/fake-dir"},
+			deployment = &fakedir.FakeDeployment{
+				NameStub: func() string { return "dep" },
 			}
+			downloader = &fakecmd.FakeDownloader{}
+			uuidGen = &fakeuuid.FakeGenerator{}
+			nonIntSSHRunner = &fakessh.FakeRunner{}
+			command = NewLogsCmd(deployment, downloader, uuidGen, nonIntSSHRunner)
 		})
 
-		act := func() error { return command.Run(opts) }
+		Describe("Run", func() {
+			var (
+				opts LogsOpts
+			)
 
-		Context("when fetching logs (not tailing)", func() {
-			It("fetches logs for a given instance", func() {
-				result := boshdir.LogsResult{BlobstoreID: "blob-id", SHA1: "sha1"}
-				deployment.FetchLogsReturns(result, nil)
+			BeforeEach(func() {
+				opts = LogsOpts{
+					Args: AllOrInstanceGroupOrInstanceSlugArgs{
+						Slug: boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index"),
+					},
 
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
+					Directory: DirOrCWDArg{Path: "/fake-dir"},
+				}
+			})
 
-				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+			act := func() error { return command.Run(opts) }
+
+			Context("when fetching logs (not tailing)", func() {
+				It("fetches logs for a given instance", func() {
+					result := boshdir.LogsResult{BlobstoreID: "blob-id", SHA1: "sha1"}
+					deployment.FetchLogsReturns(result, nil)
+
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
 				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
 				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
@@ -73,25 +86,25 @@ var _ = Describe("LogsCmd", func() {
 				Expect(system).To(BeFalse())
 				Expect(all).To(BeFalse())
 
-				Expect(downloader.DownloadCallCount()).To(Equal(1))
+					Expect(downloader.DownloadCallCount()).To(Equal(1))
 
-				blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
-				Expect(blobID).To(Equal("blob-id"))
-				Expect(sha1).To(Equal("sha1"))
-				Expect(prefix).To(Equal("dep.job.index"))
-				Expect(dstDirPath).To(Equal("/fake-dir"))
-			})
+					blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
+					Expect(blobID).To(Equal("blob-id"))
+					Expect(sha1).To(Equal("sha1"))
+					Expect(prefix).To(Equal("dep.job.index"))
+					Expect(dstDirPath).To(Equal("/fake-dir"))
+				})
 
-			It("fetches agent logs and allows custom filters", func() {
-				opts.Filters = []string{"filter1", "filter2"}
-				opts.Agent = true
+				It("fetches agent logs and allows custom filters", func() {
+					opts.Filters = []string{"filter1", "filter2"}
+					opts.Agent = true
 
-				deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
+					deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
 
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
 				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
 				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
@@ -139,212 +152,613 @@ var _ = Describe("LogsCmd", func() {
 				Expect(all).To(BeTrue())
 			})
 
-			It("fetches logs for more than one instance", func() {
-				opts.Args.Slug = boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")
+				It("fetches logs for more than one instance", func() {
+					opts.Args.Slug = boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")
 
-				result := boshdir.LogsResult{BlobstoreID: "blob-id", SHA1: "sha1"}
-				deployment.FetchLogsReturns(result, nil)
+					result := boshdir.LogsResult{BlobstoreID: "blob-id", SHA1: "sha1"}
+					deployment.FetchLogsReturns(result, nil)
 
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+					Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				Expect(downloader.DownloadCallCount()).To(Equal(1))
+					Expect(downloader.DownloadCallCount()).To(Equal(1))
 
-				blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
-				Expect(blobID).To(Equal("blob-id"))
-				Expect(sha1).To(Equal("sha1"))
-				Expect(prefix).To(Equal("dep"))
-				Expect(dstDirPath).To(Equal("/fake-dir"))
+					blobID, sha1, prefix, dstDirPath := downloader.DownloadArgsForCall(0)
+					Expect(blobID).To(Equal("blob-id"))
+					Expect(sha1).To(Equal("sha1"))
+					Expect(prefix).To(Equal("dep"))
+					Expect(dstDirPath).To(Equal("/fake-dir"))
+				})
+
+				It("returns error if fetching logs failed", func() {
+					deployment.FetchLogsReturns(boshdir.LogsResult{}, errors.New("fake-err"))
+
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("returns error if downloading release failed", func() {
+					downloader.DownloadReturns(errors.New("fake-err"))
+
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("does not try to tail logs", func() {
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+				})
 			})
 
-			It("returns error if fetching logs failed", func() {
-				deployment.FetchLogsReturns(boshdir.LogsResult{}, errors.New("fake-err"))
+			Context("when tailing logs (or specifying number of lines)", func() {
 
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
+				BeforeEach(func() {
+					opts.Follow = true
+					opts.GatewayFlags.UUIDGen = uuidGen
+					uuidGen.GeneratedUUID = UUID
+				})
 
-			It("returns error if downloading release failed", func() {
-				downloader.DownloadReturns(errors.New("fake-err"))
+				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+					nonIntSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
+						Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
+						return nil
+					}
+					Expect(act()).ToNot(HaveOccurred())
 
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
+					Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+					Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
 
-			It("does not try to tail logs", func() {
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+					setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
+					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+					Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
+					Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
+
+					slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
+					Expect(slug).To(Equal(setupSlug))
+					Expect(sshOpts).To(Equal(setupSSHOpts))
+				})
+
+				It("sets up SSH access for more than one instance", func() {
+					opts.Args.Slug = boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")
+
+					Expect(act()).ToNot(HaveOccurred())
+
+					setupSlug, _ := deployment.SetUpSSHArgsForCall(0)
+					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")))
+				})
+
+				It("runs non-interactive SSH", func() {
+					Expect(act()).ToNot(HaveOccurred())
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+				})
+
+				It("returns an error if generating SSH options fails", func() {
+					uuidGen.GenerateError = errors.New("fake-err")
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("returns an error if setting up SSH access fails", func() {
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("runs non-interactive SSH session with flags, and basic tail -f command that tails all logs", func() {
+					result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
+					deployment.SetUpSSHReturns(result, nil)
+
+					opts.GatewayFlags.Disable = true
+					opts.GatewayFlags.Username = "gw-username"
+					opts.GatewayFlags.Host = "gw-host"
+					opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+					opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
+
+					Expect(act()).ToNot(HaveOccurred())
+
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+
+					runConnOpts, runResult, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+					Expect(runConnOpts.GatewayDisable).To(Equal(true))
+					Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+					Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+					Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+					Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
+					Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
+					Expect(runCommand).To(Equal([]string{"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+				})
+
+				It("runs tail command with specified number of lines and quiet option", func() {
+					opts.Num = 10
+					opts.Quiet = true
+
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
+					Expect(act()).ToNot(HaveOccurred())
+
+					_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal([]string{
+						"sudo", "bash", "-c", "'exec tail -F -n 10 -q /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+				})
+
+				It("runs tail command with specified number of lines even if following is not requested", func() {
+					opts.Follow = false
+					opts.Num = 10
+
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
+					Expect(act()).ToNot(HaveOccurred())
+
+					_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal([]string{
+						"sudo", "bash", "-c", "'exec tail -n 10 /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+				})
+
+				It("runs tail command for the agent log if agent is specified", func() {
+					opts.Agent = true
+
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
+					Expect(act()).ToNot(HaveOccurred())
+
+					_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal([]string{
+						"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current'"}))
+				})
+
+				It("runs tail command with jobs filters if specified", func() {
+					opts.Jobs = []string{"job1", "job2"}
+
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
+					Expect(act()).ToNot(HaveOccurred())
+
+					_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal([]string{
+						"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/job1/*.log /var/vcap/sys/log/job2/*.log'"}))
+				})
+
+				It("runs tail command with custom filters if specified", func() {
+					opts.Filters = []string{"other/*.log", "**/*.log"}
+
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
+					Expect(act()).ToNot(HaveOccurred())
+
+					_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal([]string{
+						"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
+				})
+
+				It("runs tail command with agent log, and custom filters", func() {
+					opts.Agent = true
+					opts.Filters = []string{"other/*.log", "**/*.log"}
+
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
+					Expect(act()).ToNot(HaveOccurred())
+
+					_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal([]string{
+						"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
+				})
+
+				It("returns error if non-interactive SSH session errors", func() {
+					nonIntSSHRunner.RunReturns(errors.New("fake-err"))
+
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("does not try to fetch logs", func() {
+					err := act()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deployment.FetchLogsCallCount()).To(Equal(0))
+				})
 			})
 		})
+	})
 
-		Context("when tailing logs (or specifying number of lines)", func() {
+	Describe("EnvLogsCmd", func() {
+		var (
+			mockCtrl *gomock.Controller
+
+			agentClientFactory *mockhttpagent.MockAgentClientFactory
+			agentClient        *mockagentclient.MockAgentClient
+			nonIntSSHRunner    *fakessh.FakeRunner
+			scpRunner          *fakessh.FakeSCPRunner
+			fs                 *fakes.FakeFileSystem
+			timeService        clock.Clock
+			ui                 *fakeui.FakeUI
+
+			uuidGen *fakeuuid.FakeGenerator
+
+			command EnvLogsCmd
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+
+			agentClient = mockagentclient.NewMockAgentClient(mockCtrl)
+			agentClientFactory = mockhttpagent.NewMockAgentClientFactory(mockCtrl)
+			nonIntSSHRunner = &fakessh.FakeRunner{}
+			scpRunner = &fakessh.FakeSCPRunner{}
+			fs = fakes.NewFakeFileSystem()
+			timeService = fakeclock.NewFakeClock(time.Date(2009, time.November, 10, 23, 1, 2, 333, time.UTC))
+			ui = &fakeui.FakeUI{}
+
+			uuidGen = &fakeuuid.FakeGenerator{}
+
+			command = NewEnvLogsCmd(agentClientFactory, nonIntSSHRunner, scpRunner, fs, timeService, ui)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		Describe("Run", func() {
+			var (
+				opts LogsOpts
+			)
 
 			BeforeEach(func() {
-				opts.Follow = true
-				opts.GatewayFlags.UUIDGen = uuidGen
-				uuidGen.GeneratedUUID = UUID
-			})
-
-			It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
-				nonIntSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
-					Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
-					return nil
+				opts = LogsOpts{
+					CreateEnvAuthFlags: CreateEnvAuthFlags{
+						TargetDirector: true,
+						Endpoint:       "https:///foo:bar@10.0.0.5",
+						Certificate:    "some-cert",
+					},
+					GatewayFlags: GatewayFlags{UUIDGen: uuidGen},
 				}
-				Expect(act()).ToNot(HaveOccurred())
 
-				Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
-				Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
-				Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
+				uuidGen.GeneratedUUID = UUID
 
-				setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
-				Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
-				Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
-				Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
-
-				slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
-				Expect(slug).To(Equal(setupSlug))
-				Expect(sshOpts).To(Equal(setupSSHOpts))
-			})
-
-			It("sets up SSH access for more than one instance", func() {
-				opts.Args.Slug = boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")
-
-				Expect(act()).ToNot(HaveOccurred())
-
-				setupSlug, _ := deployment.SetUpSSHArgsForCall(0)
-				Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("", "")))
-			})
-
-			It("runs non-interactive SSH", func() {
-				Expect(act()).ToNot(HaveOccurred())
-				Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+				agentClientFactory.EXPECT().NewAgentClient(
+					gomock.Eq("bosh-cli"),
+					gomock.Eq("https:///foo:bar@10.0.0.5"),
+					gomock.Eq("some-cert"),
+				).Return(agentClient, nil).Times(1)
 			})
 
 			It("returns an error if generating SSH options fails", func() {
 				uuidGen.GenerateError = errors.New("fake-err")
-				err := act()
+
+				err := command.Run(opts)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-err"))
 			})
 
 			It("returns an error if setting up SSH access fails", func() {
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
-				err := act()
+				agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, errors.New("fake-ssh-err"))
+
+				err := command.Run(opts)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
+				Expect(err.Error()).To(ContainSubstring("fake-ssh-err"))
 			})
 
-			It("runs non-interactive SSH session with flags, and basic tail -f command that tails all logs", func() {
-				result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
-				deployment.SetUpSSHReturns(result, nil)
+			Context("tailing logs", func() {
+				BeforeEach(func() {
+					opts.Follow = true
+				})
 
-				opts.GatewayFlags.Disable = true
-				opts.GatewayFlags.Username = "gw-username"
-				opts.GatewayFlags.Host = "gw-host"
-				opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
-				opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
+				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+					nonIntSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(0)
+						return nil
+					}
 
-				Expect(act()).ToNot(HaveOccurred())
+					agentClient.EXPECT().SetUpSSH(gomock.Eq(ExpUsername), mocks.GomegaMock(ContainSubstring("ssh-rsa AAAA"))).
+						Times(1)
+					agentClient.EXPECT().CleanUpSSH(gomock.Eq(ExpUsername)).
+						Times(1)
 
-				Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
 
-				runConnOpts, runResult, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
-				Expect(runConnOpts.GatewayDisable).To(Equal(true))
-				Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
-				Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
-				Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
-				Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
-				Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
-				Expect(runCommand).To(Equal([]string{"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+				})
+
+				It("runs non-interactive SSH session with flags, and basic tail -f command that tails all logs", func() {
+					result := agentclient.SSHResult{
+						Command:       "setup",
+						Status:        "success",
+						Ip:            "10.0.0.5",
+						HostPublicKey: "some-public-key",
+					}
+					agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(result, nil)
+					agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+
+					opts.GatewayFlags.Disable = true
+					opts.GatewayFlags.Username = "gw-username"
+					opts.GatewayFlags.Host = "gw-host"
+					opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+					opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
+
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+
+					runConnOpts, runResult, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+					Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+					Expect(runConnOpts.GatewayDisable).To(Equal(true))
+					Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+					Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+					Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+					Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
+					Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Username: ExpUsername, Host: "10.0.0.5", HostPublicKey: "some-public-key", Job: "create-env-vm", IndexOrID: "0"}}}))
+					Expect(runCommand).To(Equal([]string{"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+				})
+
+				Context("tail options", func() {
+					BeforeEach(func() {
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, nil).Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
+					})
+
+					It("runs tail command with specified number of lines and quiet option", func() {
+						opts.Num = 10
+						opts.Quiet = true
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal([]string{
+							"sudo", "bash", "-c", "'exec tail -F -n 10 -q /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+					})
+
+					It("runs tail command with specified number of lines even if following is not requested", func() {
+						opts.Follow = false
+						opts.Num = 10
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal([]string{
+							"sudo", "bash", "-c", "'exec tail -n 10 /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
+					})
+
+					It("runs tail command for the agent log if agent is specified", func() {
+						opts.Agent = true
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal([]string{
+							"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current'"}))
+					})
+
+					It("runs tail command with jobs filters if specified", func() {
+						opts.Jobs = []string{"job1", "job2"}
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal([]string{
+							"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/job1/*.log /var/vcap/sys/log/job2/*.log'"}))
+					})
+
+					It("runs tail command with custom filters if specified", func() {
+						opts.Filters = []string{"other/*.log", "**/*.log"}
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal([]string{
+							"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
+					})
+
+					It("runs tail command with agent log, and custom filters", func() {
+						opts.Agent = true
+						opts.Filters = []string{"other/*.log", "**/*.log"}
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal([]string{
+							"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
+					})
+
+					It("returns error if non-interactive SSH session errors", func() {
+						nonIntSSHRunner.RunReturns(errors.New("fake-err"))
+
+						err := command.Run(opts)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-err"))
+					})
+
+					It("does not try to fetch logs", func() {
+						agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+					})
+				})
 			})
 
-			It("runs tail command with specified number of lines and quiet option", func() {
-				opts.Num = 10
-				opts.Quiet = true
+			Context("fetching logs", func() {
+				const emptyFileSHA512 string = "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+				var (
+					bundleResult agentclient.BundleLogsResult
+				)
 
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
-				Expect(act()).ToNot(HaveOccurred())
+				BeforeEach(func() {
+					agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).Return(agentclient.SSHResult{}, nil).Times(1)
+					agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(1)
 
-				_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal([]string{
-					"sudo", "bash", "-c", "'exec tail -F -n 10 -q /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
-			})
+					bundleResult = agentclient.BundleLogsResult{
+						LogsTarPath:  "/foo/bar",
+						SHA512Digest: emptyFileSHA512,
+					}
+				})
 
-			It("runs tail command with specified number of lines even if following is not requested", func() {
-				opts.Follow = false
-				opts.Num = 10
+				It("bundles logs for jobs by default", func() {
+					agentClient.EXPECT().BundleLogs(
+						gomock.Eq(ExpUsername),
+						gomock.Eq("job"),
+						mocks.GomegaMock(HaveLen(0)),
+					).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
 
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
-				Expect(act()).ToNot(HaveOccurred())
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
+				})
 
-				_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal([]string{
-					"sudo", "bash", "-c", "'exec tail -n 10 /var/vcap/sys/log/**/*.log $(if [ -f /var/vcap/sys/log/*.log ]; then echo /var/vcap/sys/log/*.log ; fi)'"}))
-			})
+				It("bundles agent logs and allows custom filters", func() {
+					opts.Filters = []string{"filter1", "filter2"}
+					opts.Agent = true
 
-			It("runs tail command for the agent log if agent is specified", func() {
-				opts.Agent = true
+					agentClient.EXPECT().BundleLogs(
+						gomock.Eq(ExpUsername),
+						gomock.Eq("agent"),
+						gomock.Eq([]string{"filter1", "filter2"}),
+					).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
 
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
-				Expect(act()).ToNot(HaveOccurred())
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
+				})
 
-				_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal([]string{
-					"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current'"}))
-			})
+				It("returns error if bundling logs failed", func() {
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).Return(agentclient.BundleLogsResult{}, errors.New("fake-logs-err"))
 
-			It("runs tail command with jobs filters if specified", func() {
-				opts.Jobs = []string{"job1", "job2"}
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-logs-err"))
+				})
 
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
-				Expect(act()).ToNot(HaveOccurred())
+				It("uses scp to download the log bundle", func() {
+					fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
+					fs.ReturnTempFile = fakeFile
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
 
-				_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal([]string{
-					"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/job1/*.log /var/vcap/sys/log/job2/*.log'"}))
-			})
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
 
-			It("runs tail command with custom filters if specified", func() {
-				opts.Filters = []string{"other/*.log", "**/*.log"}
+					Expect(scpRunner.RunCallCount()).To(Equal(1))
+					_, _, scpArgs := scpRunner.RunArgsForCall(0)
+					slug, err := scpArgs.AllOrInstanceGroupOrInstanceSlug()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(slug.String()).To(Equal("create-env-vm/0"))
+					scpHost := boshdir.Host{Username: ExpUsername, Host: "10.0.0.5", Job: "create-env-vm", IndexOrID: "0"}
+					Expect(scpArgs.ForHost(scpHost)).To(HaveExactElements(fmt.Sprintf("%s@10.0.0.5:/foo/bar", ExpUsername), "/tmp/baz"))
 
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
-				Expect(act()).ToNot(HaveOccurred())
+					Expect(ui.Said).To(ContainElement("Downloading create-env-vm/0 logs to 'create-env-vm-logs-20091110-230102-000000333.tgz'..."))
+				})
 
-				_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal([]string{
-					"sudo", "bash", "-c", "'exec tail -F /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
-			})
+				It("returns error if scp fails", func() {
+					scpRunner.RunReturns(errors.New("fake-scp-error"))
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
 
-			It("runs tail command with agent log, and custom filters", func() {
-				opts.Agent = true
-				opts.Filters = []string{"other/*.log", "**/*.log"}
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Running SCP"))
+					Expect(err.Error()).To(ContainSubstring("fake-scp-err"))
+				})
 
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, nil)
-				Expect(act()).ToNot(HaveOccurred())
+				It("returns error if parsing the sha fails", func() {
+					bundleResult.SHA512Digest = "garbage can"
 
-				_, _, runCommand := nonIntSSHRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal([]string{
-					"sudo", "bash", "-c", "'exec tail -F /var/vcap/bosh/log/current /var/vcap/sys/log/other/*.log /var/vcap/sys/log/**/*.log'"}))
-			})
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
 
-			It("returns error if non-interactive SSH session errors", func() {
-				nonIntSSHRunner.RunReturns(errors.New("fake-err"))
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Unable to parse digest string"))
+				})
 
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
+				It("returns error if verifying the log file sha fails", func() {
+					fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
+					fakeFile.Write([]byte("not empty anymore!")) //nolint:errcheck
+					fs.ReturnTempFile = fakeFile
 
-			It("does not try to fetch logs", func() {
-				err := act()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(deployment.FetchLogsCallCount()).To(Equal(0))
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
+
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Expected stream to have digest"))
+				})
+
+				It("Respects the path arg", func() {
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
+					opts.Directory.Path = "/hey/hello"
+					fs.MkdirAll("/hey/hello", os.FileMode(0777)) //nolint:errcheck
+					fs.ReturnTempFilesByPrefix = map[string]boshsys.File{
+						"bosh-cli-scp-download": fakes.NewFakeFile("/tmp/baz", fs),
+					}
+					fs.RenameStub = func(oldPath, newPath string) error {
+						Expect(oldPath).To(Equal("/tmp/baz"))
+						Expect(newPath).To(Equal("/hey/hello/create-env-vm-logs-20091110-230102-000000333.tgz"))
+
+						return nil
+					}
+
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
+					Expect(ui.Said).To(ContainElement("Downloading create-env-vm/0 logs to '/hey/hello/create-env-vm-logs-20091110-230102-000000333.tgz'..."))
+				})
+
+				It("returns error if closing temp file fails", func() {
+					fakeFile := fakes.NewFakeFile("/tmp/baz", fs)
+					fakeFile.CloseErr = errors.New("fake-close-error")
+					fs.ReturnTempFile = fakeFile
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
+
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-close-err"))
+				})
+
+				It("returns error if moving file fails", func() {
+					fs.RenameError = errors.New("fake-rename-error")
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
+
+					err := command.Run(opts)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Moving to final destination"))
+					Expect(err.Error()).To(ContainSubstring("fake-rename-err"))
+				})
+
+				It("does not try to tail logs", func() {
+					agentClient.EXPECT().BundleLogs(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(bundleResult, nil).
+						Times(1)
+					agentClient.EXPECT().RemoveFile(gomock.Any()).
+						Times(1)
+
+					Expect(command.Run(opts)).ToNot(HaveOccurred())
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+				})
 			})
 		})
 	})

--- a/cmd/mocks/gomock_gomega_wrapper.go
+++ b/cmd/mocks/gomock_gomega_wrapper.go
@@ -1,0 +1,29 @@
+package mocks
+
+import "github.com/golang/mock/gomock"
+
+// Shamelessly lifted from https://github.com/onsi/gomega/issues/451
+
+type GomegaMatcher interface {
+	Match(actual interface{}) (success bool, err error)
+	FailureMessage(actual interface{}) (message string)
+}
+
+type matcher struct {
+	GomegaMatcher
+	x interface{}
+}
+
+func (m matcher) Matches(x interface{}) bool {
+	m.x = x
+	result, _ := m.Match(x)
+	return result
+}
+
+func (m matcher) String() string {
+	return m.FailureMessage(m.x)
+}
+
+func GomegaMock(gmather GomegaMatcher) gomock.Matcher {
+	return matcher{gmather, nil}
+}

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -952,6 +952,8 @@ type SSHOpts struct {
 
 	GatewayFlags
 
+	CreateEnvAuthFlags
+
 	cmd
 }
 

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -968,6 +968,8 @@ type SCPOpts struct {
 
 	GatewayFlags
 
+	CreateEnvAuthFlags
+
 	cmd
 }
 

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -858,7 +858,15 @@ type LogsOpts struct {
 
 	GatewayFlags
 
+	CreateEnvAuthFlags
+
 	cmd
+}
+
+type CreateEnvAuthFlags struct {
+	TargetDirector bool   `long:"director"             description:"Target the command at the BOSH director (or other type of VM deployed via create-env)"`
+	Endpoint       string `long:"agent-endpoint"       description:"Address to connect to the agent's HTTPS endpoint (used with --director)"      env:"BOSH_AGENT_ENDPOINT"`
+	Certificate    string `long:"agent-certificate"    description:"CA certificate to validate the agent's HTTPS endpoint (used with --director)" env:"BOSH_AGENT_CERTIFICATE"`
 }
 
 type StartOpts struct {

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -6,11 +6,12 @@ import (
 	"reflect"
 	"regexp"
 
-	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
+	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 )
 
 var (
@@ -2845,6 +2846,32 @@ var _ = Describe("Opts", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Paths", opts)).To(Equal(`positional-arg-name:"PATH"`))
 			})
+		})
+	})
+
+	Describe("CreateEnvAuthFlags", func() {
+		var opts *CreateEnvAuthFlags
+
+		BeforeEach(func() {
+			opts = &CreateEnvAuthFlags{}
+		})
+
+		It("TargetDirector contains desired values", func() {
+			Expect(getStructTagForName("TargetDirector", opts)).To(Equal(
+				`long:"director" description:"Target the command at the BOSH director (or other type of VM deployed via create-env)"`,
+			))
+		})
+
+		It("Endpoint contains desired values", func() {
+			Expect(getStructTagForName("Endpoint", opts)).To(Equal(
+				`long:"agent-endpoint" description:"Address to connect to the agent's HTTPS endpoint (used with --director)" env:"BOSH_AGENT_ENDPOINT"`,
+			))
+		})
+
+		It("Certificate contains desired values", func() {
+			Expect(getStructTagForName("Certificate", opts)).To(Equal(
+				`long:"agent-certificate" description:"CA certificate to validate the agent's HTTPS endpoint (used with --director)" env:"BOSH_AGENT_CERTIFICATE"`,
+			))
 		})
 	})
 

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -106,6 +106,9 @@ func (c EnvSCPCmd) Run(opts SCPOpts) error {
 	if opts.PrivateKey.Bytes != nil {
 		return errors.New("the --private-key flag is not supported in combination with the --director flag")
 	}
+	if opts.Endpoint == "" || opts.Certificate == "" {
+		return errors.New("the --director flag requires both the --agent-endpoint and --agent-certificate flags to be set")
+	}
 
 	agentClient, err := c.agentClientFactory.NewAgentClient("bosh-cli", opts.Endpoint, opts.Certificate)
 	if err != nil {

--- a/cmd/scp.go
+++ b/cmd/scp.go
@@ -1,33 +1,29 @@
 package cmd
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
+	"errors"
 
-	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
+	bihttpagent "github.com/cloudfoundry/bosh-agent/agentclient/http"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	boshssh "github.com/cloudfoundry/bosh-cli/v7/ssh"
-	biui "github.com/cloudfoundry/bosh-cli/v7/ui"
+
+	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 )
 
 type SCPCmd struct {
 	deployment  boshdir.Deployment
-	uuidGen     boshuuid.Generator
 	scpRunner   boshssh.SCPRunner
-	ui          biui.UI
 	hostBuilder boshssh.HostBuilder
 }
 
 func NewSCPCmd(
-	uuidGen boshuuid.Generator,
 	scpRunner boshssh.SCPRunner,
-	ui biui.UI,
 	hostBuilder boshssh.HostBuilder,
 ) SCPCmd {
 	return SCPCmd{
-		uuidGen:     uuidGen,
 		scpRunner:   scpRunner,
-		ui:          ui,
 		hostBuilder: hostBuilder,
 	}
 }
@@ -82,6 +78,69 @@ func (c SCPCmd) Run(opts SCPOpts, deploymentFetcher boshssh.DeploymentFetcher) e
 			GatewayHost:     connOpts.GatewayHost,
 		}
 	}
+
+	err = c.scpRunner.Run(connOpts, result, scpArgs)
+	if err != nil {
+		return bosherr.WrapErrorf(err, "Running SCP")
+	}
+
+	return nil
+}
+
+type EnvSCPCmd struct {
+	agentClientFactory bihttpagent.AgentClientFactory
+	scpRunner          boshssh.SCPRunner
+}
+
+func NewEnvSCPCmd(
+	agentClientFactory bihttpagent.AgentClientFactory,
+	scpRunner boshssh.SCPRunner,
+) EnvSCPCmd {
+	return EnvSCPCmd{
+		agentClientFactory: agentClientFactory,
+		scpRunner:          scpRunner,
+	}
+}
+
+func (c EnvSCPCmd) Run(opts SCPOpts) error {
+	if opts.PrivateKey.Bytes != nil {
+		return errors.New("the --private-key flag is not supported in combination with the --director flag")
+	}
+
+	agentClient, err := c.agentClientFactory.NewAgentClient("bosh-cli", opts.Endpoint, opts.Certificate)
+	if err != nil {
+		return err
+	}
+
+	scpArgs := boshssh.NewSCPArgs(opts.Args.Paths, opts.Recursive)
+
+	sshOpts, connOpts, err := opts.GatewayFlags.AsSSHOpts()
+	if err != nil {
+		return err
+	}
+
+	agentResult, err := agentClient.SetUpSSH(sshOpts.Username, sshOpts.PublicKey)
+	if err != nil {
+		return err
+	}
+	result := boshdir.SSHResult{
+		Hosts: []boshdir.Host{
+			{
+				Username:      sshOpts.Username,
+				Host:          agentResult.Ip,
+				HostPublicKey: agentResult.HostPublicKey,
+				Job:           "create-env-vm",
+				IndexOrID:     "0",
+			},
+		},
+	}
+
+	defer func() {
+		_, _ = agentClient.CleanUpSSH(sshOpts.Username)
+	}()
+
+	// host key will be returned by agent over HTTPS
+	connOpts.RawOpts = append(connOpts.RawOpts, "-o", "StrictHostKeyChecking=yes")
 
 	err = c.scpRunner.Run(connOpts, result, scpArgs)
 	if err != nil {

--- a/cmd/scp_test.go
+++ b/cmd/scp_test.go
@@ -3,215 +3,386 @@ package cmd_test
 import (
 	"errors"
 
+	"github.com/cloudfoundry/bosh-agent/agentclient"
+	mockhttpagent "github.com/cloudfoundry/bosh-agent/agentclient/http/mocks"
 	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mockagentclient "github.com/cloudfoundry/bosh-cli/v7/agentclient/mocks"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd"
+	"github.com/cloudfoundry/bosh-cli/v7/cmd/mocks"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/v7/director/directorfakes"
 	boshssh "github.com/cloudfoundry/bosh-cli/v7/ssh"
 	fakessh "github.com/cloudfoundry/bosh-cli/v7/ssh/sshfakes"
-	fakeui "github.com/cloudfoundry/bosh-cli/v7/ui/fakes"
 )
 
-var _ = Describe("SCPCmd", func() {
+var _ = Describe("SCP", func() {
 	const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
 	const ExpUsername = "bosh_8c5ff117957245c"
 
-	var (
-		deployment  *fakedir.FakeDeployment
-		uuidGen     *fakeuuid.FakeGenerator
-		scpRunner   *fakessh.FakeSCPRunner
-		ui          *fakeui.FakeUI
-		hostBuilder *fakessh.FakeHostBuilder
-		command     SCPCmd
-	)
-
-	BeforeEach(func() {
-		deployment = &fakedir.FakeDeployment{}
-		uuidGen = &fakeuuid.FakeGenerator{}
-		scpRunner = &fakessh.FakeSCPRunner{}
-		ui = &fakeui.FakeUI{}
-		hostBuilder = &fakessh.FakeHostBuilder{}
-		command = NewSCPCmd(uuidGen, scpRunner, ui, hostBuilder)
-	})
-
-	Describe("Run", func() {
+	Describe("SCPCmd", func() {
 		var (
-			opts SCPOpts
-			act  func() error
+			deployment  *fakedir.FakeDeployment
+			uuidGen     *fakeuuid.FakeGenerator
+			scpRunner   *fakessh.FakeSCPRunner
+			hostBuilder *fakessh.FakeHostBuilder
+			command     SCPCmd
 		)
 
 		BeforeEach(func() {
-			opts = SCPOpts{
-				GatewayFlags: GatewayFlags{
-					UUIDGen: uuidGen,
-				},
-			}
-			uuidGen.GeneratedUUID = UUID
-
-			act = func() error {
-				return command.Run(opts, func() (boshdir.Deployment, error) {
-					return deployment, nil
-				})
-			}
+			deployment = &fakedir.FakeDeployment{}
+			uuidGen = &fakeuuid.FakeGenerator{}
+			scpRunner = &fakessh.FakeSCPRunner{}
+			hostBuilder = &fakessh.FakeHostBuilder{}
+			command = NewSCPCmd(scpRunner, hostBuilder)
 		})
 
-		Context("when valid SCP args are provided", func() {
+		Describe("Run", func() {
+			var (
+				opts SCPOpts
+				act  func() error
+			)
+
 			BeforeEach(func() {
-				opts.Args.Paths = []string{"from:file", "/something"}
-			})
-
-			It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
-				scpRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, boshssh.SCPArgs) error {
-					Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
-					return nil
-				}
-				Expect(act()).ToNot(HaveOccurred())
-
-				Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
-				Expect(scpRunner.RunCallCount()).To(Equal(1))
-				Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
-
-				setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
-				Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("from", "")))
-				Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
-				Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
-
-				slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
-				Expect(slug).To(Equal(setupSlug))
-				Expect(sshOpts).To(Equal(setupSSHOpts))
-			})
-
-			It("returns an error if setting up SSH access fails", func() {
-				deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
-
-			It("returns an error if generating SSH options fails", func() {
-				uuidGen.GenerateError = errors.New("fake-err")
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
-
-			It("runs SCP with flags, and command", func() {
-				result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
-				deployment.SetUpSSHReturns(result, nil)
-
-				opts.GatewayFlags.Disable = true
-				opts.GatewayFlags.Username = "gw-username"
-				opts.GatewayFlags.Host = "gw-host"
-				opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
-				opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
-
-				Expect(act()).ToNot(HaveOccurred())
-
-				Expect(scpRunner.RunCallCount()).To(Equal(1))
-
-				runConnOpts, runResult, runCommand := scpRunner.RunArgsForCall(0)
-				Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
-				Expect(runConnOpts.GatewayDisable).To(Equal(true))
-				Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
-				Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
-				Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
-				Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
-				Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
-				Expect(runCommand).To(Equal(boshssh.NewSCPArgs([]string{"from:file", "/something"}, false)))
-			})
-
-			It("sets up SCP to be recursive if recursive flag is set", func() {
-				opts.Recursive = true
-				Expect(act()).ToNot(HaveOccurred())
-				Expect(scpRunner.RunCallCount()).To(Equal(1))
-
-				_, _, runCommand := scpRunner.RunArgsForCall(0)
-				Expect(runCommand).To(Equal(boshssh.NewSCPArgs([]string{"from:file", "/something"}, true)))
-			})
-
-			It("returns error if SCP errors", func() {
-				scpRunner.RunReturns(errors.New("fake-err"))
-				err := act()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
-			})
-		})
-
-		Context("when private key is provided", func() {
-			var expectedHost = boshdir.Host{
-				Job:       "",
-				IndexOrID: "",
-				Username:  "vcap",
-				Host:      "1.2.3.4",
-			}
-			BeforeEach(func() {
-				ui.Interactive = false
-				opts.Args.Paths = []string{"1.2.3.4:file", "/something"}
-
-				opts.PrivateKey.Bytes = []byte("topsecret")
-				opts.Username = "vcap"
-
-				hostBuilder.BuildHostReturns(expectedHost, nil)
-			})
-
-			It("agent is not used to setup ssh", func() {
-				Expect(act()).ToNot(HaveOccurred())
-
-				Expect(deployment.SetUpSSHCallCount()).To(Equal(0))
-				Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
-			})
-
-			It("builds host from args", func() {
-				Expect(act()).ToNot(HaveOccurred())
-
-				Expect(hostBuilder.BuildHostCallCount()).To(Equal(1))
-				slug, username, _ := hostBuilder.BuildHostArgsForCall(0)
-
-				expectedSlug, _ := boshdir.NewAllOrInstanceGroupOrInstanceSlugFromString("1.2.3.4")
-				Expect(slug).To(Equal(expectedSlug))
-				Expect(username).To(Equal(opts.Username))
-
-				Expect(scpRunner.RunCallCount()).To(Equal(1))
-				conn, result, _ := scpRunner.RunArgsForCall(0)
-
-				expectedResult := boshdir.SSHResult{
-					Hosts: []boshdir.Host{
-						expectedHost,
+				opts = SCPOpts{
+					GatewayFlags: GatewayFlags{
+						UUIDGen: uuidGen,
 					},
-					GatewayUsername: "",
-					GatewayHost:     "",
 				}
-				Expect(result).To(Equal(expectedResult))
+				uuidGen.GeneratedUUID = UUID
 
-				expectedConn := boshssh.ConnectionOpts{
-					PrivateKey: "topsecret",
-
-					GatewayDisable: false,
-
-					GatewayUsername:       "",
-					GatewayHost:           "",
-					GatewayPrivateKeyPath: "",
-
-					SOCKS5Proxy: "",
-					RawOpts:     []string{"-o", "StrictHostKeyChecking=no"},
+				act = func() error {
+					return command.Run(opts, func() (boshdir.Deployment, error) {
+						return deployment, nil
+					})
 				}
-				Expect(conn).To(Equal(expectedConn))
+			})
 
+			Context("when valid SCP args are provided", func() {
+				BeforeEach(func() {
+					opts.Args.Paths = []string{"from:file", "/something"}
+				})
+
+				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+					scpRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, boshssh.SCPArgs) error {
+						Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
+						return nil
+					}
+					Expect(act()).ToNot(HaveOccurred())
+
+					Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
+					Expect(scpRunner.RunCallCount()).To(Equal(1))
+					Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
+
+					setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
+					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("from", "")))
+					Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
+					Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
+
+					slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
+					Expect(slug).To(Equal(setupSlug))
+					Expect(sshOpts).To(Equal(setupSSHOpts))
+				})
+
+				It("returns an error if setting up SSH access fails", func() {
+					deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("returns an error if generating SSH options fails", func() {
+					uuidGen.GenerateError = errors.New("fake-err")
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+
+				It("runs SCP with flags, and command", func() {
+					result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
+					deployment.SetUpSSHReturns(result, nil)
+
+					opts.GatewayFlags.Disable = true
+					opts.GatewayFlags.Username = "gw-username"
+					opts.GatewayFlags.Host = "gw-host"
+					opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+					opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
+
+					Expect(act()).ToNot(HaveOccurred())
+
+					Expect(scpRunner.RunCallCount()).To(Equal(1))
+
+					runConnOpts, runResult, runCommand := scpRunner.RunArgsForCall(0)
+					Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+					Expect(runConnOpts.GatewayDisable).To(Equal(true))
+					Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+					Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+					Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+					Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
+					Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
+					Expect(runCommand).To(Equal(boshssh.NewSCPArgs([]string{"from:file", "/something"}, false)))
+				})
+
+				It("sets up SCP to be recursive if recursive flag is set", func() {
+					opts.Recursive = true
+					Expect(act()).ToNot(HaveOccurred())
+					Expect(scpRunner.RunCallCount()).To(Equal(1))
+
+					_, _, runCommand := scpRunner.RunArgsForCall(0)
+					Expect(runCommand).To(Equal(boshssh.NewSCPArgs([]string{"from:file", "/something"}, true)))
+				})
+
+				It("returns error if SCP errors", func() {
+					scpRunner.RunReturns(errors.New("fake-err"))
+					err := act()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("fake-err"))
+				})
+			})
+
+			Context("when private key is provided", func() {
+				var expectedHost = boshdir.Host{
+					Job:       "",
+					IndexOrID: "",
+					Username:  "vcap",
+					Host:      "1.2.3.4",
+				}
+				BeforeEach(func() {
+					opts.Args.Paths = []string{"1.2.3.4:file", "/something"}
+
+					opts.PrivateKey.Bytes = []byte("topsecret")
+					opts.Username = "vcap"
+
+					hostBuilder.BuildHostReturns(expectedHost, nil)
+				})
+
+				It("agent is not used to setup ssh", func() {
+					Expect(act()).ToNot(HaveOccurred())
+
+					Expect(deployment.SetUpSSHCallCount()).To(Equal(0))
+					Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
+				})
+
+				It("builds host from args", func() {
+					Expect(act()).ToNot(HaveOccurred())
+
+					Expect(hostBuilder.BuildHostCallCount()).To(Equal(1))
+					slug, username, _ := hostBuilder.BuildHostArgsForCall(0)
+
+					expectedSlug, _ := boshdir.NewAllOrInstanceGroupOrInstanceSlugFromString("1.2.3.4")
+					Expect(slug).To(Equal(expectedSlug))
+					Expect(username).To(Equal(opts.Username))
+
+					Expect(scpRunner.RunCallCount()).To(Equal(1))
+					conn, result, _ := scpRunner.RunArgsForCall(0)
+
+					expectedResult := boshdir.SSHResult{
+						Hosts: []boshdir.Host{
+							expectedHost,
+						},
+						GatewayUsername: "",
+						GatewayHost:     "",
+					}
+					Expect(result).To(Equal(expectedResult))
+
+					expectedConn := boshssh.ConnectionOpts{
+						PrivateKey: "topsecret",
+
+						GatewayDisable: false,
+
+						GatewayUsername:       "",
+						GatewayHost:           "",
+						GatewayPrivateKeyPath: "",
+
+						SOCKS5Proxy: "",
+						RawOpts:     []string{"-o", "StrictHostKeyChecking=no"},
+					}
+					Expect(conn).To(Equal(expectedConn))
+
+				})
+			})
+
+			Context("when valid SCP args are not provided", func() {
+				BeforeEach(func() {
+					opts.Args.Paths = []string{"invalid-arg"}
+				})
+
+				It("returns an error", func() {
+					Expect(act()).To(Equal(errors.New(
+						"Missing remote host information in source/destination arguments")))
+				})
 			})
 		})
+	})
 
-		Context("when valid SCP args are not provided", func() {
-			BeforeEach(func() {
-				opts.Args.Paths = []string{"invalid-arg"}
+	Describe("EnvSCPCmd", func() {
+		var (
+			mockCtrl *gomock.Controller
+
+			agentClientFactory *mockhttpagent.MockAgentClientFactory
+			agentClient        *mockagentclient.MockAgentClient
+			uuidGen            *fakeuuid.FakeGenerator
+			scpRunner          *fakessh.FakeSCPRunner
+			command            EnvSCPCmd
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+
+			agentClient = mockagentclient.NewMockAgentClient(mockCtrl)
+			agentClientFactory = mockhttpagent.NewMockAgentClientFactory(mockCtrl)
+
+			uuidGen = &fakeuuid.FakeGenerator{}
+			scpRunner = &fakessh.FakeSCPRunner{}
+			command = NewEnvSCPCmd(agentClientFactory, scpRunner)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		Describe("Run", func() {
+			var (
+				opts SCPOpts
+			)
+
+			Context("when private key is provided", func() {
+				BeforeEach(func() {
+					opts.PrivateKey.Bytes = []byte("topsecret")
+				})
+
+				It("errors", func() {
+					err := command.Run(opts)
+
+					Expect(err).To(MatchError("the --private-key flag is not supported in combination with the --director flag"))
+				})
 			})
 
-			It("returns an error", func() {
-				Expect(act()).To(Equal(errors.New(
-					"Missing remote host information in source/destination arguments")))
+			Context("when private key is not provided", func() {
+				BeforeEach(func() {
+					opts = SCPOpts{
+						CreateEnvAuthFlags: CreateEnvAuthFlags{
+							TargetDirector: true,
+							Endpoint:       "https:///foo:bar@10.0.0.5",
+							Certificate:    "some-cert",
+						},
+						GatewayFlags: GatewayFlags{
+							UUIDGen: uuidGen,
+						},
+					}
+					uuidGen.GeneratedUUID = UUID
+
+					agentClientFactory.EXPECT().NewAgentClient(
+						gomock.Eq("bosh-cli"),
+						gomock.Eq("https:///foo:bar@10.0.0.5"),
+						gomock.Eq("some-cert"),
+					).Return(agentClient, nil).Times(1)
+				})
+
+				Context("when valid SCP args are provided", func() {
+					BeforeEach(func() {
+						opts.Args.Paths = []string{"from:file", "/something"}
+					})
+
+					It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+						scpRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, boshssh.SCPArgs) error {
+							agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(0)
+							return nil
+						}
+						agentClient.EXPECT().SetUpSSH(gomock.Eq(ExpUsername), mocks.GomegaMock(ContainSubstring("ssh-rsa AAAA"))).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Eq(ExpUsername)).
+							Times(1)
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(scpRunner.RunCallCount()).To(Equal(1))
+					})
+
+					It("returns an error if setting up SSH access fails", func() {
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Return(agentclient.SSHResult{}, errors.New("fake-ssh-err")).
+							Times(1)
+
+						err := command.Run(opts)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-ssh-err"))
+					})
+
+					It("returns an error if generating SSH options fails", func() {
+						uuidGen.GenerateError = errors.New("fake-uuid-err")
+
+						err := command.Run(opts)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-uuid-err"))
+					})
+
+					It("runs SCP with flags, and command", func() {
+						result := agentclient.SSHResult{
+							Command:       "setup",
+							Status:        "success",
+							Ip:            "10.0.0.5",
+							HostPublicKey: "some-public-key",
+						}
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Return(result, nil).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+							Times(1)
+
+						opts.GatewayFlags.Disable = true
+						opts.GatewayFlags.Username = "gw-username"
+						opts.GatewayFlags.Host = "gw-host"
+						opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+						opts.GatewayFlags.SOCKS5Proxy = "some-proxy"
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(scpRunner.RunCallCount()).To(Equal(1))
+
+						runConnOpts, runResult, runCommand := scpRunner.RunArgsForCall(0)
+						Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+						Expect(runConnOpts.GatewayDisable).To(Equal(true))
+						Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+						Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+						Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+						Expect(runConnOpts.SOCKS5Proxy).To(Equal("some-proxy"))
+						Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Username: ExpUsername, Host: "10.0.0.5", HostPublicKey: "some-public-key", Job: "create-env-vm", IndexOrID: "0"}}}))
+						Expect(runCommand).To(Equal(boshssh.NewSCPArgs([]string{"from:file", "/something"}, false)))
+					})
+
+					It("sets up SCP to be recursive if recursive flag is set", func() {
+						opts.Recursive = true
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+							Times(1)
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+						Expect(scpRunner.RunCallCount()).To(Equal(1))
+
+						_, _, runCommand := scpRunner.RunArgsForCall(0)
+						Expect(runCommand).To(Equal(boshssh.NewSCPArgs([]string{"from:file", "/something"}, true)))
+					})
+
+					It("returns error if SCP errors", func() {
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+							Times(1)
+						scpRunner.RunReturns(errors.New("fake-scp-err"))
+
+						err := command.Run(opts)
+
+						Expect(err).To(MatchError(ContainSubstring("fake-scp-err")))
+					})
+				})
 			})
 		})
 	})

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -136,6 +136,9 @@ func (c EnvSSHCmd) Run(opts SSHOpts) error {
 	if opts.PrivateKey.Bytes != nil {
 		return errors.New("the --private-key flag is not supported in combination with the --director flag")
 	}
+	if opts.Endpoint == "" || opts.Certificate == "" {
+		return errors.New("the --director flag requires both the --agent-endpoint and --agent-certificate flags to be set")
+	}
 
 	agentClient, err := c.agentClientFactory.NewAgentClient("bosh-cli", opts.Endpoint, opts.Certificate)
 	if err != nil {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -1,17 +1,20 @@
 package cmd
 
 import (
-	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
+	"errors"
+
+	bihttpagent "github.com/cloudfoundry/bosh-agent/agentclient/http"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	boshssh "github.com/cloudfoundry/bosh-cli/v7/ssh"
 	boshui "github.com/cloudfoundry/bosh-cli/v7/ui"
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
+
+	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 )
 
 type SSHCmd struct {
 	deployment       boshdir.Deployment
-	uuidGen          boshuuid.Generator
 	intSSHRunner     boshssh.Runner
 	nonIntSSHRunner  boshssh.Runner
 	resultsSSHRunner boshssh.Runner
@@ -20,7 +23,6 @@ type SSHCmd struct {
 }
 
 func NewSSHCmd(
-	uuidGen boshuuid.Generator,
 	intSSHRunner boshssh.Runner,
 	nonIntSSHRunner boshssh.Runner,
 	resultsSSHRunner boshssh.Runner,
@@ -28,7 +30,6 @@ func NewSSHCmd(
 	hostBuilder boshssh.HostBuilder,
 ) SSHCmd {
 	return SSHCmd{
-		uuidGen:          uuidGen,
 		intSSHRunner:     intSSHRunner,
 		nonIntSSHRunner:  nonIntSSHRunner,
 		resultsSSHRunner: resultsSSHRunner,
@@ -88,6 +89,87 @@ func (c SSHCmd) Run(opts SSHOpts, deploymentFetcher boshssh.DeploymentFetcher) e
 			GatewayHost:     connOpts.GatewayHost,
 		}
 	}
+
+	var runner boshssh.Runner
+
+	if opts.Results {
+		runner = c.resultsSSHRunner
+	} else if !c.ui.IsInteractive() || len(opts.Command) > 0 {
+		runner = c.nonIntSSHRunner
+	} else {
+		runner = c.intSSHRunner
+	}
+
+	err = runner.Run(connOpts, result, opts.Command)
+	if err != nil {
+		return bosherr.WrapErrorf(err, "Running SSH")
+	}
+
+	return nil
+}
+
+type EnvSSHCmd struct {
+	agentClientFactory bihttpagent.AgentClientFactory
+	intSSHRunner       boshssh.Runner
+	nonIntSSHRunner    boshssh.Runner
+	resultsSSHRunner   boshssh.Runner
+	ui                 boshui.UI
+}
+
+func NewEnvSSHCmd(
+	agentClientFactory bihttpagent.AgentClientFactory,
+	intSSHRunner boshssh.Runner,
+	nonIntSSHRunner boshssh.Runner,
+	resultsSSHRunner boshssh.Runner,
+	ui boshui.UI,
+) EnvSSHCmd {
+	return EnvSSHCmd{
+		agentClientFactory: agentClientFactory,
+		intSSHRunner:       intSSHRunner,
+		nonIntSSHRunner:    nonIntSSHRunner,
+		resultsSSHRunner:   resultsSSHRunner,
+		ui:                 ui,
+	}
+}
+
+func (c EnvSSHCmd) Run(opts SSHOpts) error {
+	if opts.PrivateKey.Bytes != nil {
+		return errors.New("the --private-key flag is not supported in combination with the --director flag")
+	}
+
+	agentClient, err := c.agentClientFactory.NewAgentClient("bosh-cli", opts.Endpoint, opts.Certificate)
+	if err != nil {
+		return err
+	}
+
+	sshOpts, connOpts, err := opts.GatewayFlags.AsSSHOpts()
+	if err != nil {
+		return err
+	}
+
+	connOpts.RawOpts = opts.RawOpts.AsStrings()
+	agentResult, err := agentClient.SetUpSSH(sshOpts.Username, sshOpts.PublicKey)
+	if err != nil {
+		return err
+	}
+	result := boshdir.SSHResult{
+		Hosts: []boshdir.Host{
+			{
+				Username:      sshOpts.Username,
+				Host:          agentResult.Ip,
+				HostPublicKey: agentResult.HostPublicKey,
+				Job:           "create-env-vm",
+				IndexOrID:     "0",
+			},
+		},
+	}
+
+	defer func() {
+		_, _ = agentClient.CleanUpSSH(sshOpts.Username)
+	}()
+
+	// host key will be returned by agent over HTTPS
+	connOpts.RawOpts = append(connOpts.RawOpts, "-o", "StrictHostKeyChecking=yes")
 
 	var runner boshssh.Runner
 

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -3,12 +3,16 @@ package cmd_test
 import (
 	"errors"
 
+	"github.com/cloudfoundry/bosh-agent/agentclient"
+	mockhttpagent "github.com/cloudfoundry/bosh-agent/agentclient/http/mocks"
 	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
-
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	mockagentclient "github.com/cloudfoundry/bosh-cli/v7/agentclient/mocks"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd"
+	"github.com/cloudfoundry/bosh-cli/v7/cmd/mocks"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	fakedir "github.com/cloudfoundry/bosh-cli/v7/director/directorfakes"
@@ -17,320 +21,573 @@ import (
 	fakeui "github.com/cloudfoundry/bosh-cli/v7/ui/fakes"
 )
 
-var _ = Describe("SSHCmd", func() {
-	var (
-		deployment       *fakedir.FakeDeployment
-		uuidGen          *fakeuuid.FakeGenerator
-		intSSHRunner     *fakessh.FakeRunner
-		nonIntSSHRunner  *fakessh.FakeRunner
-		resultsSSHRunner *fakessh.FakeRunner
-		ui               *fakeui.FakeUI
-		hostBuilder      *fakessh.FakeHostBuilder
-		command          SSHCmd
-	)
+var _ = Describe("SSH", func() {
+	const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
+	const ExpUsername = "bosh_8c5ff117957245c"
 
-	BeforeEach(func() {
-		deployment = &fakedir.FakeDeployment{}
-		uuidGen = &fakeuuid.FakeGenerator{}
-		intSSHRunner = &fakessh.FakeRunner{}
-		nonIntSSHRunner = &fakessh.FakeRunner{}
-		resultsSSHRunner = &fakessh.FakeRunner{}
-		hostBuilder = &fakessh.FakeHostBuilder{}
-		ui = &fakeui.FakeUI{}
-		command = NewSSHCmd(uuidGen, intSSHRunner, nonIntSSHRunner, resultsSSHRunner, ui, hostBuilder)
-	})
-
-	Describe("Run", func() {
-		const UUID = "8c5ff117-9572-45c5-8564-8bcf076ecafa"
-		const ExpUsername = "bosh_8c5ff117957245c"
-
+	Describe("SSHCmd", func() {
 		var (
-			opts SSHOpts
-			act  func() error
+			deployment       *fakedir.FakeDeployment
+			uuidGen          *fakeuuid.FakeGenerator
+			intSSHRunner     *fakessh.FakeRunner
+			nonIntSSHRunner  *fakessh.FakeRunner
+			resultsSSHRunner *fakessh.FakeRunner
+			ui               *fakeui.FakeUI
+			hostBuilder      *fakessh.FakeHostBuilder
+			command          SSHCmd
 		)
 
 		BeforeEach(func() {
-			opts = SSHOpts{
-				Args: SshSlugArgs{
-					Slug: boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", ""),
-				},
-
-				GatewayFlags: GatewayFlags{
-					UUIDGen: uuidGen,
-				},
-			}
-
-			uuidGen.GeneratedUUID = UUID
-
-			act = func() error {
-				return command.Run(opts, func() (boshdir.Deployment, error) {
-					return deployment, nil
-				})
-			}
+			deployment = &fakedir.FakeDeployment{}
+			uuidGen = &fakeuuid.FakeGenerator{}
+			intSSHRunner = &fakessh.FakeRunner{}
+			nonIntSSHRunner = &fakessh.FakeRunner{}
+			resultsSSHRunner = &fakessh.FakeRunner{}
+			hostBuilder = &fakessh.FakeHostBuilder{}
+			ui = &fakeui.FakeUI{}
+			command = NewSSHCmd(intSSHRunner, nonIntSSHRunner, resultsSSHRunner, ui, hostBuilder)
 		})
 
-		itRunsNonInteractiveSSHWhenCommandIsGiven := func(runner **fakessh.FakeRunner) {
-			Context("when command is provided", func() {
+		Describe("Run", func() {
+			var (
+				opts SSHOpts
+				act  func() error
+			)
+
+			BeforeEach(func() {
+				opts = SSHOpts{
+					Args: SshSlugArgs{
+						Slug: boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", ""),
+					},
+
+					GatewayFlags: GatewayFlags{
+						UUIDGen: uuidGen,
+					},
+				}
+
+				uuidGen.GeneratedUUID = UUID
+
+				act = func() error {
+					return command.Run(opts, func() (boshdir.Deployment, error) {
+						return deployment, nil
+					})
+				}
+			})
+
+			itRunsNonInteractiveSSHWhenCommandIsGiven := func(runner **fakessh.FakeRunner) {
+				Context("when command is provided", func() {
+					BeforeEach(func() {
+						opts.Command = []string{"cmd", "arg1"}
+					})
+
+					It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+						(*runner).RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
+							Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
+							return nil
+						}
+						Expect(act()).ToNot(HaveOccurred())
+
+						Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
+						Expect((*runner).RunCallCount()).To(Equal(1))
+						Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
+
+						setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
+						Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", "")))
+						Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
+						Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
+
+						slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
+						Expect(slug).To(Equal(setupSlug))
+						Expect(sshOpts).To(Equal(setupSSHOpts))
+					})
+
+					It("runs non-interactive SSH", func() {
+						Expect(act()).ToNot(HaveOccurred())
+						Expect((*runner).RunCallCount()).To(Equal(1))
+						Expect(intSSHRunner.RunCallCount()).To(Equal(0))
+					})
+
+					It("returns an error if setting up SSH access fails", func() {
+						deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-err"))
+					})
+
+					It("returns an error if generating SSH options fails", func() {
+						uuidGen.GenerateError = errors.New("fake-err")
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-err"))
+					})
+
+					It("runs non-interactive SSH session with flags, and command", func() {
+						result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
+						deployment.SetUpSSHReturns(result, nil)
+
+						opts.RawOpts = TrimmedSpaceArgs([]string{"raw1", "raw2"})
+						opts.GatewayFlags.Disable = true
+						opts.GatewayFlags.Username = "gw-username"
+						opts.GatewayFlags.Host = "gw-host"
+						opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+						opts.GatewayFlags.SOCKS5Proxy = "socks5"
+
+						Expect(act()).ToNot(HaveOccurred())
+
+						Expect((*runner).RunCallCount()).To(Equal(1))
+
+						runConnOpts, runResult, runCommand := (*runner).RunArgsForCall(0)
+						Expect(runConnOpts.RawOpts).To(Equal([]string{"raw1", "raw2", "-o", "StrictHostKeyChecking=yes"}))
+						Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+						Expect(runConnOpts.GatewayDisable).To(Equal(true))
+						Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+						Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+						Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+						Expect(runConnOpts.SOCKS5Proxy).To(Equal("socks5"))
+						Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
+						Expect(runCommand).To(Equal([]string{"cmd", "arg1"}))
+					})
+
+					It("returns error if non-interactive SSH session errors", func() {
+						(*runner).RunReturns(errors.New("fake-err"))
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-err"))
+					})
+				})
+			}
+
+			Context("when ui is interactive", func() {
 				BeforeEach(func() {
-					opts.Command = []string{"cmd", "arg1"}
+					ui.Interactive = true
 				})
 
-				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
-					(*runner).RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
-						Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
-						return nil
+				itRunsNonInteractiveSSHWhenCommandIsGiven(&nonIntSSHRunner)
+
+				Context("when command is not provided", func() {
+					It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+						intSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
+							Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
+							return nil
+						}
+						Expect(act()).ToNot(HaveOccurred())
+
+						Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
+						Expect(intSSHRunner.RunCallCount()).To(Equal(1))
+						Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
+
+						setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
+						Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", "")))
+						Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
+						Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
+
+						slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
+						Expect(slug).To(Equal(setupSlug))
+						Expect(sshOpts).To(Equal(setupSSHOpts))
+					})
+
+					It("runs only interactive SSH", func() {
+						Expect(act()).ToNot(HaveOccurred())
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(intSSHRunner.RunCallCount()).To(Equal(1))
+						Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
+					})
+
+					It("returns an error if setting up SSH access fails", func() {
+						deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-err"))
+					})
+
+					It("runs interactive SSH session with flags, but without command", func() {
+						result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
+						deployment.SetUpSSHReturns(result, nil)
+
+						opts.RawOpts = TrimmedSpaceArgs([]string{"raw1", "raw2"})
+						opts.GatewayFlags.Disable = true
+						opts.GatewayFlags.Username = "gw-username"
+						opts.GatewayFlags.Host = "gw-host"
+						opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+
+						Expect(act()).ToNot(HaveOccurred())
+
+						Expect(intSSHRunner.RunCallCount()).To(Equal(1))
+
+						runConnOpts, runResult, runCommand := intSSHRunner.RunArgsForCall(0)
+						Expect(runConnOpts.RawOpts).To(Equal([]string{"raw1", "raw2", "-o", "StrictHostKeyChecking=yes"}))
+						Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+						Expect(runConnOpts.GatewayDisable).To(Equal(true))
+						Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+						Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+						Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+						Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
+						Expect(runCommand).To(BeNil())
+					})
+
+					It("returns error if interactive SSH session errors", func() {
+						intSSHRunner.RunReturns(errors.New("fake-err"))
+						err := act()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("fake-err"))
+					})
+				})
+			})
+
+			Context("when ui is not interactive", func() {
+				BeforeEach(func() {
+					ui.Interactive = false
+				})
+
+				itRunsNonInteractiveSSHWhenCommandIsGiven(&nonIntSSHRunner)
+
+				Context("when command is not provided", func() {
+					It("returns an error since command is required", func() {
+						Expect(act()).To(Equal(errors.New("Non-interactive SSH requires non-empty command")))
+					})
+
+					It("does not try to run any SSH sessions", func() {
+						Expect(act()).To(HaveOccurred())
+						Expect(intSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
+					})
+				})
+			})
+
+			Context("when results are requested", func() {
+				BeforeEach(func() {
+					ui.Interactive = true
+					opts.Results = true
+				})
+
+				itRunsNonInteractiveSSHWhenCommandIsGiven(&resultsSSHRunner)
+
+				Context("when command is not provided", func() {
+					It("returns an error since command is required", func() {
+						Expect(act()).To(Equal(errors.New("Non-interactive SSH requires non-empty command")))
+					})
+
+					It("does not try to run any SSH sessions", func() {
+						Expect(act()).To(HaveOccurred())
+						Expect(intSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
+					})
+				})
+			})
+
+			Context("when private key is provided", func() {
+				var expectedHost = boshdir.Host{
+					Job:       "",
+					IndexOrID: "",
+					Username:  "vcap",
+					Host:      "1.2.3.4",
+				}
+				BeforeEach(func() {
+					ui.Interactive = false
+					opts.Command = []string{"do", "it"}
+
+					opts.PrivateKey.Bytes = []byte("topsecret")
+					opts.Username = "vcap"
+					opts.Args.Slug, _ = boshdir.NewAllOrInstanceGroupOrInstanceSlugFromString("1.2.3.4")
+
+					hostBuilder.BuildHostReturns(expectedHost, nil)
+				})
+
+				It("agent is not used to setup ssh", func() {
+					Expect(act()).ToNot(HaveOccurred())
+					Expect(deployment.SetUpSSHCallCount()).To(Equal(0))
+					Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
+				})
+
+				It("builds host from args", func() {
+					Expect(act()).ToNot(HaveOccurred())
+
+					Expect(hostBuilder.BuildHostCallCount()).To(Equal(1))
+					slug, username, _ := hostBuilder.BuildHostArgsForCall(0)
+
+					Expect(slug).To(Equal(opts.Args.Slug))
+					Expect(username).To(Equal(opts.Username))
+
+					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+					conn, result, _ := nonIntSSHRunner.RunArgsForCall(0)
+
+					expectedResult := boshdir.SSHResult{
+						Hosts: []boshdir.Host{
+							expectedHost,
+						},
+						GatewayUsername: "",
+						GatewayHost:     "",
 					}
-					Expect(act()).ToNot(HaveOccurred())
+					Expect(result).To(Equal(expectedResult))
 
-					Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
-					Expect((*runner).RunCallCount()).To(Equal(1))
-					Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
+					expectedConn := boshssh.ConnectionOpts{
+						PrivateKey: "topsecret",
 
-					setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
-					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", "")))
-					Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
-					Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
+						GatewayDisable: false,
 
-					slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
-					Expect(slug).To(Equal(setupSlug))
-					Expect(sshOpts).To(Equal(setupSSHOpts))
+						GatewayUsername:       "",
+						GatewayHost:           "",
+						GatewayPrivateKeyPath: "",
+
+						SOCKS5Proxy: "",
+						RawOpts:     []string{"-o", "StrictHostKeyChecking=no"},
+					}
+					Expect(conn).To(Equal(expectedConn))
+
+				})
+			})
+		})
+	})
+
+	Describe("EnvSSHCmd", func() {
+
+		var (
+			mockCtrl *gomock.Controller
+
+			agentClientFactory *mockhttpagent.MockAgentClientFactory
+			agentClient        *mockagentclient.MockAgentClient
+			intSSHRunner       *fakessh.FakeRunner
+			nonIntSSHRunner    *fakessh.FakeRunner
+			resultsSSHRunner   *fakessh.FakeRunner
+			ui                 *fakeui.FakeUI
+
+			uuidGen *fakeuuid.FakeGenerator
+
+			command EnvSSHCmd
+		)
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+
+			agentClient = mockagentclient.NewMockAgentClient(mockCtrl)
+			agentClientFactory = mockhttpagent.NewMockAgentClientFactory(mockCtrl)
+			intSSHRunner = &fakessh.FakeRunner{}
+			nonIntSSHRunner = &fakessh.FakeRunner{}
+			resultsSSHRunner = &fakessh.FakeRunner{}
+			ui = &fakeui.FakeUI{}
+
+			uuidGen = &fakeuuid.FakeGenerator{}
+
+			command = NewEnvSSHCmd(agentClientFactory, intSSHRunner, nonIntSSHRunner, resultsSSHRunner, ui)
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		Describe("Run", func() {
+			var (
+				opts SSHOpts
+			)
+
+			Context("when private key is provided", func() {
+				BeforeEach(func() {
+					opts.PrivateKey.Bytes = []byte("topsecret")
 				})
 
-				It("runs non-interactive SSH", func() {
-					Expect(act()).ToNot(HaveOccurred())
-					Expect((*runner).RunCallCount()).To(Equal(1))
-					Expect(intSSHRunner.RunCallCount()).To(Equal(0))
-				})
+				It("errors", func() {
+					err := command.Run(opts)
 
-				It("returns an error if setting up SSH access fails", func() {
-					deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
-					err := act()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-err"))
+					Expect(err).To(MatchError("the --private-key flag is not supported in combination with the --director flag"))
+				})
+			})
+
+			Context("when private key is not provided", func() {
+				BeforeEach(func() {
+					opts = SSHOpts{
+						CreateEnvAuthFlags: CreateEnvAuthFlags{
+							TargetDirector: true,
+							Endpoint:       "https:///foo:bar@10.0.0.5",
+							Certificate:    "some-cert",
+						},
+						GatewayFlags: GatewayFlags{UUIDGen: uuidGen},
+					}
+
+					uuidGen.GeneratedUUID = UUID
+
+					agentClientFactory.EXPECT().NewAgentClient(
+						gomock.Eq("bosh-cli"),
+						gomock.Eq("https:///foo:bar@10.0.0.5"),
+						gomock.Eq("some-cert"),
+					).Return(agentClient, nil).Times(1)
 				})
 
 				It("returns an error if generating SSH options fails", func() {
 					uuidGen.GenerateError = errors.New("fake-err")
-					err := act()
+
+					err := command.Run(opts)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("fake-err"))
 				})
 
-				It("runs non-interactive SSH session with flags, and command", func() {
-					result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
-					deployment.SetUpSSHReturns(result, nil)
+				itRunsSpecifiedRunnerProperlyWhenCommandGiven := func(runner **fakessh.FakeRunner) {
+					Context("when command is provided", func() {
+						BeforeEach(func() {
+							opts.Command = []string{"cmd", "arg1"}
+						})
 
-					opts.RawOpts = TrimmedSpaceArgs([]string{"raw1", "raw2"})
-					opts.GatewayFlags.Disable = true
-					opts.GatewayFlags.Username = "gw-username"
-					opts.GatewayFlags.Host = "gw-host"
-					opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
-					opts.GatewayFlags.SOCKS5Proxy = "socks5"
+						It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
+							(*runner).RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
+								agentClient.EXPECT().CleanUpSSH(gomock.Any()).Times(0)
+								return nil
+							}
+							agentClient.EXPECT().SetUpSSH(gomock.Eq(ExpUsername), mocks.GomegaMock(ContainSubstring("ssh-rsa AAAA"))).
+								Times(1)
+							agentClient.EXPECT().CleanUpSSH(gomock.Eq(ExpUsername)).
+								Times(1)
 
-					Expect(act()).ToNot(HaveOccurred())
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
 
-					Expect((*runner).RunCallCount()).To(Equal(1))
+							Expect((*runner).RunCallCount()).To(Equal(1))
+						})
 
-					runConnOpts, runResult, runCommand := (*runner).RunArgsForCall(0)
-					Expect(runConnOpts.RawOpts).To(Equal([]string{"raw1", "raw2", "-o", "StrictHostKeyChecking=yes"}))
-					Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
-					Expect(runConnOpts.GatewayDisable).To(Equal(true))
-					Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
-					Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
-					Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
-					Expect(runConnOpts.SOCKS5Proxy).To(Equal("socks5"))
-					Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
-					Expect(runCommand).To(Equal([]string{"cmd", "arg1"}))
-				})
+						It("runs non-interactive SSH", func() {
+							agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+								Times(1)
+							agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+								Times(1)
 
-				It("returns error if non-interactive SSH session errors", func() {
-					(*runner).RunReturns(errors.New("fake-err"))
-					err := act()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-err"))
-				})
-			})
-		}
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
 
-		Context("when ui is interactive", func() {
-			BeforeEach(func() {
-				ui.Interactive = true
-			})
+							Expect((*runner).RunCallCount()).To(Equal(1))
+							Expect(intSSHRunner.RunCallCount()).To(Equal(0))
+						})
 
-			itRunsNonInteractiveSSHWhenCommandIsGiven(&nonIntSSHRunner)
+						It("returns an error if setting up SSH access fails", func() {
+							agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+								Return(agentclient.SSHResult{}, errors.New("fake-ssh-err")).
+								Times(1)
 
-			Context("when command is not provided", func() {
-				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
-					intSSHRunner.RunStub = func(boshssh.ConnectionOpts, boshdir.SSHResult, []string) error {
-						Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
-						return nil
-					}
-					Expect(act()).ToNot(HaveOccurred())
+							err := command.Run(opts)
 
-					Expect(deployment.SetUpSSHCallCount()).To(Equal(1))
-					Expect(intSSHRunner.RunCallCount()).To(Equal(1))
-					Expect(deployment.CleanUpSSHCallCount()).To(Equal(1))
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-ssh-err"))
+						})
 
-					setupSlug, setupSSHOpts := deployment.SetUpSSHArgsForCall(0)
-					Expect(setupSlug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job-name", "")))
-					Expect(setupSSHOpts.Username).To(Equal(ExpUsername))
-					Expect(setupSSHOpts.PublicKey).To(ContainSubstring("ssh-rsa AAAA"))
+						It("returns an error if generating SSH options fails", func() {
+							uuidGen.GenerateError = errors.New("fake-uuid-err")
 
-					slug, sshOpts := deployment.CleanUpSSHArgsForCall(0)
-					Expect(slug).To(Equal(setupSlug))
-					Expect(sshOpts).To(Equal(setupSSHOpts))
-				})
+							err := command.Run(opts)
 
-				It("runs only interactive SSH", func() {
-					Expect(act()).ToNot(HaveOccurred())
-					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
-					Expect(intSSHRunner.RunCallCount()).To(Equal(1))
-					Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
-				})
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-uuid-err"))
+						})
 
-				It("returns an error if setting up SSH access fails", func() {
-					deployment.SetUpSSHReturns(boshdir.SSHResult{}, errors.New("fake-err"))
-					err := act()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-err"))
-				})
+						It("runs non-interactive SSH session with flags, and command", func() {
+							result := agentclient.SSHResult{
+								Command:       "setup",
+								Status:        "success",
+								Ip:            "10.0.0.5",
+								HostPublicKey: "some-public-key",
+							}
+							agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+								Return(result, nil).
+								Times(1)
+							agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+								Times(1)
 
-				It("runs interactive SSH session with flags, but without command", func() {
-					result := boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}
-					deployment.SetUpSSHReturns(result, nil)
+							opts.RawOpts = TrimmedSpaceArgs([]string{"raw1", "raw2"})
+							opts.GatewayFlags.Disable = true
+							opts.GatewayFlags.Username = "gw-username"
+							opts.GatewayFlags.Host = "gw-host"
+							opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+							opts.GatewayFlags.SOCKS5Proxy = "socks5"
 
-					opts.RawOpts = TrimmedSpaceArgs([]string{"raw1", "raw2"})
-					opts.GatewayFlags.Disable = true
-					opts.GatewayFlags.Username = "gw-username"
-					opts.GatewayFlags.Host = "gw-host"
-					opts.GatewayFlags.PrivateKeyPath = "gw-private-key"
+							Expect(command.Run(opts)).ToNot(HaveOccurred())
 
-					Expect(act()).ToNot(HaveOccurred())
+							Expect((*runner).RunCallCount()).To(Equal(1))
 
-					Expect(intSSHRunner.RunCallCount()).To(Equal(1))
+							runConnOpts, runResult, runCommand := (*runner).RunArgsForCall(0)
+							Expect(runConnOpts.RawOpts).To(Equal([]string{"raw1", "raw2", "-o", "StrictHostKeyChecking=yes"}))
+							Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
+							Expect(runConnOpts.GatewayDisable).To(Equal(true))
+							Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
+							Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
+							Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
+							Expect(runConnOpts.SOCKS5Proxy).To(Equal("socks5"))
+							Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Username: ExpUsername, Host: "10.0.0.5", HostPublicKey: "some-public-key", Job: "create-env-vm", IndexOrID: "0"}}}))
+							Expect(runCommand).To(Equal([]string{"cmd", "arg1"}))
+						})
 
-					runConnOpts, runResult, runCommand := intSSHRunner.RunArgsForCall(0)
-					Expect(runConnOpts.RawOpts).To(Equal([]string{"raw1", "raw2", "-o", "StrictHostKeyChecking=yes"}))
-					Expect(runConnOpts.PrivateKey).To(ContainSubstring("-----BEGIN RSA PRIVATE KEY-----"))
-					Expect(runConnOpts.GatewayDisable).To(Equal(true))
-					Expect(runConnOpts.GatewayUsername).To(Equal("gw-username"))
-					Expect(runConnOpts.GatewayHost).To(Equal("gw-host"))
-					Expect(runConnOpts.GatewayPrivateKeyPath).To(Equal("gw-private-key"))
-					Expect(runResult).To(Equal(boshdir.SSHResult{Hosts: []boshdir.Host{{Host: "ip1"}}}))
-					Expect(runCommand).To(BeNil())
-				})
+						It("returns error if non-interactive SSH session errors", func() {
+							(*runner).RunReturns(errors.New("fake-err"))
+							agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+								Times(1)
+							agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+								Times(1)
 
-				It("returns error if interactive SSH session errors", func() {
-					intSSHRunner.RunReturns(errors.New("fake-err"))
-					err := act()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("fake-err"))
-				})
-			})
-		})
+							err := command.Run(opts)
 
-		Context("when ui is not interactive", func() {
-			BeforeEach(func() {
-				ui.Interactive = false
-			})
-
-			itRunsNonInteractiveSSHWhenCommandIsGiven(&nonIntSSHRunner)
-
-			Context("when command is not provided", func() {
-				It("returns an error since command is required", func() {
-					Expect(act()).To(Equal(errors.New("Non-interactive SSH requires non-empty command")))
-				})
-
-				It("does not try to run any SSH sessions", func() {
-					Expect(act()).To(HaveOccurred())
-					Expect(intSSHRunner.RunCallCount()).To(Equal(0))
-					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
-					Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
-				})
-			})
-		})
-
-		Context("when results are requested", func() {
-			BeforeEach(func() {
-				ui.Interactive = true
-				opts.Results = true
-			})
-
-			itRunsNonInteractiveSSHWhenCommandIsGiven(&resultsSSHRunner)
-
-			Context("when command is not provided", func() {
-				It("returns an error since command is required", func() {
-					Expect(act()).To(Equal(errors.New("Non-interactive SSH requires non-empty command")))
-				})
-
-				It("does not try to run any SSH sessions", func() {
-					Expect(act()).To(HaveOccurred())
-					Expect(intSSHRunner.RunCallCount()).To(Equal(0))
-					Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
-					Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
-				})
-			})
-		})
-
-		Context("when private key is provided", func() {
-			var expectedHost = boshdir.Host{
-				Job:       "",
-				IndexOrID: "",
-				Username:  "vcap",
-				Host:      "1.2.3.4",
-			}
-			BeforeEach(func() {
-				ui.Interactive = false
-				opts.Command = []string{"do", "it"}
-
-				opts.PrivateKey.Bytes = []byte("topsecret")
-				opts.Username = "vcap"
-				opts.Args.Slug, _ = boshdir.NewAllOrInstanceGroupOrInstanceSlugFromString("1.2.3.4")
-
-				hostBuilder.BuildHostReturns(expectedHost, nil)
-			})
-
-			It("agent is not used to setup ssh", func() {
-				Expect(act()).ToNot(HaveOccurred())
-				Expect(deployment.SetUpSSHCallCount()).To(Equal(0))
-				Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
-			})
-
-			It("builds host from args", func() {
-				Expect(act()).ToNot(HaveOccurred())
-
-				Expect(hostBuilder.BuildHostCallCount()).To(Equal(1))
-				slug, username, _ := hostBuilder.BuildHostArgsForCall(0)
-
-				Expect(slug).To(Equal(opts.Args.Slug))
-				Expect(username).To(Equal(opts.Username))
-
-				Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
-				conn, result, _ := nonIntSSHRunner.RunArgsForCall(0)
-
-				expectedResult := boshdir.SSHResult{
-					Hosts: []boshdir.Host{
-						expectedHost,
-					},
-					GatewayUsername: "",
-					GatewayHost:     "",
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring("fake-err"))
+						})
+					})
 				}
-				Expect(result).To(Equal(expectedResult))
 
-				expectedConn := boshssh.ConnectionOpts{
-					PrivateKey: "topsecret",
+				Context("when ui is interactive", func() {
+					BeforeEach(func() {
+						ui.Interactive = true
+					})
 
-					GatewayDisable: false,
+					itRunsSpecifiedRunnerProperlyWhenCommandGiven(&nonIntSSHRunner)
 
-					GatewayUsername:       "",
-					GatewayHost:           "",
-					GatewayPrivateKeyPath: "",
+					It("uses the interactive runner", func() {
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+							Times(1)
 
-					SOCKS5Proxy: "",
-					RawOpts:     []string{"-o", "StrictHostKeyChecking=no"},
-				}
-				Expect(conn).To(Equal(expectedConn))
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
 
+						Expect(intSSHRunner.RunCallCount()).To(Equal(1))
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when ui is noninteractive", func() {
+					BeforeEach(func() {
+						ui.Interactive = false
+					})
+
+					itRunsSpecifiedRunnerProperlyWhenCommandGiven(&nonIntSSHRunner)
+
+					It("uses the noninteractive runner", func() {
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+							Times(1)
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(intSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(1))
+						Expect(resultsSSHRunner.RunCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when the results option is used", func() {
+					BeforeEach(func() {
+						opts.Results = true
+					})
+
+					itRunsSpecifiedRunnerProperlyWhenCommandGiven(&resultsSSHRunner)
+
+					It("uses the results runner", func() {
+						agentClient.EXPECT().SetUpSSH(gomock.Any(), gomock.Any()).
+							Times(1)
+						agentClient.EXPECT().CleanUpSSH(gomock.Any()).
+							Times(1)
+
+						Expect(command.Run(opts)).ToNot(HaveOccurred())
+
+						Expect(intSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(nonIntSSHRunner.RunCallCount()).To(Equal(0))
+						Expect(resultsSSHRunner.RunCallCount()).To(Equal(1))
+					})
+				})
 			})
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/clock v1.0.0
 	code.cloudfoundry.org/workpool v0.0.0-20200131000409-2ac56b354115
 	github.com/cheggaaa/pb/v3 v3.1.2
-	github.com/cloudfoundry/bosh-agent v2.367.0+incompatible
+	github.com/cloudfoundry/bosh-agent v0.0.61-0.20230301011448-4cfe06c13ad7
 	github.com/cloudfoundry/bosh-davcli v0.0.161
 	github.com/cloudfoundry/bosh-gcscli v0.0.108
 	github.com/cloudfoundry/bosh-s3cli v0.0.178

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudfoundry/bosh-agent v0.0.61-0.20230301011448-4cfe06c13ad7 h1:WqAIRLehvJrDhnDaVDS+OTjlbmHInIVU+dhVcvUWqmA=
+github.com/cloudfoundry/bosh-agent v0.0.61-0.20230301011448-4cfe06c13ad7/go.mod h1:FVqJVDjAlpDNjaI1k79SXdh+ymNMDWPg38jSIzYUF+4=
 github.com/cloudfoundry/bosh-agent v2.367.0+incompatible h1:cdpYNIqi69cIl1JP8D/3nvQcnPP0su0xapMzzBMXOSw=
 github.com/cloudfoundry/bosh-agent v2.367.0+incompatible/go.mod h1:7UvVn5vc/d6icLrBx6GhBlpSMwe2+x1C2A7x4TbPhiU=
 github.com/cloudfoundry/bosh-davcli v0.0.161 h1:2sj/6xkUsE6GgoA56oLq0b9YmgzNeNEDeZktmoQDeLE=

--- a/vendor/github.com/cloudfoundry/bosh-agent/agentclient/agent_client_interface.go
+++ b/vendor/github.com/cloudfoundry/bosh-agent/agentclient/agent_client_interface.go
@@ -2,7 +2,7 @@ package agentclient
 
 import "github.com/cloudfoundry/bosh-agent/agentclient/applyspec"
 
-//go:generate counterfeiter -o fakes/fake_agent_client.go agent_client_interface.go AgentClient
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o fakes/fake_agent_client.go . AgentClient
 
 type AgentClient interface {
 	Ping() (string, error)
@@ -21,6 +21,10 @@ type AgentClient interface {
 	DeleteARPEntries(ips []string) error
 	SyncDNS(blobID, sha1 string, version uint64) (string, error)
 	RunScript(scriptName string, options map[string]interface{}) error
+	SetUpSSH(username string, publicKey string) (SSHResult, error)
+	CleanUpSSH(username string) (SSHResult, error)
+	BundleLogs(owningUser string, logType string, filters []string) (BundleLogsResult, error)
+	RemoveFile(path string) error
 }
 
 type AgentState struct {
@@ -37,4 +41,16 @@ type BlobRef struct {
 	Version     string
 	BlobstoreID string
 	SHA1        string
+}
+
+type SSHResult struct {
+	Command       string
+	Status        string
+	Ip            string
+	HostPublicKey string
+}
+
+type BundleLogsResult struct {
+	LogsTarPath  string
+	SHA512Digest string
 }

--- a/vendor/github.com/cloudfoundry/bosh-agent/agentclient/fakes/fake_agent_client.go
+++ b/vendor/github.com/cloudfoundry/bosh-agent/agentclient/fakes/fake_agent_client.go
@@ -32,6 +32,34 @@ type FakeAgentClient struct {
 	applyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	BundleLogsStub        func(string, string, []string) (agentclient.BundleLogsResult, error)
+	bundleLogsMutex       sync.RWMutex
+	bundleLogsArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 []string
+	}
+	bundleLogsReturns struct {
+		result1 agentclient.BundleLogsResult
+		result2 error
+	}
+	bundleLogsReturnsOnCall map[int]struct {
+		result1 agentclient.BundleLogsResult
+		result2 error
+	}
+	CleanUpSSHStub        func(string) (agentclient.SSHResult, error)
+	cleanUpSSHMutex       sync.RWMutex
+	cleanUpSSHArgsForCall []struct {
+		arg1 string
+	}
+	cleanUpSSHReturns struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}
+	cleanUpSSHReturnsOnCall map[int]struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}
 	CompilePackageStub        func(agentclient.BlobRef, []agentclient.BlobRef) (agentclient.BlobRef, error)
 	compilePackageMutex       sync.RWMutex
 	compilePackageArgsForCall []struct {
@@ -127,6 +155,17 @@ type FakeAgentClient struct {
 		result1 string
 		result2 error
 	}
+	RemoveFileStub        func(string) error
+	removeFileMutex       sync.RWMutex
+	removeFileArgsForCall []struct {
+		arg1 string
+	}
+	removeFileReturns struct {
+		result1 error
+	}
+	removeFileReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RemovePersistentDiskStub        func(string) error
 	removePersistentDiskMutex       sync.RWMutex
 	removePersistentDiskArgsForCall []struct {
@@ -149,6 +188,20 @@ type FakeAgentClient struct {
 	}
 	runScriptReturnsOnCall map[int]struct {
 		result1 error
+	}
+	SetUpSSHStub        func(string, string) (agentclient.SSHResult, error)
+	setUpSSHMutex       sync.RWMutex
+	setUpSSHArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	setUpSSHReturns struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}
+	setUpSSHReturnsOnCall map[int]struct {
+		result1 agentclient.SSHResult
+		result2 error
 	}
 	StartStub        func() error
 	startMutex       sync.RWMutex
@@ -319,6 +372,139 @@ func (fake *FakeAgentClient) ApplyReturnsOnCall(i int, result1 error) {
 	fake.applyReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeAgentClient) BundleLogs(arg1 string, arg2 string, arg3 []string) (agentclient.BundleLogsResult, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.bundleLogsMutex.Lock()
+	ret, specificReturn := fake.bundleLogsReturnsOnCall[len(fake.bundleLogsArgsForCall)]
+	fake.bundleLogsArgsForCall = append(fake.bundleLogsArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 []string
+	}{arg1, arg2, arg3Copy})
+	fake.recordInvocation("BundleLogs", []interface{}{arg1, arg2, arg3Copy})
+	fake.bundleLogsMutex.Unlock()
+	if fake.BundleLogsStub != nil {
+		return fake.BundleLogsStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.bundleLogsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAgentClient) BundleLogsCallCount() int {
+	fake.bundleLogsMutex.RLock()
+	defer fake.bundleLogsMutex.RUnlock()
+	return len(fake.bundleLogsArgsForCall)
+}
+
+func (fake *FakeAgentClient) BundleLogsCalls(stub func(string, string, []string) (agentclient.BundleLogsResult, error)) {
+	fake.bundleLogsMutex.Lock()
+	defer fake.bundleLogsMutex.Unlock()
+	fake.BundleLogsStub = stub
+}
+
+func (fake *FakeAgentClient) BundleLogsArgsForCall(i int) (string, string, []string) {
+	fake.bundleLogsMutex.RLock()
+	defer fake.bundleLogsMutex.RUnlock()
+	argsForCall := fake.bundleLogsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeAgentClient) BundleLogsReturns(result1 agentclient.BundleLogsResult, result2 error) {
+	fake.bundleLogsMutex.Lock()
+	defer fake.bundleLogsMutex.Unlock()
+	fake.BundleLogsStub = nil
+	fake.bundleLogsReturns = struct {
+		result1 agentclient.BundleLogsResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAgentClient) BundleLogsReturnsOnCall(i int, result1 agentclient.BundleLogsResult, result2 error) {
+	fake.bundleLogsMutex.Lock()
+	defer fake.bundleLogsMutex.Unlock()
+	fake.BundleLogsStub = nil
+	if fake.bundleLogsReturnsOnCall == nil {
+		fake.bundleLogsReturnsOnCall = make(map[int]struct {
+			result1 agentclient.BundleLogsResult
+			result2 error
+		})
+	}
+	fake.bundleLogsReturnsOnCall[i] = struct {
+		result1 agentclient.BundleLogsResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAgentClient) CleanUpSSH(arg1 string) (agentclient.SSHResult, error) {
+	fake.cleanUpSSHMutex.Lock()
+	ret, specificReturn := fake.cleanUpSSHReturnsOnCall[len(fake.cleanUpSSHArgsForCall)]
+	fake.cleanUpSSHArgsForCall = append(fake.cleanUpSSHArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("CleanUpSSH", []interface{}{arg1})
+	fake.cleanUpSSHMutex.Unlock()
+	if fake.CleanUpSSHStub != nil {
+		return fake.CleanUpSSHStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.cleanUpSSHReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAgentClient) CleanUpSSHCallCount() int {
+	fake.cleanUpSSHMutex.RLock()
+	defer fake.cleanUpSSHMutex.RUnlock()
+	return len(fake.cleanUpSSHArgsForCall)
+}
+
+func (fake *FakeAgentClient) CleanUpSSHCalls(stub func(string) (agentclient.SSHResult, error)) {
+	fake.cleanUpSSHMutex.Lock()
+	defer fake.cleanUpSSHMutex.Unlock()
+	fake.CleanUpSSHStub = stub
+}
+
+func (fake *FakeAgentClient) CleanUpSSHArgsForCall(i int) string {
+	fake.cleanUpSSHMutex.RLock()
+	defer fake.cleanUpSSHMutex.RUnlock()
+	argsForCall := fake.cleanUpSSHArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeAgentClient) CleanUpSSHReturns(result1 agentclient.SSHResult, result2 error) {
+	fake.cleanUpSSHMutex.Lock()
+	defer fake.cleanUpSSHMutex.Unlock()
+	fake.CleanUpSSHStub = nil
+	fake.cleanUpSSHReturns = struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAgentClient) CleanUpSSHReturnsOnCall(i int, result1 agentclient.SSHResult, result2 error) {
+	fake.cleanUpSSHMutex.Lock()
+	defer fake.cleanUpSSHMutex.Unlock()
+	fake.CleanUpSSHStub = nil
+	if fake.cleanUpSSHReturnsOnCall == nil {
+		fake.cleanUpSSHReturnsOnCall = make(map[int]struct {
+			result1 agentclient.SSHResult
+			result2 error
+		})
+	}
+	fake.cleanUpSSHReturnsOnCall[i] = struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeAgentClient) CompilePackage(arg1 agentclient.BlobRef, arg2 []agentclient.BlobRef) (agentclient.BlobRef, error) {
@@ -795,6 +981,66 @@ func (fake *FakeAgentClient) PingReturnsOnCall(i int, result1 string, result2 er
 	}{result1, result2}
 }
 
+func (fake *FakeAgentClient) RemoveFile(arg1 string) error {
+	fake.removeFileMutex.Lock()
+	ret, specificReturn := fake.removeFileReturnsOnCall[len(fake.removeFileArgsForCall)]
+	fake.removeFileArgsForCall = append(fake.removeFileArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("RemoveFile", []interface{}{arg1})
+	fake.removeFileMutex.Unlock()
+	if fake.RemoveFileStub != nil {
+		return fake.RemoveFileStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.removeFileReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeAgentClient) RemoveFileCallCount() int {
+	fake.removeFileMutex.RLock()
+	defer fake.removeFileMutex.RUnlock()
+	return len(fake.removeFileArgsForCall)
+}
+
+func (fake *FakeAgentClient) RemoveFileCalls(stub func(string) error) {
+	fake.removeFileMutex.Lock()
+	defer fake.removeFileMutex.Unlock()
+	fake.RemoveFileStub = stub
+}
+
+func (fake *FakeAgentClient) RemoveFileArgsForCall(i int) string {
+	fake.removeFileMutex.RLock()
+	defer fake.removeFileMutex.RUnlock()
+	argsForCall := fake.removeFileArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeAgentClient) RemoveFileReturns(result1 error) {
+	fake.removeFileMutex.Lock()
+	defer fake.removeFileMutex.Unlock()
+	fake.RemoveFileStub = nil
+	fake.removeFileReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeAgentClient) RemoveFileReturnsOnCall(i int, result1 error) {
+	fake.removeFileMutex.Lock()
+	defer fake.removeFileMutex.Unlock()
+	fake.RemoveFileStub = nil
+	if fake.removeFileReturnsOnCall == nil {
+		fake.removeFileReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeFileReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeAgentClient) RemovePersistentDisk(arg1 string) error {
 	fake.removePersistentDiskMutex.Lock()
 	ret, specificReturn := fake.removePersistentDiskReturnsOnCall[len(fake.removePersistentDiskArgsForCall)]
@@ -914,6 +1160,70 @@ func (fake *FakeAgentClient) RunScriptReturnsOnCall(i int, result1 error) {
 	fake.runScriptReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeAgentClient) SetUpSSH(arg1 string, arg2 string) (agentclient.SSHResult, error) {
+	fake.setUpSSHMutex.Lock()
+	ret, specificReturn := fake.setUpSSHReturnsOnCall[len(fake.setUpSSHArgsForCall)]
+	fake.setUpSSHArgsForCall = append(fake.setUpSSHArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SetUpSSH", []interface{}{arg1, arg2})
+	fake.setUpSSHMutex.Unlock()
+	if fake.SetUpSSHStub != nil {
+		return fake.SetUpSSHStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.setUpSSHReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAgentClient) SetUpSSHCallCount() int {
+	fake.setUpSSHMutex.RLock()
+	defer fake.setUpSSHMutex.RUnlock()
+	return len(fake.setUpSSHArgsForCall)
+}
+
+func (fake *FakeAgentClient) SetUpSSHCalls(stub func(string, string) (agentclient.SSHResult, error)) {
+	fake.setUpSSHMutex.Lock()
+	defer fake.setUpSSHMutex.Unlock()
+	fake.SetUpSSHStub = stub
+}
+
+func (fake *FakeAgentClient) SetUpSSHArgsForCall(i int) (string, string) {
+	fake.setUpSSHMutex.RLock()
+	defer fake.setUpSSHMutex.RUnlock()
+	argsForCall := fake.setUpSSHArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeAgentClient) SetUpSSHReturns(result1 agentclient.SSHResult, result2 error) {
+	fake.setUpSSHMutex.Lock()
+	defer fake.setUpSSHMutex.Unlock()
+	fake.SetUpSSHStub = nil
+	fake.setUpSSHReturns = struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAgentClient) SetUpSSHReturnsOnCall(i int, result1 agentclient.SSHResult, result2 error) {
+	fake.setUpSSHMutex.Lock()
+	defer fake.setUpSSHMutex.Unlock()
+	fake.SetUpSSHStub = nil
+	if fake.setUpSSHReturnsOnCall == nil {
+		fake.setUpSSHReturnsOnCall = make(map[int]struct {
+			result1 agentclient.SSHResult
+			result2 error
+		})
+	}
+	fake.setUpSSHReturnsOnCall[i] = struct {
+		result1 agentclient.SSHResult
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeAgentClient) Start() error {
@@ -1152,6 +1462,10 @@ func (fake *FakeAgentClient) Invocations() map[string][][]interface{} {
 	defer fake.addPersistentDiskMutex.RUnlock()
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
+	fake.bundleLogsMutex.RLock()
+	defer fake.bundleLogsMutex.RUnlock()
+	fake.cleanUpSSHMutex.RLock()
+	defer fake.cleanUpSSHMutex.RUnlock()
 	fake.compilePackageMutex.RLock()
 	defer fake.compilePackageMutex.RUnlock()
 	fake.deleteARPEntriesMutex.RLock()
@@ -1168,10 +1482,14 @@ func (fake *FakeAgentClient) Invocations() map[string][][]interface{} {
 	defer fake.mountDiskMutex.RUnlock()
 	fake.pingMutex.RLock()
 	defer fake.pingMutex.RUnlock()
+	fake.removeFileMutex.RLock()
+	defer fake.removeFileMutex.RUnlock()
 	fake.removePersistentDiskMutex.RLock()
 	defer fake.removePersistentDiskMutex.RUnlock()
 	fake.runScriptMutex.RLock()
 	defer fake.runScriptMutex.RUnlock()
+	fake.setUpSSHMutex.RLock()
+	defer fake.setUpSSHMutex.RUnlock()
 	fake.startMutex.RLock()
 	defer fake.startMutex.RUnlock()
 	fake.stopMutex.RLock()

--- a/vendor/github.com/cloudfoundry/bosh-agent/agentclient/http/agent_request.go
+++ b/vendor/github.com/cloudfoundry/bosh-agent/agentclient/http/agent_request.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -48,7 +48,7 @@ func (r agentRequest) Send(method string, arguments []interface{}, response Resp
 		return bosherr.Errorf("Agent responded with non-successful status code: %d", httpResponse.StatusCode)
 	}
 
-	responseBody, err := ioutil.ReadAll(httpResponse.Body)
+	responseBody, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return bosherr.WrapError(err, "Reading agent response")
 	}

--- a/vendor/github.com/cloudfoundry/bosh-agent/agentclient/http/agent_response.go
+++ b/vendor/github.com/cloudfoundry/bosh-agent/agentclient/http/agent_response.go
@@ -2,11 +2,11 @@ package http
 
 import (
 	"encoding/json"
-
 	"runtime/debug"
 
-	"github.com/cloudfoundry/bosh-agent/agentclient"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+
+	"github.com/cloudfoundry/bosh-agent/agentclient"
 )
 
 type Response interface {
@@ -161,4 +161,48 @@ func (r *TaskResponse) TaskState() (string, error) {
 	}
 
 	return "finished", nil
+}
+
+type SSHResponse struct {
+	Value     SSHState
+	Exception *exception
+}
+
+func (r *SSHResponse) ServerError() error {
+	if r.Exception != nil {
+		return bosherr.Errorf("Agent responded with error: %s", r.Exception.Message)
+	}
+	return nil
+}
+
+func (r *SSHResponse) Unmarshal(message []byte) error {
+	return json.Unmarshal(message, r)
+}
+
+type SSHState struct {
+	Command       string `json:"command"`
+	Status        string `json:"status"`
+	Ip            string `json:"ip"`
+	HostPublicKey string `json:"host_public_key"`
+}
+
+type BundleLogsResponse struct {
+	Value     BundleLogsState
+	Exception *exception
+}
+
+func (r *BundleLogsResponse) ServerError() error {
+	if r.Exception != nil {
+		return bosherr.Errorf("Agent responded with error: %s", r.Exception.Message)
+	}
+	return nil
+}
+
+func (r *BundleLogsResponse) Unmarshal(message []byte) error {
+	return json.Unmarshal(message, r)
+}
+
+type BundleLogsState struct {
+	LogsTarPath  string `json:"logs_tar_path"`
+	SHA512Digest string `json:"sha512"`
 }

--- a/vendor/github.com/cloudfoundry/bosh-agent/agentclient/http/mocks/mocks.go
+++ b/vendor/github.com/cloudfoundry/bosh-agent/agentclient/http/mocks/mocks.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	agentclient "github.com/cloudfoundry/bosh-agent/agentclient"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockAgentClientFactory is a mock of AgentClientFactory interface
+// MockAgentClientFactory is a mock of AgentClientFactory interface.
 type MockAgentClientFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockAgentClientFactoryMockRecorder
 }
 
-// MockAgentClientFactoryMockRecorder is the mock recorder for MockAgentClientFactory
+// MockAgentClientFactoryMockRecorder is the mock recorder for MockAgentClientFactory.
 type MockAgentClientFactoryMockRecorder struct {
 	mock *MockAgentClientFactory
 }
 
-// NewMockAgentClientFactory creates a new mock instance
+// NewMockAgentClientFactory creates a new mock instance.
 func NewMockAgentClientFactory(ctrl *gomock.Controller) *MockAgentClientFactory {
 	mock := &MockAgentClientFactory{ctrl: ctrl}
 	mock.recorder = &MockAgentClientFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAgentClientFactory) EXPECT() *MockAgentClientFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewAgentClient mocks base method
+// NewAgentClient mocks base method.
 func (m *MockAgentClientFactory) NewAgentClient(directorID, mbusURL, caCert string) (agentclient.AgentClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewAgentClient", directorID, mbusURL, caCert)
@@ -42,7 +43,7 @@ func (m *MockAgentClientFactory) NewAgentClient(directorID, mbusURL, caCert stri
 	return ret0, ret1
 }
 
-// NewAgentClient indicates an expected call of NewAgentClient
+// NewAgentClient indicates an expected call of NewAgentClient.
 func (mr *MockAgentClientFactoryMockRecorder) NewAgentClient(directorID, mbusURL, caCert interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAgentClient", reflect.TypeOf((*MockAgentClientFactory)(nil).NewAgentClient), directorID, mbusURL, caCert)

--- a/vendor/github.com/cloudfoundry/bosh-agent/agentclient/ping_retryable.go
+++ b/vendor/github.com/cloudfoundry/bosh-agent/agentclient/ping_retryable.go
@@ -28,7 +28,7 @@ func (r *pingRetryable) Attempt() (bool, error) {
 				break
 			}
 		}
-		r, _ := regexp.Compile("x509: ")
+		r := regexp.MustCompile("x509: ")
 		if r.MatchString(err.Error()) {
 			return false, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,8 +171,8 @@ github.com/chavacava/garif
 ## explicit; go 1.17
 github.com/cheggaaa/pb/v3
 github.com/cheggaaa/pb/v3/termutil
-# github.com/cloudfoundry/bosh-agent v2.367.0+incompatible
-## explicit
+# github.com/cloudfoundry/bosh-agent v0.0.61-0.20230301011448-4cfe06c13ad7
+## explicit; go 1.20
 github.com/cloudfoundry/bosh-agent/agentclient
 github.com/cloudfoundry/bosh-agent/agentclient/applyspec
 github.com/cloudfoundry/bosh-agent/agentclient/fakes


### PR DESCRIPTION
3 new flags are added to the `logs`, `ssh`, and `scp` commands:
* `--director` targets the director's agent HTTP endpoint
* `--agent-endpoint` corresponds to the agent's HTTP endpoint, reference the [cloud_provider.mbus](https://github.com/cloudfoundry/bosh-deployment/blob/de79d6c790f531b56f32d5f303e9254a8fa1b20b/bosh.yml#L3) property of the director manifest
* `--agent-certificate` corresponds to the certificate provided to the agent's HTTP endpoint, reference the [cloud_prodvider.cert](https://github.com/cloudfoundry/bosh-deployment/blob/de79d6c790f531b56f32d5f303e9254a8fa1b20b/bosh.yml#L2) property of the director manifest

The functionality of all of these commands is the same as without the `--director` flag, with the exception of using a private key/username (which doesn't make much sense in this context).

This flag is `--director` for simplicity, and we imagine that it will mostly be used with BOSH directors, but this feature works with any VM created with the `bosh create-env` command.

This feature depends on `bosh-agent` code that is present on stemcell versions:
* Jammy: `1.93`
* Bionic: `1.181`