### PR TITLE
Adds --system and --all-logs flags to logs action

### DIFF
--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -66,10 +66,12 @@ var _ = Describe("LogsCmd", func() {
 
 				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				slug, filters, agent := deployment.FetchLogsArgsForCall(0)
+				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
 				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
 				Expect(filters).To(BeEmpty())
 				Expect(agent).To(BeFalse())
+				Expect(system).To(BeFalse())
+				Expect(all).To(BeFalse())
 
 				Expect(downloader.DownloadCallCount()).To(Equal(1))
 
@@ -91,10 +93,50 @@ var _ = Describe("LogsCmd", func() {
 
 				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
 
-				slug, filters, agent := deployment.FetchLogsArgsForCall(0)
+				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
 				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
 				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
 				Expect(agent).To(BeTrue())
+				Expect(system).To(BeFalse())
+				Expect(all).To(BeFalse())
+			})
+
+			It("fetches system logs and allows custom filters", func() {
+				opts.Filters = []string{"filter1", "filter2"}
+				opts.System = true
+
+				deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
+
+				err := act()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+
+				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
+				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
+				Expect(agent).To(BeFalse())
+				Expect(system).To(BeTrue())
+				Expect(all).To(BeFalse())
+			})
+
+			It("fetches all logs and allows custom filters", func() {
+				opts.Filters = []string{"filter1", "filter2"}
+				opts.All = true
+
+				deployment.FetchLogsReturns(boshdir.LogsResult{}, nil)
+
+				err := act()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(deployment.FetchLogsCallCount()).To(Equal(1))
+
+				slug, filters, agent, system, all := deployment.FetchLogsArgsForCall(0)
+				Expect(slug).To(Equal(boshdir.NewAllOrInstanceGroupOrInstanceSlug("job", "index")))
+				Expect(filters).To(Equal([]string{"filter1", "filter2"}))
+				Expect(agent).To(BeFalse())
+				Expect(system).To(BeFalse())
+				Expect(all).To(BeTrue())
 			})
 
 			It("fetches logs for more than one instance", func() {

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -853,6 +853,8 @@ type LogsOpts struct {
 	Jobs    []string `long:"job"   description:"Limit to only specific jobs"`
 	Filters []string `long:"only"  description:"Filter logs (comma-separated)"`
 	Agent   bool     `long:"agent" description:"Include only agent logs"`
+	System  bool     `long:"system" description:"Include only system logs"`
+	All     bool     `long:"all-logs" description:"Include all logs (agent, system, and job logs)"`
 
 	GatewayFlags
 

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -2580,6 +2580,22 @@ var _ = Describe("Opts", func() {
 				))
 			})
 		})
+
+		Describe("System", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("System", opts)).To(Equal(
+					`long:"system" description:"Include only system logs"`,
+				))
+			})
+		})
+
+		Describe("All", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("All", opts)).To(Equal(
+					`long:"all-logs" description:"Include all logs (agent, system, and job logs)"`,
+				))
+			})
+		})
 	})
 
 	Describe("StartOpts", func() {

--- a/director/directorfakes/fake_deployment.go
+++ b/director/directorfakes/fake_deployment.go
@@ -141,12 +141,14 @@ type FakeDeployment struct {
 		result1 director.ExportReleaseResult
 		result2 error
 	}
-	FetchLogsStub        func(director.AllOrInstanceGroupOrInstanceSlug, []string, bool) (director.LogsResult, error)
+	FetchLogsStub        func(director.AllOrInstanceGroupOrInstanceSlug, []string, bool, bool, bool) (director.LogsResult, error)
 	fetchLogsMutex       sync.RWMutex
 	fetchLogsArgsForCall []struct {
 		arg1 director.AllOrInstanceGroupOrInstanceSlug
 		arg2 []string
 		arg3 bool
+		arg4 bool
+		arg5 bool
 	}
 	fetchLogsReturns struct {
 		result1 director.LogsResult
@@ -1100,7 +1102,7 @@ func (fake *FakeDeployment) ExportReleaseReturnsOnCall(i int, result1 director.E
 	}{result1, result2}
 }
 
-func (fake *FakeDeployment) FetchLogs(arg1 director.AllOrInstanceGroupOrInstanceSlug, arg2 []string, arg3 bool) (director.LogsResult, error) {
+func (fake *FakeDeployment) FetchLogs(arg1 director.AllOrInstanceGroupOrInstanceSlug, arg2 []string, arg3 bool, arg4 bool, arg5 bool) (director.LogsResult, error) {
 	var arg2Copy []string
 	if arg2 != nil {
 		arg2Copy = make([]string, len(arg2))
@@ -1112,13 +1114,15 @@ func (fake *FakeDeployment) FetchLogs(arg1 director.AllOrInstanceGroupOrInstance
 		arg1 director.AllOrInstanceGroupOrInstanceSlug
 		arg2 []string
 		arg3 bool
-	}{arg1, arg2Copy, arg3})
+		arg4 bool
+		arg5 bool
+	}{arg1, arg2Copy, arg3, arg4, arg5})
 	stub := fake.FetchLogsStub
 	fakeReturns := fake.fetchLogsReturns
-	fake.recordInvocation("FetchLogs", []interface{}{arg1, arg2Copy, arg3})
+	fake.recordInvocation("FetchLogs", []interface{}{arg1, arg2Copy, arg3, arg4, arg5})
 	fake.fetchLogsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1132,17 +1136,17 @@ func (fake *FakeDeployment) FetchLogsCallCount() int {
 	return len(fake.fetchLogsArgsForCall)
 }
 
-func (fake *FakeDeployment) FetchLogsCalls(stub func(director.AllOrInstanceGroupOrInstanceSlug, []string, bool) (director.LogsResult, error)) {
+func (fake *FakeDeployment) FetchLogsCalls(stub func(director.AllOrInstanceGroupOrInstanceSlug, []string, bool, bool, bool) (director.LogsResult, error)) {
 	fake.fetchLogsMutex.Lock()
 	defer fake.fetchLogsMutex.Unlock()
 	fake.FetchLogsStub = stub
 }
 
-func (fake *FakeDeployment) FetchLogsArgsForCall(i int) (director.AllOrInstanceGroupOrInstanceSlug, []string, bool) {
+func (fake *FakeDeployment) FetchLogsArgsForCall(i int) (director.AllOrInstanceGroupOrInstanceSlug, []string, bool, bool, bool) {
 	fake.fetchLogsMutex.RLock()
 	defer fake.fetchLogsMutex.RUnlock()
 	argsForCall := fake.fetchLogsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeDeployment) FetchLogsReturns(result1 director.LogsResult, result2 error) {

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -172,7 +172,7 @@ type Deployment interface {
 	CleanUpSSH(AllOrInstanceGroupOrInstanceSlug, SSHOpts) error
 
 	// Instance specifics
-	FetchLogs(AllOrInstanceGroupOrInstanceSlug, []string, bool) (LogsResult, error)
+	FetchLogs(AllOrInstanceGroupOrInstanceSlug, []string, bool, bool, bool) (LogsResult, error)
 	TakeSnapshot(InstanceSlug) error
 	Ignore(InstanceSlug, bool) error
 	EnableResurrection(InstanceSlug, bool) error


### PR DESCRIPTION
This commit adds the --system and --all-logs flags to the "bosh logs" action.

The --system flag allows an operator to fetch or follow logs in the '/var/log' directory in a Bosh-deployed VM. The --all-logs flag allows an operator to fetch or follow logs provided by all of the --jobs (the default flag if none are specified), --agent, and --system flags in one convenient operation.

The code for the --system flag in the --follow operation adds a dependency on the 'find' command, but we believe that we currently include that command in every stemcell that we ship, so this should not be a problem. Because /var/log typically contains rotated logs, as well as files that are binary data, we had file-exclusion requirements that were too complex to be expressed with a glob pattern.

This commit also contains a rename of the "job" function parameter in Client.FetchLogs to "instance". The name for this concept has been "instance" for at _least_ five years, and this discrepancy was _Very Confusing_ to us when we were trying to understand that section of the code. So, we renamed the variable.

It's also important to note that use of the --follow flag should work with any version of the Bosh Agent, but _downloading_ the --system or --all-logs logs (done by omitting the --follow flag) requires Bosh Agent changes to handle the new log types. This change is backwards compatible- incompatible Agents will return an error if either the --system or --all-logs flag is used, and will work correctly if neither one is used.