### PR TITLE
release linux arm64 version

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -171,6 +171,8 @@ jobs:
       - in_parallel:
         - task: build-linux-amd64
           file: bosh-cli/ci/tasks/build-linux-amd64.yml
+        - task: build-linux-arm64
+          file: bosh-cli/ci/tasks/build-linux-arm64.yml
         - task: build-darwin-amd64
           file: bosh-cli/ci/tasks/build-darwin-amd64.yml
         - task: build-darwin-arm64
@@ -193,6 +195,7 @@ jobs:
 
       - in_parallel:
         - {put: release-bucket-linux, params: {file: compiled-linux-amd64/bosh-cli-*-linux-amd64}}
+        - {put: release-bucket-linux-arm64, params: {file: compiled-linux-arm64/bosh-cli-*-linux-arm64}}
         - {put: release-bucket-darwin, params: {file: compiled-darwin-amd64/bosh-cli-*-darwin-amd64}}
         - {put: release-bucket-darwin-arm64, params: {file: compiled-darwin-arm64/bosh-cli-*-darwin-arm64}}
         - {put: release-bucket-windows, params: {file: compiled-windows-amd64/bosh-cli-*-windows-amd64.exe}}
@@ -227,6 +230,7 @@ jobs:
             tag: release-version/version
             globs:
               - compiled-linux-amd64/bosh-cli-*-linux-amd64
+              - compiled-linux-arm64/bosh-cli-*-linux-arm64
               - compiled-darwin-amd64/bosh-cli-*-darwin-amd64
               - compiled-darwin-arm64/bosh-cli-*-darwin-arm64
               - compiled-windows-amd64/bosh-cli-*-windows-amd64.exe
@@ -268,6 +272,11 @@ jobs:
           file: bosh-cli/ci/tasks/build-linux-amd64.yml
           params:
             FILENAME_PREFIX: "alpha-"
+        - task: build-linux-arm64
+          input_mapping: {version-semver: alpha-version-semver}
+          file: bosh-cli/ci/tasks/build-linux-arm64.yml
+          params:
+            FILENAME_PREFIX: "alpha-"
         - task: build-darwin-amd64
           input_mapping: {version-semver: alpha-version-semver}
           file: bosh-cli/ci/tasks/build-darwin-amd64.yml
@@ -286,6 +295,7 @@ jobs:
 
       - in_parallel:
         - {put: alpha-release-bucket-linux-amd64, params: {file: compiled-linux-amd64/alpha-bosh-cli-*-linux-amd64}}
+        - {put: alpha-release-bucket-linux-arm64, params: {file: compiled-linux-arm64/alpha-bosh-cli-*-linux-arm64}}
         - {put: alpha-release-bucket-darwin-amd64, params: {file: compiled-darwin-amd64/alpha-bosh-cli-*-darwin-amd64}}
         - {put: alpha-release-bucket-darwin-arm64, params: {file: compiled-darwin-arm64/alpha-bosh-cli-*-darwin-arm64}}
         - {put: alpha-release-bucket-windows-amd64, params: {file: compiled-windows-amd64/alpha-bosh-cli-*-windows-amd64.exe}}
@@ -352,6 +362,15 @@ resources:
       access_key_id: ((bosh-cli-artifacts-upload_aws_access_key.username))
       secret_access_key: ((bosh-cli-artifacts-upload_aws_access_key.password))
 
+  - name: release-bucket-linux-arm64
+    type: s3
+    source:
+      regexp: bosh-cli-(.*)-linux-arm64
+      bucket: bosh-cli-artifacts
+      region_name: us-east-1
+      access_key_id: ((bosh-cli-artifacts-upload_aws_access_key.username))
+      secret_access_key: ((bosh-cli-artifacts-upload_aws_access_key.password))
+
   - name: release-bucket-darwin
     type: s3
     source:
@@ -383,6 +402,15 @@ resources:
     type: s3
     source:
       regexp: alpha-bosh-cli-(.*)-linux-amd64
+      bucket: bosh-cli-alpha-artifacts
+      region_name: us-east-1
+      access_key_id: ((bosh-cli-artifacts-upload_aws_access_key.username))
+      secret_access_key: ((bosh-cli-artifacts-upload_aws_access_key.password))
+
+  - name: alpha-release-bucket-linux-arm64
+    type: s3
+    source:
+      regexp: alpha-bosh-cli-(.*)-linux-arm64
       bucket: bosh-cli-alpha-artifacts
       region_name: us-east-1
       access_key_id: ((bosh-cli-artifacts-upload_aws_access_key.username))

--- a/ci/tasks/build-checksum-file.sh
+++ b/ci/tasks/build-checksum-file.sh
@@ -14,6 +14,10 @@ pushd compiled-linux-amd64
   shasum -a 256 bosh-cli-*-linux-amd64 >> $base/binary-checksums
 popd
 
+pushd compiled-linux-arm64
+  shasum -a 256 bosh-cli-*-linux-arm64 >> $base/binary-checksums
+popd
+
 pushd compiled-darwin-amd64
   shasum -a 256 bosh-cli-*-darwin-amd64 >> $base/binary-checksums
 popd

--- a/ci/tasks/build-checksum-file.yml
+++ b/ci/tasks/build-checksum-file.yml
@@ -10,6 +10,7 @@ image_resource:
 inputs:
 - name: bosh-cli
 - name: compiled-linux-amd64
+- name: compiled-linux-arm64
 - name: compiled-darwin-amd64
 - name: compiled-darwin-arm64
 - name: compiled-windows-amd64

--- a/ci/tasks/build-linux-arm64.yml
+++ b/ci/tasks/build-linux-arm64.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/cli
+    tag: 'latest'
+
+inputs:
+- name: bosh-cli
+- name: version-semver
+
+outputs:
+- name: compiled-linux-arm64
+
+params:
+  GOOS:   linux
+  GOARCH: arm64
+  CGO_ENABLED: 0
+  FILENAME_PREFIX: ''
+
+run:
+  path: bosh-cli/ci/tasks/build.sh


### PR DESCRIPTION
add release for linux/arm64
what's missing:
 - homebrew does not support linux on arm64 processors. Hence formula is not updated
 - dockerile for arm64. I'm afraid I'm missing how ci/tasks/create-dockerfile.yml is used for build and if we can provide the target platform as argument.