### PR TITLE
Better message for failed create-release

### DIFF
--- a/cmd/create_release.go
+++ b/cmd/create_release.go
@@ -86,7 +86,7 @@ func (c CreateReleaseCmd) buildRelease(releaseDir boshreldir.ReleaseDir, opts Cr
 	if len(name) == 0 {
 		name, err = releaseDir.DefaultName()
 		if err != nil {
-			return nil, err
+			return nil, bosherr.WrapErrorf(err, "Check that you're in the top-level of the release directory")
 		}
 	}
 

--- a/cmd/create_release_test.go
+++ b/cmd/create_release_test.go
@@ -465,7 +465,7 @@ var _ = Describe("CreateReleaseCmd", func() {
 
 				err := act()
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("fake-err"))
+				Expect(err.Error()).To(ContainSubstring("Check that you're in the top-level of the release directory: fake-err"))
 			})
 
 			It("returns error if retrieving next dev version fails", func() {


### PR DESCRIPTION
When running `bosh create-release` in the wrong directory, the error is cryptic: "Expected non-empty 'name' in config..."

This commit enhances the error message to include the most common cause, being in the incorrect directory, by wrapping the error with "Check that you're in the top-level of the release directory".

Note that although Golang 1.13 introduced error-wrapping functionality, we abide by the pre-1.13 convention, i.e. `bosh.WrapErrorf()`.

Typical error message `cd /tmp; bosh create-release`:
```
Check that you're in the top-level of the release directory:
  Expected non-empty 'name' in config '/tmp/config/final.yml'
```