### PR TITLE
Add `--force-latest-variables` flag to `deploy` command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -72,6 +72,7 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 		Canaries:                opts.Canaries,
 		MaxInFlight:             opts.MaxInFlight,
 		Diff:                    deploymentDiff,
+		ForceLatestVariables:    opts.ForceLatestVariables,
 	}
 
 	return c.deployment.Update(bytes, updateOpts)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -99,6 +99,21 @@ var _ = Describe("DeployCmd", func() {
 			}))
 		})
 
+		It("deploys manifest allowing to force latest variables", func() {
+			opts.ForceLatestVariables = true
+
+			err := act()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(deployment.UpdateCallCount()).To(Equal(1))
+
+			bytes, updateOpts := deployment.UpdateArgsForCall(0)
+			Expect(bytes).To(Equal([]byte("name: dep\n")))
+			Expect(updateOpts).To(Equal(boshdir.UpdateOpts{
+				ForceLatestVariables: true,
+			}))
+		})
+
 		It("deploys templated manifest", func() {
 			opts.Args.Manifest = FileBytesArg{
 				Bytes: []byte("name: dep\nname1: ((name1))\nname2: ((name2))\n"),

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -505,7 +505,8 @@ type DeployOpts struct {
 	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`
 	MaxInFlight string `long:"max-in-flight" description:"Override manifest values for max_in_flight"`
 
-	DryRun bool `long:"dry-run" description:"Renders job templates without altering deployment"`
+	DryRun               bool `long:"dry-run" description:"Renders job templates without altering deployment"`
+	ForceLatestVariables bool `long:"force-latest-variables" description:"Retrieve the latest variable values from the config server regardless of their update strategy"`
 
 	cmd
 }

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -1630,6 +1630,14 @@ var _ = Describe("Opts", func() {
 			})
 		})
 
+		Describe("ForceLatestVariables", func() {
+			It("contains desired values", func() {
+				Expect(getStructTagForName("ForceLatestVariables", opts)).To(Equal(
+					`long:"force-latest-variables" description:"Retrieve the latest variable values from the config server regardless of their update strategy"`,
+				))
+			})
+		})
+
 		Describe("FixReleases", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("FixReleases", opts)).To(Equal(

--- a/director/deployment.go
+++ b/director/deployment.go
@@ -545,6 +545,10 @@ func (c Client) UpdateDeployment(manifest []byte, opts UpdateOpts) error {
 		query.Add("dry_run", "true")
 	}
 
+	if opts.ForceLatestVariables {
+		query.Add("force_latest_variables", "true")
+	}
+
 	if len(opts.Diff.context) != 0 {
 		context := map[string]interface{}{}
 

--- a/director/deployment_test.go
+++ b/director/deployment_test.go
@@ -947,6 +947,29 @@ var _ = Describe("Deployment", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("succeeds updating deployment with force latest variables flag", func() {
+			forceLatestVariables := true
+
+			ConfigureTaskResult(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/deployments", fmt.Sprintf("force_latest_variables=%t", forceLatestVariables)),
+					ghttp.VerifyBasicAuth("username", "password"),
+					ghttp.VerifyHeader(http.Header{
+						"Content-Type": []string{"text/yaml"},
+					}),
+					ghttp.VerifyBody([]byte("manifest")),
+				),
+				``,
+				server,
+			)
+
+			updateOpts := UpdateOpts{
+				ForceLatestVariables: forceLatestVariables,
+			}
+			err := deployment.Update([]byte("manifest"), updateOpts)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("succeeds updating deployment with diff context values", func() {
 			context := map[string]interface{}{
 				"cloud_config_id":          "2",

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -226,6 +226,7 @@ type UpdateOpts struct {
 	MaxInFlight             string
 	DryRun                  bool
 	Diff                    DeploymentDiff
+	ForceLatestVariables    bool
 }
 
 //counterfeiter:generate . ReleaseSeries


### PR DESCRIPTION
This will override the behavior of any variables with an `on-stemcell-change` update strategy.  When supplied, the `--force-latest-variables` flag will cause the bosh director to retrieve the latest values of all variables from the config server.

This requires a director with https://github.com/cloudfoundry/bosh/pull/2460 to be effective