### PR TITLE
Remove git rev and timestamp from version number

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -8,5 +8,5 @@ VERSION_LABEL="${VERSION_LABEL:-${default_version}}"
 
 go build \
   -o "${ROOT_DIR}/out/bosh" \
-  -ldflags="-X 'github.com/cloudfoundry/bosh-cli/v7/cmd.VersionLabel=${VERSION_LABEL}'" \
+  -ldflags="-X 'github.com/cloudfoundry/bosh-cli/v7/cmd.VersionLabel=${VERSION_LABEL}' -X 'main.version=${VERSION_LABEL}'" \
   "${ROOT_DIR}"

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -14,9 +14,7 @@ fi
 
 cd bosh-cli/
 
-git_rev="$(git rev-parse --short HEAD)"
-timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-export VERSION_LABEL="${semver}-${git_rev}-${timestamp}"
+export VERSION_LABEL="${semver}"
 
 bin/build
 


### PR DESCRIPTION
We also duplicate the version into the "main.version" variable as that is where syft looks for it when scanning binaries.

This will allow us to "go get NAME@VERSION" and have go mod correctly download the source