### PR TITLE
When debugging requests, do not dump the body of the request.

### DIFF
--- a/director/client_request.go
+++ b/director/client_request.go
@@ -209,7 +209,7 @@ func (r ClientRequest) readResponse(resp *http.Response, out io.Writer) ([]byte,
 		if resp.Request != nil {
 			sanitizer := RequestSanitizer{Request: (*resp.Request)}
 			sanitizedRequest, _ := sanitizer.SanitizeRequest()
-			b, err := httputil.DumpRequest(&sanitizedRequest, true)
+			b, err := httputil.DumpRequest(&sanitizedRequest, false)
 			if err == nil {
 				r.logger.Debug(logTag, "Dumping Director client request:\n%s", string(b))
 			}


### PR DESCRIPTION
We had a report and stack trace that showed the cli running out of memory when the request body is dumped while uploading a stemcell.

While it would be good to keep this behavior for non-binary request bodies, our tests showed that those don't get printed out anyway. So just changing the true to a false in the hopes that it resolves the OOM issue.