### PR TITLE
Bump to gopkg.in/yaml.v2 to v3 in the release/manifest package

### DIFF
--- a/release/manifest/release.go
+++ b/release/manifest/release.go
@@ -5,7 +5,7 @@ import (
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type Manifest struct {


### PR DESCRIPTION
# Fixes

By merging this, we can bump the bosh-cli dependency and then th bosh-agent no longer need to import yaml.v2.

It will also make the following CVE scan results go away: https://pkg.go.dev/search?q=gopkg.in%2Fyaml.v2&m=vuln

## Notes

Updating to v3 does make changes to encoding but decoding should behave close enough to v2 for this package's use.
