### PR TITLE
`repack-stemcell` stops prefixing archive members with "./"

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -209,7 +209,7 @@ func (c Cmd) Execute() (cmdErr error) {
 		stemcellReader := bistemcell.NewReader(deps.Compressor, deps.FS)
 		stemcellExtractor := bistemcell.NewExtractor(stemcellReader, deps.FS)
 
-		return NewRepackStemcellCmd(deps.UI, deps.FS, stemcellExtractor).Run(*opts)
+		return NewRepackStemcellCmd(stemcellExtractor).Run(*opts)
 
 	case *InspectStemcellTarballOpts:
 		stemcellArchiveFactory := func(path string) boshdir.StemcellArchive {

--- a/cmd/repack_stemcell.go
+++ b/cmd/repack_stemcell.go
@@ -1,26 +1,21 @@
 package cmd
 
 import (
+	biproperty "github.com/cloudfoundry/bosh-utils/property"
+	"gopkg.in/yaml.v2"
+
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	"github.com/cloudfoundry/bosh-cli/v7/stemcell"
-	boshui "github.com/cloudfoundry/bosh-cli/v7/ui"
-	biproperty "github.com/cloudfoundry/bosh-utils/property"
-	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	"gopkg.in/yaml.v2"
 )
 
 type RepackStemcellCmd struct {
-	ui                boshui.UI
-	fs                boshsys.FileSystem
 	stemcellExtractor stemcell.Extractor
 }
 
 func NewRepackStemcellCmd(
-	ui boshui.UI,
-	fs boshsys.FileSystem,
 	stemcellExtractor stemcell.Extractor,
 ) RepackStemcellCmd {
-	return RepackStemcellCmd{ui: ui, fs: fs, stemcellExtractor: stemcellExtractor}
+	return RepackStemcellCmd{stemcellExtractor: stemcellExtractor}
 }
 
 func (c RepackStemcellCmd) Run(opts RepackStemcellOpts) error {

--- a/stemcell/stemcell.go
+++ b/stemcell/stemcell.go
@@ -2,12 +2,11 @@ package stemcell
 
 import (
 	"fmt"
+	"path/filepath"
 
 	boshfu "github.com/cloudfoundry/bosh-utils/fileutil"
 	biproperty "github.com/cloudfoundry/bosh-utils/property"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-
-	"path/filepath"
 
 	"gopkg.in/yaml.v2"
 )
@@ -98,7 +97,17 @@ func (s *extractedStemcell) Pack(destinationPath string) error {
 		return err
 	}
 
-	intermediateStemcellPath, err := s.compressor.CompressFilesInDir(s.extractedPath)
+	paths, err := s.fs.Glob(filepath.Join(s.extractedPath, "*"))
+	if err != nil {
+		return err
+	}
+
+	filenames := []string{}
+	for _, p := range paths {
+		filenames = append(filenames, filepath.Base(p))
+	}
+
+	intermediateStemcellPath, err := s.compressor.CompressSpecificFilesInDir(s.extractedPath, filenames)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prior to this commit, running `bosh repack-stemcell` would result in a repacked stemcell with archive members:
```
./
./dev_tools_file_list.txt
./image
./stemcell.MF
./packages.txt
```

while the original stemcell has archive members:
```
dev_tools_file_list.txt
image
packages.txt
stemcell.MF
```

This commit preserves the original stemcell archive members in the repacked stemcell.  This is useful if you're trying to extract a particular file from the archive by name.

In addition, this commit:
- Vastly simplifies the repack-stemcell command tests (including removing an entire compressor fake separate from the existing one in bosh-utils)
- Removes unneeded UI and FS depedencies from the repack-stemcell command