### PR TITLE
Auto-release CLI on new version of golang

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -151,6 +151,26 @@ jobs:
       - get: golang-release
       - get: version-semver
       - get: ubuntu-image
+      - get: release-bucket-linux
+    - task: build-linux-amd64
+      file: bosh-cli/ci/tasks/build-linux-amd64.yml
+    - try:
+        task: check-for-updated-binary-version
+        file: golang-release/ci/tasks/shared/check-for-updated-binary-version.yml
+        input_mapping:
+          previous_binary: release-bucket-linux
+          current_binary: compiled-linux-amd64
+        params:
+          PREVIOUS_BINARY_PATTERN: bosh-cli-*-linux-amd64
+          CURRENT_BINARY_PATTERN: bosh-cli-*-linux-amd64
+        on_success:
+          do:
+          - put: release-notes
+            params:
+              file: release-notes/release-notes.md
+          - put: version-semver
+            params:
+              bump: patch
     - try:
         task: check-for-patched-cves
         file: golang-release/ci/tasks/shared/check-for-patched-cves.yml


### PR DESCRIPTION
Adds task to the `automatically-release-new-patch` job that compares the golang version of the previously released BOSH CLI binary with the golang version of what would be released. If they're different (in the case of a bumped golang version, or intentional roll back), then an automatic release would be triggered, similar to when CVE fixes are detected.

### Additional Context
I noticed that we haven't released a version of the `bosh` CLI compiled using `golang 1.22.1`. Many BOSH-related repos have automatic releasing of patches when a golang bump occurs, the intention is to make the CLI consistent with those.

This utilizes a new shared task I just added to the golang-release: https://github.com/cloudfoundry/bosh-package-golang-release/commit/7360ed824cb8fadaec2e1c49591af07d7340c2db

A test run of the task (minus the `success` clause that causes a release) can be seen here: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-cli/jobs/automatically-release-new-patch/builds/14
