### PR TITLE
Remove PowerDNS dependent `--dns` flag and related functionality

### DIFF
--- a/cmd/instance_table.go
+++ b/cmd/instance_table.go
@@ -32,9 +32,6 @@ type InstanceTableValues struct {
 
 	Stemcell boshtbl.Value
 
-	// DNS
-	DNS boshtbl.Value
-
 	// Vitals
 	Uptime boshtbl.Value // only for Process
 	Load   boshtbl.Value
@@ -76,9 +73,6 @@ var InstanceTableHeader = InstanceTableValues{
 
 	Stemcell: boshtbl.NewValueString("Stemcell"),
 
-	// DNS
-	DNS: boshtbl.NewValueString("DNS A Records"),
-
 	// Vitals
 	Uptime: boshtbl.NewValueString("Uptime"), // only for Process
 	Load:   boshtbl.NewValueString("Load\n(1m, 5m, 15m)"),
@@ -97,7 +91,7 @@ var InstanceTableHeader = InstanceTableValues{
 }
 
 type InstanceTable struct {
-	Processes, VMDetails, DeploymentDetails, Details, Stemcell, DNS, Vitals, CloudProperties bool
+	Processes, VMDetails, DeploymentDetails, Details, Stemcell, Vitals, CloudProperties bool
 }
 
 func (t InstanceTable) Headers() []boshtbl.Header {
@@ -154,9 +148,6 @@ func (t InstanceTable) ForVMInfo(i boshdir.VMInfo) InstanceTableValues {
 		CloudProperties: boshtbl.NewValueInterface(i.CloudProperties),
 
 		Stemcell: boshtbl.NewValueString(stemcell),
-
-		// DNS
-		DNS: boshtbl.NewValueStrings(i.DNS),
 
 		// Vitals
 		Uptime: ValueUptime{i.Vitals.Uptime.Seconds},
@@ -239,10 +230,6 @@ func (t InstanceTable) AsValues(v InstanceTableValues) []boshtbl.Value {
 
 	if t.CloudProperties {
 		result = append(result, v.CloudProperties)
-	}
-
-	if t.DNS {
-		result = append(result, v.DNS)
 	}
 
 	if t.Vitals {

--- a/cmd/instance_table_test.go
+++ b/cmd/instance_table_test.go
@@ -19,7 +19,7 @@ var _ = Describe("InstanceTable", func() {
 
 		BeforeEach(func() {
 			info = boshdir.VMInfo{}
-			tbl = InstanceTable{Details: true, DNS: true, Vitals: true, CloudProperties: true}
+			tbl = InstanceTable{Details: true, Vitals: true, CloudProperties: true}
 		})
 
 		Describe("name, id", func() {

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -26,7 +26,6 @@ func (c InstancesCmd) Run(opts InstancesOpts) error {
 		DeploymentDetails: true,
 		Processes:         opts.Processes,
 		Details:           opts.Details,
-		DNS:               opts.DNS,
 		Vitals:            opts.Vitals,
 	}
 

--- a/cmd/instances_test.go
+++ b/cmd/instances_test.go
@@ -61,7 +61,6 @@ var _ = Describe("InstancesCmd", func() {
 
 					IPs:        []string{"in1-ip1", "in1-ip2"},
 					Deployment: "dep",
-					DNS:        []string{"in1-dns1", "in1-dns2"},
 
 					State:       "in1-state",
 					VMID:        "in1-cid",
@@ -115,7 +114,6 @@ var _ = Describe("InstancesCmd", func() {
 
 					IPs:        []string{"in2-ip1"},
 					Deployment: "dep",
-					DNS:        []string{"in2-dns1"},
 
 					State:       "in2-state",
 					VMID:        "in2-cid",
@@ -540,73 +538,6 @@ var _ = Describe("InstancesCmd", func() {
 										boshtbl.NewValueInt(0),
 										boshtbl.NewValueBool(false),
 										boshtbl.NewValueBool(false),
-									},
-								},
-							},
-						},
-					}))
-				})
-
-				It("lists instances for the deployment including dns", func() {
-					opts.DNS = true
-
-					Expect(act()).ToNot(HaveOccurred())
-
-					Expect(ui.Table).To(Equal(boshtbl.Table{
-						Title:   "Deployment 'dep'",
-						Content: "instances",
-
-						Header: []boshtbl.Header{
-							boshtbl.NewHeader("Instance"),
-							boshtbl.NewHeader("Process State"),
-							boshtbl.NewHeader("AZ"),
-							boshtbl.NewHeader("IPs"),
-							boshtbl.NewHeader("Deployment"),
-							boshtbl.NewHeader("DNS A Records"),
-						},
-
-						SortBy: []boshtbl.ColumnSort{
-							{Column: 0, Asc: true},
-							{Column: 1, Asc: true},
-						},
-
-						Sections: []boshtbl.Section{
-							{
-								FirstColumn: boshtbl.NewValueString("job-name"),
-								Rows: [][]boshtbl.Value{
-									{
-										boshtbl.NewValueString("job-name"),
-										boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
-										boshtbl.ValueString{},
-										boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
-										boshtbl.NewValueString("dep"),
-										boshtbl.NewValueStrings([]string{"in1-dns1", "in1-dns2"}),
-									},
-								},
-							},
-							{
-								FirstColumn: boshtbl.NewValueString("job-name"),
-								Rows: [][]boshtbl.Value{
-									{
-										boshtbl.NewValueString("job-name"),
-										boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
-										boshtbl.NewValueString("in2-az"),
-										boshtbl.NewValueStrings([]string{"in2-ip1"}),
-										boshtbl.NewValueString("dep"),
-										boshtbl.NewValueStrings([]string{"in2-dns1"}),
-									},
-								},
-							},
-							{
-								FirstColumn: boshtbl.NewValueString("?"),
-								Rows: [][]boshtbl.Value{
-									{
-										boshtbl.NewValueString("?"),
-										boshtbl.NewValueFmt(boshtbl.NewValueString("unresponsive agent"), true),
-										boshtbl.ValueString{},
-										boshtbl.ValueStrings{},
-										boshtbl.NewValueString("dep"),
-										boshtbl.ValueStrings{},
 									},
 								},
 							},

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -801,7 +801,6 @@ type InstanceSlugArgs struct {
 
 type InstancesOpts struct {
 	Details    bool `long:"details" short:"i" description:"Show details including VM CID, persistent disk CID, etc."`
-	DNS        bool `long:"dns"               description:"Show DNS A records"`
 	Vitals     bool `long:"vitals"            description:"Show vitals"`
 	Processes  bool `long:"ps"      short:"p" description:"Show processes"`
 	Failing    bool `long:"failing" short:"f" description:"Only show failing instances"`
@@ -810,7 +809,6 @@ type InstancesOpts struct {
 }
 
 type VMsOpts struct {
-	DNS             bool `long:"dns"               description:"Show DNS A records"`
 	Vitals          bool `long:"vitals"            description:"Show vitals"`
 	CloudProperties bool `long:"cloud-properties"  description:"Show cloud properties"`
 	Deployment      string

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -2366,14 +2366,6 @@ var _ = Describe("Opts", func() {
 			})
 		})
 
-		Describe("DNS", func() {
-			It("contains desired values", func() {
-				Expect(getStructTagForName("DNS", opts)).To(Equal(
-					`long:"dns" description:"Show DNS A records"`,
-				))
-			})
-		})
-
 		Describe("Vitals", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("Vitals", opts)).To(Equal(
@@ -2404,14 +2396,6 @@ var _ = Describe("Opts", func() {
 
 		BeforeEach(func() {
 			opts = &VMsOpts{}
-		})
-
-		Describe("DNS", func() {
-			It("contains desired values", func() {
-				Expect(getStructTagForName("DNS", opts)).To(Equal(
-					`long:"dns" description:"Show DNS A records"`,
-				))
-			})
 		})
 
 		Describe("Vitals", func() {

--- a/cmd/vms.go
+++ b/cmd/vms.go
@@ -34,7 +34,6 @@ func (c VMsCmd) Run(opts VMsOpts) error {
 		DeploymentDetails: false,
 		Details:           false,
 		Stemcell:          true,
-		DNS:               opts.DNS,
 		Vitals:            opts.Vitals,
 		CloudProperties:   opts.CloudProperties,
 	}

--- a/cmd/vms_test.go
+++ b/cmd/vms_test.go
@@ -2,11 +2,10 @@ package cmd_test
 
 import (
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"time"
 
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd"
 	. "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
@@ -61,7 +60,6 @@ var _ = Describe("VMsCmd", func() {
 
 					IPs:        []string{"in1-ip1", "in1-ip2"},
 					Deployment: "dep",
-					DNS:        []string{"in1-dns1", "in1-dns2"},
 
 					VMID:               "in1-cid",
 					AgentID:            "in1-agent-id",
@@ -96,7 +94,6 @@ var _ = Describe("VMsCmd", func() {
 
 					IPs:        []string{"in2-ip1"},
 					Deployment: "dep",
-					DNS:        []string{"in2-dns1"},
 
 					VMID:               "in2-cid",
 					AgentID:            "in2-agent-id",
@@ -195,68 +192,6 @@ var _ = Describe("VMsCmd", func() {
 								boshtbl.ValueString{},
 								boshtbl.ValueString{S: "-"},
 								boshtbl.ValueString{S: "-"},
-							},
-						},
-					}))
-				})
-
-				It("lists VMs for the deployment including dns", func() {
-					opts.DNS = true
-
-					Expect(act()).ToNot(HaveOccurred())
-
-					Expect(ui.Table).To(Equal(boshtbl.Table{
-						Title: "Deployment 'dep1'",
-
-						Content: "vms",
-
-						Header: []boshtbl.Header{
-							boshtbl.NewHeader("Instance"),
-							boshtbl.NewHeader("Process State"),
-							boshtbl.NewHeader("AZ"),
-							boshtbl.NewHeader("IPs"),
-							boshtbl.NewHeader("VM CID"),
-							boshtbl.NewHeader("VM Type"),
-							boshtbl.NewHeader("Active"),
-							boshtbl.NewHeader("Stemcell"),
-							boshtbl.NewHeader("DNS A Records"),
-						},
-
-						SortBy: []boshtbl.ColumnSort{{Column: 0, Asc: true}},
-
-						Rows: [][]boshtbl.Value{
-							{
-								boshtbl.NewValueString("job-name"),
-								boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
-								boshtbl.ValueString{},
-								boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
-								boshtbl.NewValueString("in1-cid"),
-								boshtbl.NewValueString("in1-rp"),
-								boshtbl.NewValueString("true"),
-								boshtbl.NewValueString("stemcell/version"),
-								boshtbl.NewValueStrings([]string{"in1-dns1", "in1-dns2"}),
-							},
-							{
-								boshtbl.NewValueString("job-name"),
-								boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
-								boshtbl.NewValueString("in2-az"),
-								boshtbl.NewValueStrings([]string{"in2-ip1"}),
-								boshtbl.NewValueString("in2-cid"),
-								boshtbl.NewValueString("in2-rp"),
-								boshtbl.NewValueString("false"),
-								boshtbl.NewValueString("stemcell/version"),
-								boshtbl.NewValueStrings([]string{"in2-dns1"}),
-							},
-							{
-								boshtbl.NewValueString("?"),
-								boshtbl.NewValueFmt(boshtbl.NewValueString("unresponsive agent"), true),
-								boshtbl.ValueString{},
-								boshtbl.ValueStrings{},
-								boshtbl.ValueString{},
-								boshtbl.ValueString{},
-								boshtbl.ValueString{S: "-"},
-								boshtbl.ValueString{S: "-"},
-								boshtbl.ValueStrings{},
 							},
 						},
 					}))

--- a/director/instances_test.go
+++ b/director/instances_test.go
@@ -1,13 +1,12 @@
 package director_test
 
 import (
+	"net/http"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-
-	"net/http"
 
 	. "github.com/cloudfoundry/bosh-cli/v7/director"
 )
@@ -99,7 +98,6 @@ var _ = Describe("Instances", func() {
 
 				IPs:        []string{"ip"},
 				Deployment: "dep",
-				DNS:        []string{"dns"},
 
 				AZ:           "az",
 				VMID:         "vm-cid",

--- a/director/vms.go
+++ b/director/vms.go
@@ -23,7 +23,6 @@ type VMInfo struct {
 
 	IPs        []string `json:"ips"`
 	Deployment string   `json:"deployment_name"`
-	DNS        []string `json:"dns"`
 
 	AZ              string      `json:"az"`
 	State           string      `json:"state"`

--- a/director/vms_test.go
+++ b/director/vms_test.go
@@ -32,6 +32,61 @@ var _ = Describe("VMs", func() {
 	})
 
 	Describe("VMInfos", func() {
+		index := 1
+		uptime := uint64(10020)
+		procCPUTotal := 10.0
+		procMemPer := 0.5
+		procMemKB := uint64(23952)
+		procUptime := uint64(343020)
+
+		expectedVmInfo := VMInfo{
+			AgentID: "agent-id",
+
+			JobName:      "job",
+			ID:           "id",
+			Index:        &index,
+			ProcessState: "running",
+			Bootstrap:    true,
+
+			IPs:        []string{"ip"},
+			Deployment: "dep",
+
+			AZ:              "az",
+			Ignore:          true,
+			VMID:            "vm-cid",
+			VMType:          "vm-type",
+			ResourcePool:    "rp",
+			VMCreatedAtRaw:  "2016-01-09T06:23:25+00:00",
+			VMCreatedAt:     time.Date(2016, time.January, 9, 6, 23, 25, 0, time.UTC),
+			CloudProperties: "cp1",
+			DiskID:          "disk-cid",
+			DiskIDs:         []string{"disk-cid1", "disk-cid2"},
+
+			Processes: []VMInfoProcess{
+				VMInfoProcess{
+					Name:   "service",
+					State:  "running",
+					CPU:    VMInfoVitalsCPU{Total: &procCPUTotal},
+					Mem:    VMInfoVitalsMemIntSize{KB: &procMemKB, Percent: &procMemPer},
+					Uptime: VMInfoVitalsUptime{Seconds: &procUptime},
+				},
+			},
+
+			Vitals: VMInfoVitals{
+				CPU:    VMInfoVitalsCPU{Sys: "4.5", User: "65.7", Wait: "0.8"},
+				Mem:    VMInfoVitalsMemSize{KB: "1342088", Percent: "33"},
+				Swap:   VMInfoVitalsMemSize{KB: "53580", Percent: "5"},
+				Uptime: VMInfoVitalsUptime{Seconds: &uptime},
+				Load:   []string{"2.20", "1.63", "1.53"},
+				Disk: map[string]VMInfoVitalsDiskSize{
+					"system":    VMInfoVitalsDiskSize{InodePercent: "19", Percent: "47"},
+					"ephemeral": VMInfoVitalsDiskSize{InodePercent: "19", Percent: "47"},
+				},
+			},
+
+			ResurrectionPaused: true,
+		}
+
 		It("returns vm infos", func() {
 			ConfigureTaskResult(
 				ghttp.CombineHandlers(
@@ -46,7 +101,6 @@ var _ = Describe("VMs", func() {
 	"job_state": "running",
 	"bootstrap": true,
 	"ips": [ "ip" ],
-	"dns": [ "dns" ],
 	"az": "az",
 	"ignore": true,
 	"vm_cid": "vm-cid",
@@ -83,61 +137,63 @@ var _ = Describe("VMs", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(infos).To(HaveLen(1))
 
-			index := 1
-			uptime := uint64(10020)
-			procCPUTotal := 10.0
-			procMemPer := 0.5
-			procMemKB := uint64(23952)
-			procUptime := uint64(343020)
+			Expect(infos[0]).To(Equal(expectedVmInfo))
+		})
 
-			Expect(infos[0]).To(Equal(VMInfo{
-				AgentID: "agent-id",
+		Context("when the response includes the 'dns' key (removed with PowerDNS)", func() {
+			It("returns vm infos", func() {
+				ConfigureTaskResult(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/deployments/dep/vms", "format=full"),
+						ghttp.VerifyBasicAuth("username", "password"),
+					),
+					strings.Replace(`{
+	"agent_id": "agent-id",
+	"job_name": "job",
+	"id": "id",
+	"index": 1,
+	"job_state": "running",
+	"bootstrap": true,
+	"ips": [ "ip" ],
+	"dns": [ "dns-field-from-a-pre-power-dns-removal-director" ],
+	"az": "az",
+	"ignore": true,
+	"vm_cid": "vm-cid",
+	"disk_cid": "disk-cid",
+	"disk_cids": ["disk-cid1", "disk-cid2"],
+	"vm_type": "vm-type",
+	"resource_pool": "rp",
+	"vm_created_at": "2016-01-09T06:23:25+00:00",
+	"cloud_properties": "cp1",
+	"processes": [{
+		"name": "service",
+		"state": "running",
+		"uptime": { "secs": 343020 },
+		"cpu": { "total": 10 },
+		"mem": { "percent": 0.5, "kb": 23952 }
+	}],
+	"vitals": {
+		"cpu": { "wait": "0.8", "user": "65.7", "sys": "4.5" },
+		"swap": { "percent": "5", "kb": "53580" },
+		"mem": { "percent": "33", "kb": "1342088" },
+		"uptime": { "secs": 10020 },
+		"load": [ "2.20", "1.63", "1.53" ],
+		"disk": {
+			"system": { "percent": "47", "inode_percent": "19" },
+			"ephemeral": { "percent": "47", "inode_percent": "19" }
+		}
+	},
+	"resurrection_paused": true
+}`, "\n", "", -1),
+					server,
+				)
 
-				JobName:      "job",
-				ID:           "id",
-				Index:        &index,
-				ProcessState: "running",
-				Bootstrap:    true,
+				infos, err := deployment.VMInfos()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(infos).To(HaveLen(1))
 
-				IPs:        []string{"ip"},
-				Deployment: "dep",
-				DNS:        []string{"dns"},
-
-				AZ:              "az",
-				Ignore:          true,
-				VMID:            "vm-cid",
-				VMType:          "vm-type",
-				ResourcePool:    "rp",
-				VMCreatedAtRaw:  "2016-01-09T06:23:25+00:00",
-				VMCreatedAt:     time.Date(2016, time.January, 9, 6, 23, 25, 0, time.UTC),
-				CloudProperties: "cp1",
-				DiskID:          "disk-cid",
-				DiskIDs:         []string{"disk-cid1", "disk-cid2"},
-
-				Processes: []VMInfoProcess{
-					VMInfoProcess{
-						Name:   "service",
-						State:  "running",
-						CPU:    VMInfoVitalsCPU{Total: &procCPUTotal},
-						Mem:    VMInfoVitalsMemIntSize{KB: &procMemKB, Percent: &procMemPer},
-						Uptime: VMInfoVitalsUptime{Seconds: &procUptime},
-					},
-				},
-
-				Vitals: VMInfoVitals{
-					CPU:    VMInfoVitalsCPU{Sys: "4.5", User: "65.7", Wait: "0.8"},
-					Mem:    VMInfoVitalsMemSize{KB: "1342088", Percent: "33"},
-					Swap:   VMInfoVitalsMemSize{KB: "53580", Percent: "5"},
-					Uptime: VMInfoVitalsUptime{Seconds: &uptime},
-					Load:   []string{"2.20", "1.63", "1.53"},
-					Disk: map[string]VMInfoVitalsDiskSize{
-						"system":    VMInfoVitalsDiskSize{InodePercent: "19", Percent: "47"},
-						"ephemeral": VMInfoVitalsDiskSize{InodePercent: "19", Percent: "47"},
-					},
-				},
-
-				ResurrectionPaused: true,
-			}))
+				Expect(infos[0]).To(Equal(expectedVmInfo))
+			})
 		})
 
 		It("correctly parses disk cids", func() {
@@ -154,7 +210,6 @@ var _ = Describe("VMs", func() {
 	"job_state": "running",
 	"bootstrap": true,
 	"ips": [ "ip" ],
-	"dns": [ "dns" ],
 	"az": "az",
 	"vm_cid": "vm-cid",
 	"disk_cid": "disk-cid",
@@ -208,7 +263,6 @@ var _ = Describe("VMs", func() {
 
 				IPs:        []string{"ip"},
 				Deployment: "dep",
-				DNS:        []string{"dns"},
 
 				AZ:              "az",
 				VMID:            "vm-cid",
@@ -260,7 +314,6 @@ var _ = Describe("VMs", func() {
 	"job_state": "running",
 	"bootstrap": true,
 	"ips": [ "ip" ],
-	"dns": [ "dns" ],
 	"az": "az",
 	"vm_cid": "vm-cid",
 	"disk_cid": "",
@@ -314,7 +367,6 @@ var _ = Describe("VMs", func() {
 
 				IPs:        []string{"ip"},
 				Deployment: "dep",
-				DNS:        []string{"dns"},
 
 				AZ:              "az",
 				VMID:            "vm-cid",
@@ -412,7 +464,6 @@ var _ = Describe("VMs", func() {
 	"job_state": "running",
 	"bootstrap": true,
 	"ips": [ "ip" ],
-	"dns": [ "dns" ],
 	"az": "az",
 	"vm_cid": "vm-cid",
 	"disk_cid": "",


### PR DESCRIPTION
PowerDNS is being removed from the BOSH Director, and as a consequence the data returned from the `instances` and `vms` commands no longer have DNS data returned.

This commit removes the `--dns` flag and logic to display the data returnd when it is sent.

See: https://github.com/cloudfoundry/bosh/pull/2501