### PR TITLE
Quiet completion tests

### DIFF
--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -157,13 +157,17 @@ func (c *BoshComplete) Execute(args []string) (*cobra.Command, error) {
 }
 
 func (c *BoshComplete) ExecuteCaptured(args []string) (*CapturedResult, error) {
-	buf := new(bytes.Buffer)
-	c.rootCmd.SetOut(buf)
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+
+	c.rootCmd.SetOut(outBuf)
+	c.rootCmd.SetErr(errBuf)
 	retCmd, err := c.Execute(args)
 	if err != nil {
 		return nil, err
 	}
-	retLines := strings.Split(buf.String(), "\n")
+	retLines := strings.Split(outBuf.String(), "\n")
+	c.logger.Debug("BoshComplete.ExecuteCapture() STDERR", errBuf.String())
 	return &CapturedResult{Lines: retLines, Command: retCmd}, nil
 }
 

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -23,6 +23,11 @@ func IsItCompletionCommand(args []string) bool {
 	return len(args) > 0 && (args[0] == cobraCompletionCmdName || args[0] == cobraCompleteCmdName)
 }
 
+type CapturedResult struct {
+	Lines   []string
+	Command *cobra.Command
+}
+
 type CmdContext struct {
 	ConfigPath      string
 	EnvironmentName string
@@ -169,9 +174,4 @@ func (c *BoshComplete) tryToBindValidArgsFunction(cmd *cobra.Command, argsTypeNa
 	} else {
 		c.logger.Warn(logTag, "Unknown Args Type %s, command %s", argsTypeName, cmd.Name())
 	}
-}
-
-type CapturedResult struct {
-	Lines   []string
-	Command *cobra.Command
 }

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -1,10 +1,9 @@
 package completion_test
 
 import (
-	"os"
 	"strings"
 
-	"github.com/cloudfoundry/bosh-utils/logger"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -12,15 +11,15 @@ import (
 )
 
 var _ = Describe("Completion Integration Tests", func() {
-	var (
-		boshComplete *completion.BoshComplete
-	)
+	var boshComplete *completion.BoshComplete
 
 	BeforeEach(func() {
-		testLogger := logger.NewWriterLogger(logger.LevelInfo, os.Stderr)
+		testLogger := boshlog.NewWriterLogger(boshlog.LevelInfo, GinkgoWriter)
 		fakeCmdCtx := &completion.CmdContext{}
 		fakeDq := completion.NewDirectorQueryFake(fakeCmdCtx)
-		fakeCompletionFunctionMap := completion.NewCompleteFunctionsMap(testLogger, fakeDq)
+		fakeCompletionFunctionMap :=
+			completion.NewCompleteFunctionsMap(testLogger, fakeDq)
+
 		boshComplete = completion.NewBoshCompleteWithFunctions(testLogger, fakeCmdCtx, fakeCompletionFunctionMap)
 	})
 

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -129,9 +129,8 @@ func (tc testCase) check(boshComplete *completion.BoshComplete) {
 	} else {
 		Expect(err).ToNot(HaveOccurred())
 	}
-	if result == nil {
-		Expect(result).ToNot(BeNil())
-	}
+	Expect(result).ToNot(BeNil())
+
 	if tc.wantStartsWith {
 		for i, wantLine := range tc.wantRes {
 			Expect(wantLine).To(Equal(result.Lines[i]))


### PR DESCRIPTION
Move code used only in tests out of `completion` package, and use `GinkgoWriter` for STDERR to reduce noise when running specs.