### PR TITLE
Relative local blobstore

### DIFF
--- a/releasedir/provider.go
+++ b/releasedir/provider.go
@@ -2,6 +2,7 @@ package releasedir
 
 import (
 	"path/filepath"
+	"strings"
 
 	"code.cloudfoundry.org/clock"
 	boshblob "github.com/cloudfoundry/bosh-utils/blobstore"
@@ -112,6 +113,10 @@ func (p Provider) newBlobstore(dirPath string) boshblob.DigestBlobstore {
 
 	switch provider {
 	case "local":
+		blobstorePath, found := options["blobstore_path"].(string)
+		if found && !strings.HasPrefix(blobstorePath, "/") {
+			options["blobstore_path"] = filepath.Join(dirPath, blobstorePath)
+		}
 		blobstore = boshblob.NewLocalBlobstore(p.fs, p.uuidGen, options)
 	case "s3":
 		blobstore = NewS3Blobstore(p.fs, p.uuidGen, options)

--- a/releasedir/provider.go
+++ b/releasedir/provider.go
@@ -2,7 +2,6 @@ package releasedir
 
 import (
 	"path/filepath"
-	"strings"
 
 	"code.cloudfoundry.org/clock"
 	boshblob "github.com/cloudfoundry/bosh-utils/blobstore"
@@ -114,7 +113,7 @@ func (p Provider) newBlobstore(dirPath string) boshblob.DigestBlobstore {
 	switch provider {
 	case "local":
 		blobstorePath, found := options["blobstore_path"].(string)
-		if found && !strings.HasPrefix(blobstorePath, "/") {
+		if found && !filepath.IsAbs(blobstorePath) {
 			options["blobstore_path"] = filepath.Join(dirPath, blobstorePath)
 		}
 		blobstore = boshblob.NewLocalBlobstore(p.fs, p.uuidGen, options)


### PR DESCRIPTION
Re-submitting: https://github.com/cloudfoundry/bosh-cli/pull/395 (develop branch, which the previous PR was against no longer exists, so it can not be re-opened). 

Additional context: https://github.com/cloudfoundry/bosh-cli/issues/567

Local blobstore can be found here: https://github.com/cloudfoundry/bosh-utils/blob/master/blobstore/local_blobstore.go#L101