### PR TITLE
allow white-space in (( var_name )) template

### DIFF
--- a/director/template/template.go
+++ b/director/template/template.go
@@ -88,7 +88,7 @@ func (t Template) interpolateRoot(obj interface{}, tracker varsTracker) (interfa
 type interpolator struct{}
 
 var (
-	interpolationRegex         = regexp.MustCompile(`\(\((!?[-/\.\w\pL]+)\)\)`)
+	interpolationRegex         = regexp.MustCompile(`\(\( ?(!?[-/\.\w\pL]+) ?\)\)`)
 	interpolationAnchoredRegex = regexp.MustCompile("\\A" + interpolationRegex.String() + "\\z")
 )
 

--- a/director/template/template_test.go
+++ b/director/template/template_test.go
@@ -20,6 +20,44 @@ var _ = Describe("Template", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal([]byte("foo\n")))
 	})
+	Context("the (( variable )) placeholder uses spaces", func() {
+		It(`can interpolate values even if var name is prefixed with a whitespace`, func() {
+			template := NewTemplate([]byte("(( key))"))
+			vars := StaticVariables{"key": "foo"}
+
+			result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal([]byte("foo\n")))
+		})
+		It(`can interpolate values even if var name is suffixed with a whitespace`, func() {
+			template := NewTemplate([]byte("((key ))"))
+			vars := StaticVariables{"key": "foo"}
+
+			result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal([]byte("foo\n")))
+		})
+		It(`can interpolate values even if var name is surrounded by whitespace`, func() {
+			template := NewTemplate([]byte("(( key ))"))
+			vars := StaticVariables{"key": "foo"}
+
+			result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal([]byte("foo\n")))
+		})
+		It("can interpolate a specific indexed value of an variable that is an array", func() {
+			template := NewTemplate([]byte("(( key)): (( value.1))"))
+			vars := StaticVariables{
+				"key":   "foo",
+				"value": []interface{}{"bar", "baz"},
+			}
+
+			result, err := template.Evaluate(vars, nil, EvaluateOpts{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal([]byte("foo: baz\n")))
+		})
+
+	})
 
 	It("can interpolate a specific indexed value of an variable that is an array", func() {
 		template := NewTemplate([]byte("((key)): ((value.1))"))


### PR DESCRIPTION
currently

`bosh int <( echo "test: (( var_name ))")  --v=var_name=value` will render

```
test: (( var_name ))
```

with the provided patch it will render:

```
test: value
```

I guess this behavior has been the same forever and this is not strictly required. I just happened to lose 20 minutes of my life trying to figure out why my interpolation didn't work and figured I'd at least try to create a commit.