### PR TITLE
error message instead of panic when --column is used with a column that does not exist

### DIFF
--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -144,7 +144,7 @@ var globalFlags = []string{
 	"--ca-cert\tDirector CA certificate path or value, env: BOSH_CA_CERT",
 	"--client\tOverride username or UAA client, env: BOSH_CLIENT",
 	"--client-secret\tOverride password or UAA client secret, env: BOSH_CLIENT_SECRET",
-	"--column\tFilter to show only given column(s)",
+	"--column\tFilter to show only given column(s), use the --column flag for each column you wish to include",
 	"--config\tConfig file path, env: BOSH_CONFIG",
 	"--deployment\tDeployment name, env: BOSH_DEPLOYMENT",
 	"-d\tDeployment name, env: BOSH_DEPLOYMENT",

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -29,7 +29,7 @@ type BoshOpts struct {
 	DeploymentOpt string `long:"deployment" short:"d" description:"Deployment name" env:"BOSH_DEPLOYMENT"`
 
 	// Output formatting
-	ColumnOpt         []ColumnOpt `long:"column"                    description:"Filter to show only given column(s)"`
+	ColumnOpt         []ColumnOpt `long:"column"                    description:"Filter to show only given column(s), use the --column flag for each column you wish to include"`
 	JSONOpt           bool        `long:"json"                      description:"Output as JSON"`
 	TTYOpt            bool        `long:"tty"                       description:"Force TTY-like output"`
 	NoColorOpt        bool        `long:"no-color"                  description:"Toggle colorized output"`

--- a/ui/conf_ui.go
+++ b/ui/conf_ui.go
@@ -84,7 +84,7 @@ func (ui *ConfUI) PrintTable(table Table) {
 	if len(ui.showColumns) > 0 {
 		err := table.SetColumnVisibility(ui.showColumns)
 		if err != nil {
-			panic(err)
+			ui.parent.PrintErrorBlock(err.Error())
 		}
 	}
 
@@ -95,7 +95,7 @@ func (ui *ConfUI) PrintTableFiltered(table Table, filterHeader []Header) {
 	if len(ui.showColumns) > 0 {
 		err := table.SetColumnVisibilityFiltered(ui.showColumns, filterHeader)
 		if err != nil {
-			panic(err)
+			ui.parent.PrintErrorBlock(err.Error())
 		}
 	}
 


### PR DESCRIPTION
update the help text of the --column flag to indicate a flag is required for each column to be shown

issue: https://github.com/cloudfoundry/bosh-cli/issues/636 