### PR TITLE
Pass existing disk CIDs to CPI in create-env command

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -23,6 +23,7 @@ type Cloud interface {
 		agentID string,
 		stemcellCID string,
 		cloudProperties biproperty.Map,
+		diskCIDS []string,
 		networksInterfaces map[string]biproperty.Map,
 		env biproperty.Map,
 	) (vmCID string, err error)
@@ -153,14 +154,14 @@ func (c cloud) CreateVM(
 	agentID string,
 	stemcellCID string,
 	cloudProperties biproperty.Map,
+	diskCIDS []string,
 	networksInterfaces map[string]biproperty.Map,
 	env biproperty.Map,
 ) (string, error) {
 	var (
-		ok           bool
-		cidString    string
-		method       = "create_vm"
-		diskLocality = []interface{}{} // not used with bosh-init
+		ok        bool
+		cidString string
+		method    = "create_vm"
 	)
 
 	cpiInfo, err := c.Info()
@@ -176,7 +177,7 @@ func (c cloud) CreateVM(
 		stemcellCID,
 		cloudProperties,
 		networksInterfaces,
-		diskLocality,
+		diskCIDS,
 		env,
 	)
 

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -373,6 +373,7 @@ var _ = Describe("Cloud", func() {
 			stemcellCID       string
 			cloudProperties   biproperty.Map
 			networkInterfaces map[string]biproperty.Map
+			diskCIDs          []string
 			env               biproperty.Map
 		)
 
@@ -387,6 +388,7 @@ var _ = Describe("Cloud", func() {
 					},
 				},
 			}
+			diskCIDs = []string{"fake-disk-cid"}
 			cloudProperties = biproperty.Map{
 				"fake-cloud-property-key": "fake-cloud-property-value",
 			}
@@ -408,7 +410,7 @@ var _ = Describe("Cloud", func() {
 			})
 
 			It("executes the cpi job script with the director UUID and stemcell CID", func() {
-				_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+				_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeCPICmdRunner.CurrentRunInput).To(HaveLen(2))
 				Expect(fakeCPICmdRunner.CurrentRunInput[1]).To(Equal(fakebicloud.RunInput{
@@ -419,7 +421,7 @@ var _ = Describe("Cloud", func() {
 						stemcellCID,
 						cloudProperties,
 						networkInterfaces,
-						[]interface{}{},
+						diskCIDs,
 						env,
 					},
 					ApiVersion: 1,
@@ -427,7 +429,7 @@ var _ = Describe("Cloud", func() {
 			})
 
 			It("returns the cid returned from executing the cpi script", func() {
-				cid, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+				cid, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cid).To(Equal("fake-vm-cid"))
 			})
@@ -448,7 +450,7 @@ var _ = Describe("Cloud", func() {
 				})
 
 				It("returns the vm cid", func() {
-					cid, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+					cid, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cid).To(Equal("fake-vm-cid"))
 				})
@@ -468,7 +470,7 @@ var _ = Describe("Cloud", func() {
 					})
 
 					It("returns error", func() {
-						_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+						_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("Unexpected external CPI command result: '[]interface {}"))
 					})
@@ -489,7 +491,7 @@ var _ = Describe("Cloud", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+				_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Unexpected external CPI command result: '1'"))
 			})
@@ -501,14 +503,14 @@ var _ = Describe("Cloud", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+				_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-run-error"))
 			})
 		})
 
 		itHandlesCPIErrors("create_vm", func() error {
-			_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, networkInterfaces, env)
+			_, err := cloud.CreateVM(agentID, stemcellCID, cloudProperties, diskCIDs, networkInterfaces, env)
 			return err
 		})
 

--- a/cloud/fakes/fake_cloud.go
+++ b/cloud/fakes/fake_cloud.go
@@ -64,6 +64,7 @@ type CreateVMInput struct {
 	AgentID            string
 	StemcellCID        string
 	CloudProperties    biproperty.Map
+	DiskCIDs           []string
 	NetworksInterfaces map[string]biproperty.Map
 	Env                biproperty.Map
 }
@@ -130,6 +131,7 @@ func (c *FakeCloud) CreateVM(
 	agentID string,
 	stemcellCID string,
 	cloudProperties biproperty.Map,
+	diskCIDs []string,
 	networksInterfaces map[string]biproperty.Map,
 	env biproperty.Map,
 ) (string, error) {
@@ -137,6 +139,7 @@ func (c *FakeCloud) CreateVM(
 		AgentID:            agentID,
 		StemcellCID:        stemcellCID,
 		CloudProperties:    cloudProperties,
+		DiskCIDs:           diskCIDs,
 		NetworksInterfaces: networksInterfaces,
 		Env:                env,
 	}

--- a/cloud/mocks/mocks.go
+++ b/cloud/mocks/mocks.go
@@ -82,18 +82,18 @@ func (mr *MockCloudMockRecorder) CreateStemcell(arg0, arg1 interface{}) *gomock.
 }
 
 // CreateVM mocks base method.
-func (m *MockCloud) CreateVM(arg0, arg1 string, arg2 property.Map, arg3 map[string]property.Map, arg4 property.Map) (string, error) {
+func (m *MockCloud) CreateVM(arg0, arg1 string, arg2 property.Map, arg3 []string, arg4 map[string]property.Map, arg5 property.Map) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVM", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CreateVM", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVM indicates an expected call of CreateVM.
-func (mr *MockCloudMockRecorder) CreateVM(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockCloudMockRecorder) CreateVM(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVM", reflect.TypeOf((*MockCloud)(nil).CreateVM), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVM", reflect.TypeOf((*MockCloud)(nil).CreateVM), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // DeleteDisk mocks base method.

--- a/cmd/deployment_preparer.go
+++ b/cmd/deployment_preparer.go
@@ -199,7 +199,6 @@ func (c *DeploymentPreparer) PrepareDeployment(stage biui.Stage, recreate bool, 
 
 		deploy := func() error {
 			return c.deploy(
-				installation,
 				deploymentState,
 				extractedStemcell,
 				installationManifest,
@@ -230,7 +229,6 @@ func (c *DeploymentPreparer) PrepareDeployment(stage biui.Stage, recreate bool, 
 }
 
 func (c *DeploymentPreparer) deploy(
-	installation biinstall.Installation,
 	deploymentState biconfig.DeploymentState,
 	extractedStemcell bistemcell.ExtractedStemcell,
 	installationManifest biinstallmanifest.Manifest,
@@ -271,6 +269,7 @@ func (c *DeploymentPreparer) deploy(
 			vmManager,
 			blobstore,
 			skipDrain,
+			c.extractDiskCIDsFromState(deploymentState),
 			deployStage,
 		)
 		if err != nil {
@@ -304,4 +303,14 @@ func (c *DeploymentPreparer) stemcellApiVersion(stemcell bistemcell.ExtractedSte
 		return 1
 	}
 	return stemcellApiVersion
+}
+
+// These disk CIDs get passed all the way to the create_vm cpi call
+func (c *DeploymentPreparer) extractDiskCIDsFromState(deploymentState biconfig.DeploymentState) []string {
+	var diskCIDs []string
+	for _, disk := range deploymentState.Disks {
+		diskCIDs = append(diskCIDs, disk.CID)
+	}
+
+	return diskCIDs
 }

--- a/deployment/instance/manager.go
+++ b/deployment/instance/manager.go
@@ -24,6 +24,7 @@ type Manager interface {
 		id int,
 		deploymentManifest bideplmanifest.Manifest,
 		cloudStemcell bistemcell.CloudStemcell,
+		diskCIDs []string,
 		eventLoggerStage biui.Stage,
 	) (Instance, []bidisk.Disk, error)
 	DeleteAll(
@@ -97,13 +98,14 @@ func (m *manager) Create(
 	id int,
 	deploymentManifest bideplmanifest.Manifest,
 	cloudStemcell bistemcell.CloudStemcell,
+	diskCIDs []string,
 	eventLoggerStage biui.Stage,
 ) (Instance, []bidisk.Disk, error) {
 	var vm bivm.VM
 	stepName := fmt.Sprintf("Creating VM for instance '%s/%d' from stemcell '%s'", jobName, id, cloudStemcell.CID())
 	err := eventLoggerStage.Perform(stepName, func() error {
 		var err error
-		vm, err = m.vmManager.Create(cloudStemcell, deploymentManifest)
+		vm, err = m.vmManager.Create(cloudStemcell, deploymentManifest, diskCIDs)
 		if err != nil {
 			return bosherr.WrapError(err, "Creating VM")
 		}

--- a/deployment/instance/manager_test.go
+++ b/deployment/instance/manager_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Manager", func() {
 			diskPool           bideplmanifest.DiskPool
 			deploymentManifest bideplmanifest.Manifest
 			fakeCloudStemcell  *fakebistemcell.FakeCloudStemcell
+			diskCIDs           []string
 
 			expectedInstance Instance
 			expectedDisk     *fakebidisk.FakeDisk
@@ -164,6 +165,8 @@ var _ = Describe("Manager", func() {
 
 			fakeCloudStemcell = fakebistemcell.NewFakeCloudStemcell("fake-stemcell-cid", "fake-stemcell-name", "fake-stemcell-version", apiVersion)
 
+			diskCIDs = []string{"fake-disk-cid"}
+
 			fakeVM = fakebivm.NewFakeVM("fake-vm-cid")
 			fakeVMManager.CreateVM = fakeVM
 
@@ -194,6 +197,7 @@ var _ = Describe("Manager", func() {
 				0,
 				deploymentManifest,
 				fakeCloudStemcell,
+				diskCIDs,
 				fakeStage,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -202,6 +206,7 @@ var _ = Describe("Manager", func() {
 			Expect(fakeVMManager.CreateInput).To(Equal(fakebivm.CreateInput{
 				Stemcell: fakeCloudStemcell,
 				Manifest: deploymentManifest,
+				DiskCIDs: diskCIDs,
 			}))
 		})
 
@@ -211,6 +216,7 @@ var _ = Describe("Manager", func() {
 				0,
 				deploymentManifest,
 				fakeCloudStemcell,
+				diskCIDs,
 				fakeStage,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -224,6 +230,7 @@ var _ = Describe("Manager", func() {
 				0,
 				deploymentManifest,
 				fakeCloudStemcell,
+				diskCIDs,
 				fakeStage,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -240,6 +247,7 @@ var _ = Describe("Manager", func() {
 				0,
 				deploymentManifest,
 				fakeCloudStemcell,
+				diskCIDs,
 				fakeStage,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -262,6 +270,7 @@ var _ = Describe("Manager", func() {
 				0,
 				deploymentManifest,
 				fakeCloudStemcell,
+				diskCIDs,
 				fakeStage,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -286,6 +295,7 @@ var _ = Describe("Manager", func() {
 					0,
 					deploymentManifest,
 					fakeCloudStemcell,
+					diskCIDs,
 					fakeStage,
 				)
 				Expect(err).To(HaveOccurred())
@@ -298,6 +308,7 @@ var _ = Describe("Manager", func() {
 					0,
 					deploymentManifest,
 					fakeCloudStemcell,
+					diskCIDs,
 					fakeStage,
 				)
 				Expect(err).To(HaveOccurred())

--- a/deployment/instance/mocks/mocks.go
+++ b/deployment/instance/mocks/mocks.go
@@ -191,9 +191,9 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockManager) Create(arg0 string, arg1 int, arg2 manifest.Manifest, arg3 stemcell.CloudStemcell, arg4 ui.Stage) (instance.Instance, []disk.Disk, error) {
+func (m *MockManager) Create(arg0 string, arg1 int, arg2 manifest.Manifest, arg3 stemcell.CloudStemcell, arg4 []string, arg5 ui.Stage) (instance.Instance, []disk.Disk, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(instance.Instance)
 	ret1, _ := ret[1].([]disk.Disk)
 	ret2, _ := ret[2].(error)
@@ -201,9 +201,9 @@ func (m *MockManager) Create(arg0 string, arg1 int, arg2 manifest.Manifest, arg3
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockManagerMockRecorder) Create(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Create(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockManager)(nil).Create), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockManager)(nil).Create), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // DeleteAll mocks base method.

--- a/deployment/mocks/mocks.go
+++ b/deployment/mocks/mocks.go
@@ -146,18 +146,18 @@ func (m *MockDeployer) EXPECT() *MockDeployerMockRecorder {
 }
 
 // Deploy mocks base method.
-func (m *MockDeployer) Deploy(arg0 cloud.Cloud, arg1 manifest.Manifest, arg2 stemcell.CloudStemcell, arg3 vm.Manager, arg4 blobstore.Blobstore, arg5 bool, arg6 ui.Stage) (deployment.Deployment, error) {
+func (m *MockDeployer) Deploy(arg0 cloud.Cloud, arg1 manifest.Manifest, arg2 stemcell.CloudStemcell, arg3 vm.Manager, arg4 blobstore.Blobstore, arg5 bool, arg6 []string, arg7 ui.Stage) (deployment.Deployment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Deploy", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "Deploy", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(deployment.Deployment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Deploy indicates an expected call of Deploy.
-func (mr *MockDeployerMockRecorder) Deploy(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockDeployerMockRecorder) Deploy(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockDeployer)(nil).Deploy), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockDeployer)(nil).Deploy), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // MockManager is a mock of Manager interface.

--- a/deployment/vm/fakes/fake_manager.go
+++ b/deployment/vm/fakes/fake_manager.go
@@ -9,6 +9,7 @@ import (
 type CreateInput struct {
 	Stemcell bistemcell.CloudStemcell
 	Manifest bideplmanifest.Manifest
+	DiskCIDs []string
 }
 
 type FakeManager struct {
@@ -33,10 +34,11 @@ func (m *FakeManager) FindCurrent() (bivm.VM, bool, error) {
 	return m.findCurrentBehaviour.vm, m.findCurrentBehaviour.found, m.findCurrentBehaviour.err
 }
 
-func (m *FakeManager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest bideplmanifest.Manifest) (bivm.VM, error) {
+func (m *FakeManager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest bideplmanifest.Manifest, diskCIDs []string) (bivm.VM, error) {
 	input := CreateInput{
 		Stemcell: stemcell,
 		Manifest: deploymentManifest,
+		DiskCIDs: diskCIDs,
 	}
 	m.CreateInput = input
 

--- a/deployment/vm/manager.go
+++ b/deployment/vm/manager.go
@@ -20,7 +20,7 @@ import (
 
 type Manager interface {
 	FindCurrent() (VM, bool, error)
-	Create(bistemcell.CloudStemcell, bideplmanifest.Manifest) (VM, error)
+	Create(stemcell bistemcell.CloudStemcell, deploymentManifest bideplmanifest.Manifest, diskCIDs []string) (VM, error)
 }
 
 type manager struct {
@@ -86,7 +86,7 @@ func (m *manager) FindCurrent() (VM, bool, error) {
 	return vm, true, err
 }
 
-func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest bideplmanifest.Manifest) (VM, error) {
+func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest bideplmanifest.Manifest, diskCIDs []string) (VM, error) {
 	jobName := deploymentManifest.JobName()
 	networkInterfaces, err := deploymentManifest.NetworkInterfaces(jobName)
 	m.logger.Debug(m.logTag, "Creating VM with network interfaces: %#v", networkInterfaces)
@@ -113,7 +113,7 @@ func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest b
 			}
 		}
 	}
-	cid, err := m.createAndRecordVM(agentID, stemcell, resourcePool, networkInterfaces)
+	cid, err := m.createAndRecordVM(agentID, stemcell, resourcePool, diskCIDs, networkInterfaces)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +158,8 @@ func (m *manager) Create(stemcell bistemcell.CloudStemcell, deploymentManifest b
 	return vm, nil
 }
 
-func (m *manager) createAndRecordVM(agentID string, stemcell bistemcell.CloudStemcell, resourcePool bideplmanifest.ResourcePool, networkInterfaces map[string]biproperty.Map) (string, error) {
-	cid, err := m.cloud.CreateVM(agentID, stemcell.CID(), resourcePool.CloudProperties, networkInterfaces, resourcePool.Env)
+func (m *manager) createAndRecordVM(agentID string, stemcell bistemcell.CloudStemcell, resourcePool bideplmanifest.ResourcePool, diskCIDs []string, networkInterfaces map[string]biproperty.Map) (string, error) {
+	cid, err := m.cloud.CreateVM(agentID, stemcell.CID(), resourcePool.CloudProperties, diskCIDs, networkInterfaces, resourcePool.Env)
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "Creating vm with stemcell cid '%s'", stemcell.CID())
 	}


### PR DESCRIPTION
The create_vm (ref https://bosh.io/docs/cpi-api-v2-method/create-vm/) CPI method takes an optional array of CIDs that feed into the VM placement strategy.  The BOSH director sends these along, but the create-env command did not.  This commit adds that functionality by reading the disks from the state file.