### PR TITLE
Support BOSH_TTY environment variable for --tty flag

### DIFF
--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -158,7 +158,7 @@ var globalFlags = []string{
 	"-n\tDon't ask for user input, env: BOSH_NON_INTERACTIVE",
 	"--parallel\tThe max number of parallel operations",
 	"--sha2\tUse SHA256 checksums, env: BOSH_SHA2",
-	"--tty\tForce TTY-like output",
+	"--tty\tForce TTY-like output, env: BOSH_TTY",
 	"--version\tShow CLI version",
 	"-v\tShow CLI version",
 }

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -31,7 +31,7 @@ type BoshOpts struct {
 	// Output formatting
 	ColumnOpt         []ColumnOpt `long:"column"                    description:"Filter to show only given column(s), use the --column flag for each column you wish to include"`
 	JSONOpt           bool        `long:"json"                      description:"Output as JSON"`
-	TTYOpt            bool        `long:"tty"                       description:"Force TTY-like output"`
+	TTYOpt            bool        `long:"tty"                       description:"Force TTY-like output" env:"BOSH_TTY"`
 	NoColorOpt        bool        `long:"no-color"                  description:"Toggle colorized output"`
 	NonInteractiveOpt bool        `long:"non-interactive" short:"n" description:"Don't ask for user input" env:"BOSH_NON_INTERACTIVE"`
 

--- a/cmd/opts/opts_test.go
+++ b/cmd/opts/opts_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Opts", func() {
 		Describe("TTYOpt", func() {
 			It("contains desired values", func() {
 				Expect(getStructTagForName("TTYOpt", opts)).To(Equal(
-					`long:"tty" description:"Force TTY-like output"`,
+					`long:"tty" description:"Force TTY-like output" env:"BOSH_TTY"`,
 				))
 			})
 		})


### PR DESCRIPTION
This is convenient for CI/CD tools that may not run jobs in a tty. See https://github.com/actions/runner/issues/241