### PR TITLE
fix: make dirty check more resilient

### DIFF
--- a/releasedir/git_repo.go
+++ b/releasedir/git_repo.go
@@ -74,7 +74,7 @@ func (r FSGitRepo) LastCommitSHA() (string, error) {
 func (r FSGitRepo) MustNotBeDirty(force bool) (bool, error) {
 	cmd := boshsys.Command{
 		Name:       "git",
-		Args:       []string{"status", "--short"},
+		Args:       []string{"status", "--porcelain=1"},
 		WorkingDir: r.dirPath,
 	}
 	stdout, stderr, _, err := r.runner.RunComplexCommand(cmd)


### PR DESCRIPTION
Creating a release will fail even in a clean repo because of unexpected output from git-status when using a non-standard git-status configuration. This commit switches the check from `--short` to `--porcelain` which is intended to produce stable, machine-readable output similar to `--short`.

Resolves: #667