### PR TITLE
Fix create-env bug where an empty slice of disks from the state file results in null being passed to the CPI ask the disks argument

### DIFF
--- a/cmd/deployment_preparer.go
+++ b/cmd/deployment_preparer.go
@@ -307,7 +307,7 @@ func (c *DeploymentPreparer) stemcellApiVersion(stemcell bistemcell.ExtractedSte
 
 // These disk CIDs get passed all the way to the create_vm cpi call
 func (c *DeploymentPreparer) extractDiskCIDsFromState(deploymentState biconfig.DeploymentState) []string {
-	var diskCIDs []string
+	diskCIDs := make([]string, 0)
 	for _, disk := range deploymentState.Disks {
 		diskCIDs = append(diskCIDs, disk.CID)
 	}


### PR DESCRIPTION
This is caused by the way the original string slice is created. If you create it using var []string, it json marshals as null Instead we need to make([]string, 0), which will json marshal as []