### PR TITLE
Enhance PCAP Command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -368,7 +368,7 @@ func (c Cmd) Execute() (cmdErr error) {
 		return NewCleanUpCmd(deps.UI, c.director()).Run(*opts)
 
 	case *PcapOpts:
-		return NewPcapCmd(c.deployment(), pcap.NewPcapRunner(deps.UI, deps.Logger)).Run(*opts)
+		return NewPcapCmd(c.deployment(), pcap.NewPcapRunner(deps.UI, deps.Logger), c.BoshOpts.Parallel).Run(*opts)
 
 	case *LogsOpts:
 		sshProvider := boshssh.NewProvider(deps.CmdRunner, deps.FS, deps.UI, deps.Logger)

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -969,7 +969,7 @@ type PcapOpts struct {
 }
 
 type MultiAllOrInstanceGroupOrInstanceSlugArgs struct {
-	Slugs []boshdir.AllOrInstanceGroupOrInstanceSlug `positional-arg-name:"INSTANCE-GROUP[/INSTANCE-ID]"`
+	Slugs []boshdir.AllOrInstanceGroupOrInstanceSlug `positional-arg-name:"INSTANCE-GROUP[/INSTANCE-ID]..."`
 }
 
 type AllOrInstanceGroupOrInstanceSlugArgs struct {

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -955,7 +955,7 @@ type RecreateOpts struct {
 }
 
 type PcapOpts struct {
-	Args AllOrInstanceGroupOrInstanceSlugArgs `positional-args:"true"`
+	Args MultiAllOrInstanceGroupOrInstanceSlugArgs `positional-args:"true"`
 
 	Interface   string        `long:"interface" short:"i" description:"Specifies the network interface to listen on." default:"eth0" required:"false"`
 	Filter      string        `long:"filter" short:"f" description:"Filter to apply when running tcpdump."`
@@ -966,6 +966,10 @@ type PcapOpts struct {
 	GatewayFlags
 
 	cmd
+}
+
+type MultiAllOrInstanceGroupOrInstanceSlugArgs struct {
+	Slugs []boshdir.AllOrInstanceGroupOrInstanceSlug `positional-arg-name:"INSTANCE-GROUP[/INSTANCE-ID]"`
 }
 
 type AllOrInstanceGroupOrInstanceSlugArgs struct {

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -969,7 +969,7 @@ type PcapOpts struct {
 }
 
 type MultiAllOrInstanceGroupOrInstanceSlugArgs struct {
-	Slugs []boshdir.AllOrInstanceGroupOrInstanceSlug `positional-arg-name:"INSTANCE-GROUP[/INSTANCE-ID]..."`
+	Slugs []boshdir.AllOrInstanceGroupOrInstanceSlug `positional-arg-name:"INSTANCE-GROUP[/INSTANCE-ID]"`
 }
 
 type AllOrInstanceGroupOrInstanceSlugArgs struct {

--- a/cmd/pcap.go
+++ b/cmd/pcap.go
@@ -43,6 +43,14 @@ func (c PcapCmd) Run(opts PcapOpts) error {
 		slugs = opts.Args.Slugs
 	}
 
+	for i := 0; i < len(slugs); i++ {
+		for j := i + 1; j < len(slugs); j++ {
+			if slugs[i].Overlaps(slugs[j]) {
+				return fmt.Errorf("found redundant capture targets: %v and %v", slugs[i], slugs[j])
+			}
+		}
+	}
+
 	for _, slug := range slugs {
 		res, err := c.deployment.SetUpSSH(slug, sshOpts)
 		if err != nil {

--- a/cmd/pcap.go
+++ b/cmd/pcap.go
@@ -17,15 +17,18 @@ const (
 type PcapCmd struct {
 	deployment boshdir.Deployment
 	pcapRunner pcap.PcapRunner
+	parallel   int
 }
 
 func NewPcapCmd(
 	deployment boshdir.Deployment,
 	pcapRunner pcap.PcapRunner,
+	parallel int,
 ) PcapCmd {
 	return PcapCmd{
 		deployment: deployment,
 		pcapRunner: pcapRunner,
+		parallel:   parallel,
 	}
 }
 
@@ -71,7 +74,7 @@ func (c PcapCmd) Run(opts PcapOpts) error {
 		return fmt.Errorf("invalid pcap cmd options: %w", err)
 	}
 
-	return c.pcapRunner.Run(result, sshOpts.Username, argv, opts, connOpts.PrivateKey)
+	return c.pcapRunner.Run(result, sshOpts.Username, argv, opts, connOpts.PrivateKey, c.parallel)
 }
 
 func buildPcapCmd(opts PcapOpts) (string, error) {

--- a/cmd/pcap.go
+++ b/cmd/pcap.go
@@ -40,19 +40,14 @@ func (c PcapCmd) Run(opts PcapOpts) error {
 
 	var result boshdir.SSHResult
 
+	// If no slugs are provided, default to capturing all instances by using an empty slug.
 	slugs := []boshdir.AllOrInstanceGroupOrInstanceSlug{{}}
 
 	if len(opts.Args.Slugs) > 0 {
 		slugs = opts.Args.Slugs
 	}
 
-	for i := 0; i < len(slugs); i++ {
-		for j := i + 1; j < len(slugs); j++ {
-			if slugs[i].Overlaps(slugs[j]) {
-				return fmt.Errorf("found redundant capture targets: %v and %v", slugs[i], slugs[j])
-			}
-		}
-	}
+	slugs = boshdir.DeduplicateSlugs(slugs)
 
 	for _, slug := range slugs {
 		res, err := c.deployment.SetUpSSH(slug, sshOpts)

--- a/cmd/pcap_test.go
+++ b/cmd/pcap_test.go
@@ -56,7 +56,7 @@ var _ = Describe("pcap", func() {
 
 			Context("when valid pcap args are provided", func() {
 				BeforeEach(func() {
-					pcapOpts.Args.Slug = boshdir.AllOrInstanceGroupOrInstanceSlug{}
+					pcapOpts.Args.Slugs = []boshdir.AllOrInstanceGroupOrInstanceSlug{{}}
 				})
 
 				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {

--- a/cmd/pcap_test.go
+++ b/cmd/pcap_test.go
@@ -30,7 +30,7 @@ var _ = Describe("pcap", func() {
 			deployment = &fakedir.FakeDeployment{}
 			uuidGen = &fakeuuid.FakeGenerator{}
 			pcapRunner = &fakepcap.FakePcapRunner{}
-			command = cmd.NewPcapCmd(deployment, pcapRunner)
+			command = cmd.NewPcapCmd(deployment, pcapRunner, 5)
 		})
 
 		Describe("Run", func() {
@@ -60,7 +60,7 @@ var _ = Describe("pcap", func() {
 				})
 
 				It("sets up SSH access, runs SSH command and later cleans up SSH access", func() {
-					pcapRunner.RunStub = func(result boshdir.SSHResult, username string, argv string, pcapOpts opts.PcapOpts, privateKey string) error {
+					pcapRunner.RunStub = func(result boshdir.SSHResult, username string, argv string, pcapOpts opts.PcapOpts, privateKey string, parallel int) error {
 						Expect(argv).To(Equal("sudo tcpdump -w - -i eth0 -s 65535"))
 						return nil
 					}
@@ -87,7 +87,7 @@ var _ = Describe("pcap", func() {
 				It("provides custom opts, sets up SSH access, runs SSH command and later cleans up SSH access", func() {
 					pcapOpts.SnapLength = 300
 					pcapOpts.Interface = "any"
-					pcapRunner.RunStub = func(result boshdir.SSHResult, username string, argv string, pcapOpts opts.PcapOpts, privateKey string) error {
+					pcapRunner.RunStub = func(result boshdir.SSHResult, username string, argv string, pcapOpts opts.PcapOpts, privateKey string, parallel int) error {
 						Expect(argv).To(Equal("sudo tcpdump -w - -i any -s 300"))
 						Expect(deployment.CleanUpSSHCallCount()).To(Equal(0))
 						return nil

--- a/director/all_or_pool_or_instance_slug.go
+++ b/director/all_or_pool_or_instance_slug.go
@@ -33,6 +33,16 @@ func (s AllOrInstanceGroupOrInstanceSlug) InstanceSlug() (InstanceSlug, bool) {
 	return InstanceSlug{}, false
 }
 
+func (s AllOrInstanceGroupOrInstanceSlug) Overlaps(other AllOrInstanceGroupOrInstanceSlug) bool {
+	if s.name != other.name {
+		return false
+	}
+
+	// There is an overlap if either slug is empty or if the indexOrID or IP matches
+	return s.indexOrID == "" || other.indexOrID == "" || s.indexOrID == other.indexOrID || s.ip == other.ip
+
+}
+
 func (s AllOrInstanceGroupOrInstanceSlug) String() string {
 	if len(s.indexOrID) > 0 {
 		return fmt.Sprintf("%s/%s", s.name, s.indexOrID)

--- a/director/all_or_pool_or_instance_slug.go
+++ b/director/all_or_pool_or_instance_slug.go
@@ -34,13 +34,24 @@ func (s AllOrInstanceGroupOrInstanceSlug) InstanceSlug() (InstanceSlug, bool) {
 }
 
 func (s AllOrInstanceGroupOrInstanceSlug) Overlaps(other AllOrInstanceGroupOrInstanceSlug) bool {
+
+	// If the names/instance groups are different, there is no overlap
 	if s.name != other.name {
 		return false
 	}
 
-	// There is an overlap if either slug is empty or if the indexOrID or IP matches
-	return s.indexOrID == "" || other.indexOrID == "" || s.indexOrID == other.indexOrID || s.ip == other.ip
+	// If either slug is empty, there is an overlap
+	if s.indexOrID == "" || other.indexOrID == "" {
+		return true
+	}
 
+	// If the indexOrID matches, there is an overlap
+	if s.indexOrID == other.indexOrID {
+		return true
+	}
+
+	// If the IPs match, there is an overlap
+	return s.ip != "" && other.ip != "" && s.ip == other.ip
 }
 
 func (s AllOrInstanceGroupOrInstanceSlug) String() string {

--- a/director/all_or_pool_or_instance_slug_test.go
+++ b/director/all_or_pool_or_instance_slug_test.go
@@ -126,4 +126,22 @@ var _ = Describe("AllInstanceGroupOrInstanceSlug", func() {
 			Expect(err).To(Equal(errors.New("Expected instance 'name/' to specify non-empty ID or index")))
 		})
 	})
+
+	Describe("DeduplicateSlugs", func() {
+		It("deduplicates slugs", func() {
+			slugs := []AllOrInstanceGroupOrInstanceSlug{
+				NewAllOrInstanceGroupOrInstanceSlug("name1", ""),
+				NewAllOrInstanceGroupOrInstanceSlug("name1", "id2"),
+				NewAllOrInstanceGroupOrInstanceSlug("name2", "id1"),
+				NewAllOrInstanceGroupOrInstanceSlug("name2", "id2"),
+				NewAllOrInstanceGroupOrInstanceSlug("name1", ""),
+			}
+			Expect(DeduplicateSlugs(slugs)).To(Equal([]AllOrInstanceGroupOrInstanceSlug{
+				NewAllOrInstanceGroupOrInstanceSlug("name1", ""),
+				NewAllOrInstanceGroupOrInstanceSlug("name2", "id1"),
+				NewAllOrInstanceGroupOrInstanceSlug("name2", "id2"),
+			}))
+		})
+
+	})
 })

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -356,9 +356,9 @@ func sshResultTable(result boshdir.SSHResult) boshtbl.Table {
 		rows = append(rows, row)
 	}
 
-	notes := []string{fmt.Sprintf("Traffic on %d VMs will be captured.", len(rows))}
+	notes := []string{fmt.Sprintf("Traffic on %d VM(s) will be captured.", len(rows))}
 	if len(rows) > 5 {
-		notes = append(notes, "\nWarning: This could put a significant load on the BOSH Director. Use at your own discretion.")
+		notes = append(notes, "\nWarning: This could cause significant load for various components and could result in a very large capture file. Use at your own discretion.")
 	}
 
 	return boshtbl.Table{

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	boshtbl "github.com/cloudfoundry/bosh-cli/v7/ui/table"
-	"github.com/fatih/color"
 	"io"
 	"net"
 	"os"
@@ -14,6 +12,9 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	boshtbl "github.com/cloudfoundry/bosh-cli/v7/ui/table"
+	"github.com/fatih/color"
 
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/gopacket/gopacket"

--- a/pcap/pcapfakes/fake_pcap_runner.go
+++ b/pcap/pcapfakes/fake_pcap_runner.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FakePcapRunner struct {
-	RunStub        func(director.SSHResult, string, string, opts.PcapOpts, string) error
+	RunStub        func(director.SSHResult, string, string, opts.PcapOpts, string, int) error
 	runMutex       sync.RWMutex
 	runArgsForCall []struct {
 		arg1 director.SSHResult
@@ -18,6 +18,7 @@ type FakePcapRunner struct {
 		arg3 string
 		arg4 opts.PcapOpts
 		arg5 string
+		arg6 int
 	}
 	runReturns struct {
 		result1 error
@@ -29,7 +30,7 @@ type FakePcapRunner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakePcapRunner) Run(arg1 director.SSHResult, arg2 string, arg3 string, arg4 opts.PcapOpts, arg5 string) error {
+func (fake *FakePcapRunner) Run(arg1 director.SSHResult, arg2 string, arg3 string, arg4 opts.PcapOpts, arg5 string, arg6 int) error {
 	fake.runMutex.Lock()
 	ret, specificReturn := fake.runReturnsOnCall[len(fake.runArgsForCall)]
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
@@ -38,13 +39,14 @@ func (fake *FakePcapRunner) Run(arg1 director.SSHResult, arg2 string, arg3 strin
 		arg3 string
 		arg4 opts.PcapOpts
 		arg5 string
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 int
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.RunStub
 	fakeReturns := fake.runReturns
-	fake.recordInvocation("Run", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("Run", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.runMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
@@ -58,7 +60,7 @@ func (fake *FakePcapRunner) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
-func (fake *FakePcapRunner) RunCalls(stub func(director.SSHResult, string, string, opts.PcapOpts, string) error) {
+func (fake *FakePcapRunner) RunCalls(stub func(director.SSHResult, string, string, opts.PcapOpts, string, int) error) {
 	fake.runMutex.Lock()
 	defer fake.runMutex.Unlock()
 	fake.RunStub = stub


### PR DESCRIPTION
Changes:
* Start `tcpdump` commands in parallel, so the captures start at the same time on each VM
  * Uses the global `--parallel` parameter of the `bosh-cli` (which defaults to 5)
* Allow for multiple Instance Groups/InstanceID capture targets, e.g.:
`bosh -d cf pcap nats router/0 -o test.pcap`
  * Overlaps between Instance Groups/IDs are handled gracefully (e.g. `router router/0` will merge to `router`)
* Reduce verbosity of pcap command
* Show a table of all the VMs where the capture will be started and prompt if capturing should begin. Include a warning if the number of VMs is > 5 (`-n`/`--non-interactive` is supported):
```
./bosh pcap -d cf  -o test.pcap
[...]

Expected VMs for SSH capture

Job              IP         ID
uaa              10.1.1.65  d5033e83-5750-4e46-bc9c-e69d93cc107c
router           10.1.1.8   37747b53-7a56-460f-bdc7-f991d373cd7f
log-api          10.1.1.71  b65ed4a2-529c-45db-a0dc-50249f06e983
scheduler        10.1.1.68  da38fc60-6938-40d1-9e7d-0e65f313277c
router           10.1.1.9   5fff48d8-1456-4e7c-8a74-63f9b23096eb
cc-worker        10.1.1.67  9cd001cb-d1be-46c4-994d-6f53539710f4
diego-api        10.1.1.64  185b8031-0db4-4e19-92b5-05c7f7481d61
api              10.1.1.66  0cc45a0f-47ce-4a2d-9842-77a137de691d
doppler          10.1.1.70  b3054bbc-a02b-426f-9c3f-9f419888c8e5
nats             10.1.1.3   d6effa85-1cbd-4915-a5ff-93add8c77d4b
graphite-nozzle  10.1.1.72  9dccedaa-6138-4618-9ee9-56354f0af1ec
log-cache        10.1.1.69  1968bd85-f1fd-4007-9c94-8a83815f8124

Traffic on 12 VMs will be captured.

Warning: This could put a significant load on the BOSH Director. Use at your own discretion.

Continue? [yN]:
```
(Prompt can be omitted via `-n/--non-interactive` flag)

Correspondings docs PR: https://github.com/cloudfoundry/docs-bosh/pull/858