### PR TITLE
BOSH-1615_prevent_reupload

### DIFF
--- a/director/releases.go
+++ b/director/releases.go
@@ -241,7 +241,7 @@ func (d DirectorImpl) ReleaseHasSource(releaseSlug ReleaseSlug) (bool, error) {
 	}
 
 	for _, pkg := range pkgs {
-		if pkg.BlobstoreID == "" {
+		if pkg.BlobstoreID == "" && len(pkg.CompiledPackages) == 0 {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Releases with compiled packages are reuploaded due to missing blobstore ID. This change also checks if there are compiled packages. If yes a reupload is not necessary