### PR TITLE
Prevent Reupload of Releases

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -85,7 +85,7 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 			return err
 		}
 		for _, release := range releases {
-			c.ui.PrintLinef("Release '%s/%s' already exists.", release.Name(), release.Version())
+			c.ui.PrintLinef("Release-Check for '%s/%s' has been disabled.", release.Name(), release.Version())
 		}
 	} else {
 		bytes, err = c.releaseUploader.UploadReleases(bytes)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -79,7 +79,7 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 
 	if opts.FixReleases {
 		bytes, err = c.releaseUploader.UploadReleasesWithFix(bytes)
-	} else {
+	} else if !opts.SkipDownloadReleases {
 		bytes, err = c.releaseUploader.UploadReleases(bytes)
 	}
 	if err != nil {
@@ -125,6 +125,8 @@ func setFlags(flags []string, opts DeployOpts) DeployOpts {
 			opts.Recreate = true
 		case "recreate-persistent-disks":
 			opts.RecreatePersistentDisks = true
+		case "skip-download-release":
+			opts.SkipDownloadReleases = true
 		}
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -79,7 +79,15 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 
 	if opts.FixReleases {
 		bytes, err = c.releaseUploader.UploadReleasesWithFix(bytes)
-	} else if !opts.SkipDownloadReleases {
+	} else if opts.SkipDownloadReleases {
+		releases, err := c.deployment.Releases()
+		if err != nil {
+			return err
+		}
+		for _, release := range releases {
+			c.ui.PrintLinef("Release '%s/%s' already exists.", release.Name(), release.Version())
+		}
+	} else {
 		bytes, err = c.releaseUploader.UploadReleases(bytes)
 	}
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -79,14 +79,8 @@ func (c DeployCmd) Run(opts DeployOpts) error {
 
 	if opts.FixReleases {
 		bytes, err = c.releaseUploader.UploadReleasesWithFix(bytes)
-	} else if opts.SkipDownloadReleases {
-		releases, err := c.deployment.Releases()
-		if err != nil {
-			return err
-		}
-		for _, release := range releases {
-			c.ui.PrintLinef("Release-Check for '%s/%s' has been disabled.", release.Name(), release.Version())
-		}
+	} else if opts.SkipUploadReleases {
+		c.ui.PrintLinef("Release-Check skipped.")
 	} else {
 		bytes, err = c.releaseUploader.UploadReleases(bytes)
 	}
@@ -133,8 +127,8 @@ func setFlags(flags []string, opts DeployOpts) DeployOpts {
 			opts.Recreate = true
 		case "recreate-persistent-disks":
 			opts.RecreatePersistentDisks = true
-		case "skip-download-release":
-			opts.SkipDownloadReleases = true
+		case "skip-upload-releases":
+			opts.SkipUploadReleases = true
 		}
 	}
 

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -209,6 +209,15 @@ var _ = Describe("DeployCmd", func() {
 			Expect(bytes).To(Equal([]byte("after-upload-manifest-with-fix")))
 		})
 
+		It("skips the upload of all releases in the corresponding deployment", func() {
+			deployOpts.SkipDownloadReleases = true
+
+			err := act()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(releaseUploader.UploadReleasesWithFixCallCount()).To(Equal(0))
+			Expect(releaseUploader.UploadReleasesCallCount()).To(Equal(0))
+		})
+
 		It("returns error and does not deploy if uploading releases fails", func() {
 			deployOpts.Args.Manifest = opts.FileBytesArg{
 				Bytes: []byte(`

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -228,7 +228,7 @@ var _ = Describe("DeployCmd", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(releaseUploader.UploadReleasesWithFixCallCount()).To(Equal(0))
 			Expect(releaseUploader.UploadReleasesCallCount()).To(Equal(0))
-			Expect(ui.Said).To(ContainElement("Release 'ReleaseName/1' already exists."))
+			Expect(ui.Said).To(ContainElement("Release-Check for 'ReleaseName/1' has been disabled."))
 		})
 
 		It("returns error and does not deploy if uploading releases fails", func() {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -3,7 +3,6 @@ package cmd_test
 import (
 	"errors"
 	"github.com/cppforlife/go-patch/patch"
-	"github.com/cppforlife/go-semi-semantic/version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -23,7 +22,6 @@ var _ = Describe("DeployCmd", func() {
 		releaseUploader *fakecmd.FakeReleaseUploader
 		director        *fakedir.FakeDirector
 		command         cmd.DeployCmd
-		release         *fakedir.FakeRelease
 	)
 
 	BeforeEach(func() {
@@ -39,13 +37,6 @@ var _ = Describe("DeployCmd", func() {
 		director = &fakedir.FakeDirector{}
 
 		command = cmd.NewDeployCmd(ui, deployment, releaseUploader, director)
-
-		release = &fakedir.FakeRelease{
-			NameStub: func() string { return "ReleaseName" },
-			VersionStub: func() version.Version {
-				return version.MustNewVersionFromString("1")
-			},
-		}
 	})
 
 	Describe("Run", func() {
@@ -218,17 +209,13 @@ var _ = Describe("DeployCmd", func() {
 		})
 
 		It("skips the upload of all releases in the corresponding deployment", func() {
-			var releases = []boshdir.Release{release}
-
-			deployment.ReleasesReturns(releases, nil)
-
-			deployOpts.SkipDownloadReleases = true
+			deployOpts.SkipUploadReleases = true
 
 			err := act()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(releaseUploader.UploadReleasesWithFixCallCount()).To(Equal(0))
 			Expect(releaseUploader.UploadReleasesCallCount()).To(Equal(0))
-			Expect(ui.Said).To(ContainElement("Release-Check for 'ReleaseName/1' has been disabled."))
+			Expect(ui.Said).To(ContainElement("Release-Check skipped."))
 		})
 
 		It("returns error and does not deploy if uploading releases fails", func() {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -216,7 +216,7 @@ var _ = Describe("DeployCmd", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(releaseUploader.UploadReleasesWithFixCallCount()).To(Equal(0))
 			Expect(releaseUploader.UploadReleasesCallCount()).To(Equal(0))
-			Expect(ui.Said).To(ContainElement("Release-Checkasdfasf skipped."))
+			Expect(ui.Said).To(ContainElement("Release-Check skipped."))
 		})
 
 		It("returns error and does not deploy if uploading releases fails", func() {

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"errors"
+
 	"github.com/cppforlife/go-patch/patch"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -215,7 +216,7 @@ var _ = Describe("DeployCmd", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(releaseUploader.UploadReleasesWithFixCallCount()).To(Equal(0))
 			Expect(releaseUploader.UploadReleasesCallCount()).To(Equal(0))
-			Expect(ui.Said).To(ContainElement("Release-Check skipped."))
+			Expect(ui.Said).To(ContainElement("Release-Checkasdfasf skipped."))
 		})
 
 		It("returns error and does not deploy if uploading releases fails", func() {

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -508,7 +508,7 @@ type DeployOpts struct {
 	Fix                     bool                `long:"fix"                                     description:"Recreate an instance with an unresponsive agent instead of erroring"`
 	FixReleases             bool                `long:"fix-releases"                            description:"Reupload releases in manifest and replace corrupt or missing jobs/packages"`
 	SkipDrain               []boshdir.SkipDrain `long:"skip-drain" value-name:"[INSTANCE-GROUP[/INSTANCE-ID]]"  description:"Skip running drain and pre-stop scripts for specific instance groups" optional:"true" optional-value:"*"`
-	SkipUploadReleases      bool                `long:"skip-upload-releases"                  description:"Skips the download procedure for releases"`
+	SkipUploadReleases      bool                `long:"skip-upload-releases"                  description:"Skips the upload procedure for releases"`
 
 	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`
 	MaxInFlight string `long:"max-in-flight" description:"Override manifest values for max_in_flight"`

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -508,7 +508,7 @@ type DeployOpts struct {
 	Fix                     bool                `long:"fix"                                     description:"Recreate an instance with an unresponsive agent instead of erroring"`
 	FixReleases             bool                `long:"fix-releases"                            description:"Reupload releases in manifest and replace corrupt or missing jobs/packages"`
 	SkipDrain               []boshdir.SkipDrain `long:"skip-drain" value-name:"[INSTANCE-GROUP[/INSTANCE-ID]]"  description:"Skip running drain and pre-stop scripts for specific instance groups" optional:"true" optional-value:"*"`
-	SkipDownloadReleases    bool                `long:"skip-download-releases"                  description:"Skips the download procedure for releases"`
+	SkipUploadReleases      bool                `long:"skip-upload-releases"                  description:"Skips the download procedure for releases"`
 
 	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`
 	MaxInFlight string `long:"max-in-flight" description:"Override manifest values for max_in_flight"`

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -508,6 +508,7 @@ type DeployOpts struct {
 	Fix                     bool                `long:"fix"                                     description:"Recreate an instance with an unresponsive agent instead of erroring"`
 	FixReleases             bool                `long:"fix-releases"                            description:"Reupload releases in manifest and replace corrupt or missing jobs/packages"`
 	SkipDrain               []boshdir.SkipDrain `long:"skip-drain" value-name:"[INSTANCE-GROUP[/INSTANCE-ID]]"  description:"Skip running drain and pre-stop scripts for specific instance groups" optional:"true" optional-value:"*"`
+	SkipDownloadReleases    bool                `long:"skip-download-releases"                  description:"Skips the download procedure for releases"`
 
 	Canaries    string `long:"canaries" description:"Override manifest values for canaries"`
 	MaxInFlight string `long:"max-in-flight" description:"Override manifest values for max_in_flight"`

--- a/director/releases.go
+++ b/director/releases.go
@@ -241,7 +241,7 @@ func (d DirectorImpl) ReleaseHasSource(releaseSlug ReleaseSlug) (bool, error) {
 	}
 
 	for _, pkg := range pkgs {
-		if pkg.BlobstoreID == "" {
+		if pkg.BlobstoreID == "" && len(pkg.CompiledPackages) == 0 {
 			return false, nil
 		}
 	}

--- a/director/releases.go
+++ b/director/releases.go
@@ -241,7 +241,7 @@ func (d DirectorImpl) ReleaseHasSource(releaseSlug ReleaseSlug) (bool, error) {
 	}
 
 	for _, pkg := range pkgs {
-		if pkg.BlobstoreID == "" && len(pkg.CompiledPackages) == 0 {
+		if pkg.BlobstoreID == "" {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
For bosh deploy cmd SAP bosh team is introducing the new flag "skip-upload-releases". If flagged no upload of releases is going to be triggered during bosh deploy. This flag was introduced for edge case customer with no internet connection. The have compiled releases available but during bosh deploy releases were redownloaded.

Please see PR https://github.com/cloudfoundry/docs-bosh/pull/862 for corresponding docs description