### PR TITLE
When creating a release, add the properties_schema.json to jobs if they contain the file

### DIFF
--- a/release/job/dir_reader.go
+++ b/release/job/dir_reader.go
@@ -72,6 +72,12 @@ func (r DirReaderImpl) collectFiles(path string) (boshjobman.Manifest, []File, e
 		files = append(files, NewFile(monitPath, path))
 	}
 
+	propertiesSchemaPath := filepath.Join(path, "properties_schema.json")
+
+	if r.fs.FileExists(propertiesSchemaPath) {
+		files = append(files, NewFile(propertiesSchemaPath, path))
+	}
+
 	for src := range manifest.Templates {
 		srcPath := filepath.Join(path, "templates", src)
 		files = append(files, NewFile(srcPath, path))

--- a/release/job/dir_reader_test.go
+++ b/release/job/dir_reader_test.go
@@ -52,6 +52,9 @@ properties:
 
 			err = fs.WriteFileString(filepath.Join("/", "my-job", "monit"), "monit-content")
 			Expect(err).ToNot(HaveOccurred())
+			err = fs.WriteFileString(filepath.Join("/", "my-job", "properties_schema.json"), "properties-schema-content")
+			Expect(err).ToNot(HaveOccurred())
+
 			err = fs.WriteFileString(filepath.Join("/", "my-job", "templates", "src"), "tpl-content")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -67,6 +70,7 @@ properties:
 			Expect(collectedFiles).To(Equal([]File{
 				{Path: filepath.Join("/", "my-job", "spec"), DirPath: filepath.Join("/", "my-job"), RelativePath: "job.MF"},
 				{Path: filepath.Join("/", "my-job", "monit"), DirPath: filepath.Join("/", "my-job"), RelativePath: "monit"},
+				{Path: filepath.Join("/", "my-job", "properties_schema.json"), DirPath: filepath.Join("/", "my-job"), RelativePath: "properties_schema.json"},
 				{Path: filepath.Join("/", "my-job", "templates", "src"), DirPath: filepath.Join("/", "my-job"), RelativePath: filepath.Join("templates", "src")},
 			}))
 


### PR DESCRIPTION
This file contains a json schema that is used by the director to validate the deployment properties are correct.