### PR TITLE
remove use of the UseIsolatedEnv since it got deleted from bosh utils

### DIFF
--- a/integration/upload_release_test.go
+++ b/integration/upload_release_test.go
@@ -69,10 +69,9 @@ blobstore:
 
 			execGit := func(args []string) {
 				cmd := boshsys.Command{
-					Name:           "git",
-					Args:           args,
-					UseIsolatedEnv: true,
-					WorkingDir:     tmpDir, // --git-dir/--work-tree/etc. dont work great
+					Name:       "git",
+					Args:       args,
+					WorkingDir: tmpDir, // --git-dir/--work-tree/etc. dont work great
 				}
 				_, _, _, err := deps.CmdRunner.RunComplexCommand(cmd)
 				Expect(err).ToNot(HaveOccurred())

--- a/release/resource/archive.go
+++ b/release/resource/archive.go
@@ -117,8 +117,7 @@ func (a ArchiveImpl) runPrepScripts(stagingDir string) error {
 			Name: "bash",
 			Args: []string{"-x", prepFile.Path},
 
-			WorkingDir:     stagingDir,
-			UseIsolatedEnv: false,
+			WorkingDir: stagingDir,
 
 			Env: map[string]string{
 				"BUILD_DIR":   stagingDir,


### PR DESCRIPTION
The field `UseIsolatedEnv` is removed from bosh-utils and having it here is blocking the dependency bump