### PR TITLE
Director FactoryConfig support for InsecureSkipVerify

### DIFF
--- a/director/factory_config.go
+++ b/director/factory_config.go
@@ -15,6 +15,7 @@ type FactoryConfig struct {
 	Host string
 	Port int
 
+	InsecureSkipVerify bool
 	// CA certificate is not required
 	CACert string
 
@@ -61,7 +62,7 @@ func NewConfigFromURL(url string) (FactoryConfig, error) {
 		return FactoryConfig{}, bosherr.Errorf("Expected to extract host from URL '%s'", url)
 	}
 
-	return FactoryConfig{Host: host, Port: port}, nil
+	return FactoryConfig{Host: host, Port: port, InsecureSkipVerify: false}, nil
 }
 
 func (c FactoryConfig) Validate() error {


### PR DESCRIPTION
Added `InsecureSkipVerify` support to `Director.FactoryConfig` to allow skipping SSL certificate verification. This is needed for testing a program that connects to a BOSH Director through an SSH tunnel using `bosh_cli` and `director.Factory`.