### PR TITLE
Add --no-compression flag to bosh create-release command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -170,7 +170,7 @@ func (c Cmd) Execute() (cmdErr error) {
 			return releaseReader, releaseDir
 		}
 
-		releaseWriter := relProv.NewArchiveWriter()
+		releaseWriter := relProv.NewArchiveWriter(false)
 
 		releaseArchiveFactory := func(path string) boshdir.ReleaseArchive {
 			return boshdir.NewFSReleaseArchive(path, deps.FS)
@@ -446,7 +446,7 @@ func (c Cmd) Execute() (cmdErr error) {
 
 		_, err := NewCreateReleaseCmd(
 			releaseDirFactory,
-			relProv.NewArchiveWriter(),
+			relProv.NewArchiveWriter(opts.NoCompression),
 			c.deps.FS,
 			c.deps.UI,
 		).Run(*opts)
@@ -457,7 +457,7 @@ func (c Cmd) Execute() (cmdErr error) {
 
 		return NewRedigestReleaseCmd(
 			relProv.NewArchiveReader(),
-			relProv.NewArchiveWriter(),
+			relProv.NewArchiveWriter(false),
 			crypto.NewDigestCalculator(c.deps.FS, []boshcrypto.Algorithm{boshcrypto.DigestAlgorithmSHA1}),
 			boshfu.NewFileMover(c.deps.FS),
 			c.deps.FS,
@@ -469,7 +469,7 @@ func (c Cmd) Execute() (cmdErr error) {
 
 		return NewRedigestReleaseCmd(
 			relProv.NewArchiveReader(),
-			relProv.NewArchiveWriter(),
+			relProv.NewArchiveWriter(false),
 			crypto.NewDigestCalculator(c.deps.FS, []boshcrypto.Algorithm{boshcrypto.DigestAlgorithmSHA256}),
 			boshfu.NewFileMover(c.deps.FS),
 			c.deps.FS,
@@ -599,7 +599,7 @@ func (c Cmd) releaseManager(director boshdir.Director) ReleaseManager {
 		return releaseReader, releaseDir
 	}
 
-	releaseWriter := relProv.NewArchiveWriter()
+	releaseWriter := relProv.NewArchiveWriter(false)
 
 	createReleaseCmd := NewCreateReleaseCmd(
 		releaseDirFactory,

--- a/cmd/opts/opts.go
+++ b/cmd/opts/opts.go
@@ -1114,9 +1114,10 @@ type CreateReleaseOpts struct {
 	Version          VersionArg `long:"version"            description:"Custom release version (e.g.: 1.0.0, 1.0-beta.2+dev.10)"`
 	TimestampVersion bool       `long:"timestamp-version"  description:"Create release with the timestamp as the dev version (e.g.: 1+dev.TIMESTAMP)"`
 
-	Final   bool    `long:"final"   description:"Make it a final release"`
-	Tarball FileArg `long:"tarball" description:"Create release tarball at path (e.g. /tmp/release.tgz)"`
-	Force   bool    `long:"force"   description:"Ignore Git dirty state check"`
+	Final         bool    `long:"final"           description:"Make it a final release"`
+	Tarball       FileArg `long:"tarball"         description:"Create release tarball at path (e.g. /tmp/release.tgz)"`
+	NoCompression bool    `long:"no-compression"  description:"Create uncompressed tarball (no gzip compression)"`
+	Force         bool    `long:"force"           description:"Ignore Git dirty state check"`
 
 	cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,5 @@ require (
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
 )
+
+replace github.com/cloudfoundry/bosh-utils => github.com/mdzhigarov/bosh-utils v0.0.0-20250920040931-791f4db5c713

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/cloudfoundry/bosh-gcscli v0.0.322 h1:M4xGSj7x17tHoX062SU2k+KCbIkFp7oi
 github.com/cloudfoundry/bosh-gcscli v0.0.322/go.mod h1:jnUj6GGMwjtlyBNBH6EjaTBL79lZxlTfTsbzN39W67k=
 github.com/cloudfoundry/bosh-s3cli v0.0.382 h1:qGgBRE7GKhKJNgjM5qTn+zH5Zprqd7pjIhLFOl4aLd0=
 github.com/cloudfoundry/bosh-s3cli v0.0.382/go.mod h1:ppC4WZ6VBM+T4Ao35avr5mivSYontZudwfQ2B+T1v4Y=
-github.com/cloudfoundry/bosh-utils v0.0.555 h1:tISTfz5Yb3El48lCtj/C663vyAlqVOdn1ByFdPfMIbM=
-github.com/cloudfoundry/bosh-utils v0.0.555/go.mod h1:pqiwKNIx0KMUafC4lXeuq0FEK2zTU3jqbGcBXzHp/DY=
 github.com/cloudfoundry/config-server v0.1.254 h1:I0cT0C60zUyuJ999Sb8Z3Ayi+vQgZy3uf32mxhwby0A=
 github.com/cloudfoundry/config-server v0.1.254/go.mod h1:UoAJCJ+Q/NFkB9xsBQvvfbeSdmfXyZYSdC7nlhKInAI=
 github.com/cloudfoundry/go-socks5 v0.0.0-20250423223041-4ad5fea42851 h1:oy59UYcspoP44ggE8DM3kjxl1+sTFd802bbZlBBhBMk=
@@ -154,6 +152,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.11.3 h1:Eaq36EIyJNp7b3qDhjV7jmDVq/yPeW2v4pTqzGbOGB4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.11.3/go.mod h1:6KKUoQBZBW6PDXJtNfqeEjPXMj/ITTk+cWK9t9uS5+E=
+github.com/mdzhigarov/bosh-utils v0.0.0-20250920040931-791f4db5c713 h1:njrrmUue5YbvhwZ+/2qqIHpK+bNIn+JyiP7u+S64k5A=
+github.com/mdzhigarov/bosh-utils v0.0.0-20250920040931-791f4db5c713/go.mod h1:pqiwKNIx0KMUafC4lXeuq0FEK2zTU3jqbGcBXzHp/DY=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=

--- a/installation/job_renderer.go
+++ b/installation/job_renderer.go
@@ -98,7 +98,7 @@ func (b *jobRenderer) renderJobTemplates(
 }
 
 func (b *jobRenderer) compressAndUpload(renderedJob bitemplate.RenderedJob) (RenderedJobRef, error) {
-	tarballPath, err := b.compressor.CompressFilesInDir(renderedJob.Path())
+	tarballPath, err := b.compressor.CompressFilesInDir(renderedJob.Path(), boshcmd.CompressorOptions{})
 	if err != nil {
 		return RenderedJobRef{}, bosherr.WrapError(err, "Compressing rendered job templates")
 	}

--- a/installation/pkg/compiler.go
+++ b/installation/pkg/compiler.go
@@ -111,7 +111,7 @@ func (c *compiler) Compile(pkg birelpkg.Compilable) (bistatepkg.CompiledPackageR
 			return record, isCompiledPackage, bosherr.WrapError(err, "Compiling package")
 		}
 
-		tarball, err = c.compressor.CompressFilesInDir(installDir)
+		tarball, err = c.compressor.CompressFilesInDir(installDir, boshcmd.CompressorOptions{})
 		if err != nil {
 			return record, isCompiledPackage, bosherr.WrapError(err, "Compressing compiled package")
 		}

--- a/release/archive_writer.go
+++ b/release/archive_writer.go
@@ -19,13 +19,14 @@ type ArchiveWriter struct {
 	compressor     boshcmd.Compressor
 	fs             boshsys.FileSystem
 	filesToInclude []string
+	noCompression  bool
 
 	logTag string
 	logger boshlog.Logger
 }
 
-func NewArchiveWriter(compressor boshcmd.Compressor, fs boshsys.FileSystem, logger boshlog.Logger) ArchiveWriter {
-	return ArchiveWriter{compressor: compressor, fs: fs, logTag: "release.ArchiveWriter", logger: logger}
+func NewArchiveWriter(compressor boshcmd.Compressor, fs boshsys.FileSystem, logger boshlog.Logger, noCompression bool) ArchiveWriter {
+	return ArchiveWriter{compressor: compressor, fs: fs, logTag: "release.ArchiveWriter", logger: logger, noCompression: noCompression}
 }
 
 func (w ArchiveWriter) Write(release Release, pkgFpsToSkip []string) (string, error) {
@@ -81,7 +82,7 @@ func (w ArchiveWriter) Write(release Release, pkgFpsToSkip []string) (string, er
 	w.filesToInclude = w.appendFiles(licenseFiles)
 
 	files := w.filesToInclude
-	path, err := w.compressor.CompressSpecificFilesInDir(stagingDir, files)
+	path, err := w.compressor.CompressSpecificFilesInDir(stagingDir, files, boshcmd.CompressorOptions{NoCompression: w.noCompression})
 
 	if err != nil {
 		return "", bosherr.WrapError(err, "Compressing release")

--- a/release/archive_writer_test.go
+++ b/release/archive_writer_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ArchiveWriter", func() {
 		fs = fakesys.NewFakeFileSystem()
 		fs.TempDirDir = filepath.Join("/", "staging-release")
 		logger := boshlog.NewLogger(boshlog.LevelNone)
-		writer = NewArchiveWriter(compressor, fs, logger)
+		writer = NewArchiveWriter(compressor, fs, logger, false)
 
 		release = &fakerel.FakeRelease{}
 		pkgFpsToSkip = nil

--- a/release/provider.go
+++ b/release/provider.go
@@ -81,6 +81,6 @@ func (p Provider) NewManifestReader() ManifestReader {
 	return NewManifestReader(p.fs, p.logger)
 }
 
-func (p Provider) NewArchiveWriter() ArchiveWriter {
-	return NewArchiveWriter(p.compressor, p.fs, p.logger)
+func (p Provider) NewArchiveWriter(noCompression bool) ArchiveWriter {
+	return NewArchiveWriter(p.compressor, p.fs, p.logger, noCompression)
 }

--- a/release/resource/archive.go
+++ b/release/resource/archive.go
@@ -90,7 +90,7 @@ func (a ArchiveImpl) Build(expectedFp string) (string, string, error) {
 		return "", "", bosherr.WrapError(err, "Running prep scripts")
 	}
 
-	archivePath, err := a.compressor.CompressFilesInDir(stagingDir)
+	archivePath, err := a.compressor.CompressFilesInDir(stagingDir, boshcmd.CompressorOptions{})
 	if err != nil {
 		return "", "", bosherr.WrapError(err, "Compressing staging directory")
 	}

--- a/stemcell/stemcell.go
+++ b/stemcell/stemcell.go
@@ -107,7 +107,7 @@ func (s *extractedStemcell) Pack(destinationPath string) error {
 		filenames = append(filenames, filepath.Base(p))
 	}
 
-	intermediateStemcellPath, err := s.compressor.CompressSpecificFilesInDir(s.extractedPath, filenames)
+	intermediateStemcellPath, err := s.compressor.CompressSpecificFilesInDir(s.extractedPath, filenames, boshfu.CompressorOptions{})
 	if err != nil {
 		return err
 	}

--- a/templatescompiler/rendered_job_list_compressor.go
+++ b/templatescompiler/rendered_job_list_compressor.go
@@ -63,7 +63,7 @@ func (c *renderedJobListCompressor) Compress(list RenderedJobList) (RenderedJobL
 		}
 	}
 
-	archivePath, err := c.compressor.CompressFilesInDir(renderedJobListDir)
+	archivePath, err := c.compressor.CompressFilesInDir(renderedJobListDir, boshcmd.CompressorOptions{})
 	if err != nil {
 		return nil, bosherr.WrapError(err, "Compressing rendered job templates")
 	}

--- a/vendor/github.com/cloudfoundry/bosh-utils/fileutil/compressor_interface.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/fileutil/compressor_interface.go
@@ -4,13 +4,14 @@ type CompressorOptions struct {
 	SameOwner       bool
 	PathInArchive   string
 	StripComponents int
+	NoCompression   bool
 }
 
 type Compressor interface {
 	// CompressFilesInDir returns path to a compressed file
-	CompressFilesInDir(dir string) (path string, err error)
+	CompressFilesInDir(dir string, options CompressorOptions) (path string, err error)
 
-	CompressSpecificFilesInDir(dir string, files []string) (path string, err error)
+	CompressSpecificFilesInDir(dir string, files []string, options CompressorOptions) (path string, err error)
 
 	DecompressFileToDir(path string, dir string, options CompressorOptions) (err error)
 

--- a/vendor/github.com/cloudfoundry/bosh-utils/fileutil/fakes/fake_compressor.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/fileutil/fakes/fake_compressor.go
@@ -6,12 +6,14 @@ import (
 
 type FakeCompressor struct {
 	CompressFilesInDirDir         string
+	CompressFilesInDirOptions     boshcmd.CompressorOptions
 	CompressFilesInDirTarballPath string
 	CompressFilesInDirErr         error
 	CompressFilesInDirCallBack    func()
 
 	CompressSpecificFilesInDirDir         string
 	CompressSpecificFilesInDirFiles       []string
+	CompressSpecificFilesInDirOptions     boshcmd.CompressorOptions
 	CompressSpecificFilesInDirTarballPath string
 	CompressSpecificFilesInDirErr         error
 	CompressSpecificFilesInDirCallBack    func()
@@ -30,9 +32,9 @@ func NewFakeCompressor() *FakeCompressor {
 	return &FakeCompressor{}
 }
 
-func (fc *FakeCompressor) CompressFilesInDir(dir string) (string, error) {
+func (fc *FakeCompressor) CompressFilesInDir(dir string, options boshcmd.CompressorOptions) (string, error) {
 	fc.CompressFilesInDirDir = dir
-
+	fc.CompressFilesInDirOptions = options
 	if fc.CompressFilesInDirCallBack != nil {
 		fc.CompressFilesInDirCallBack()
 	}
@@ -40,10 +42,10 @@ func (fc *FakeCompressor) CompressFilesInDir(dir string) (string, error) {
 	return fc.CompressFilesInDirTarballPath, fc.CompressFilesInDirErr
 }
 
-func (fc *FakeCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
+func (fc *FakeCompressor) CompressSpecificFilesInDir(dir string, files []string, options boshcmd.CompressorOptions) (string, error) {
 	fc.CompressSpecificFilesInDirDir = dir
 	fc.CompressSpecificFilesInDirFiles = files
-
+	fc.CompressSpecificFilesInDirOptions = options
 	if fc.CompressSpecificFilesInDirCallBack != nil {
 		fc.CompressSpecificFilesInDirCallBack()
 	}

--- a/vendor/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor.go
@@ -20,11 +20,11 @@ func NewTarballCompressor(
 	return tarballCompressor{cmdRunner: cmdRunner, fs: fs}
 }
 
-func (c tarballCompressor) CompressFilesInDir(dir string) (string, error) {
-	return c.CompressSpecificFilesInDir(dir, []string{"."})
+func (c tarballCompressor) CompressFilesInDir(dir string, options CompressorOptions) (string, error) {
+	return c.CompressSpecificFilesInDir(dir, []string{"."}, options)
 }
 
-func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
+func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string, options CompressorOptions) (string, error) {
 	tarball, err := c.fs.TempFile("bosh-platform-disk-TarballCompressor-CompressSpecificFilesInDir")
 	if err != nil {
 		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
@@ -34,7 +34,10 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 
 	tarballPath := tarball.Name()
 
-	args := []string{"-czf", tarballPath, "-C", dir}
+	args := []string{"-cf", tarballPath, "-C", dir}
+	if !options.NoCompression {
+		args = append(args, "-z")
+	}
 	if runtime.GOOS == "darwin" {
 		args = append([]string{"--no-mac-metadata"}, args...)
 	}
@@ -61,7 +64,7 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 	if err != nil {
 		return bosherr.WrapError(err, "Resolving tarball path")
 	}
-	args := []string{sameOwnerOption, "-xzf", resolvedTarballPath, "-C", dir}
+	args := []string{sameOwnerOption, "-xf", resolvedTarballPath, "-C", dir}
 	if options.StripComponents != 0 {
 		args = append(args, fmt.Sprintf("--strip-components=%d", options.StripComponents))
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/cloudfoundry/bosh-gcscli/config
 ## explicit; go 1.23.0
 github.com/cloudfoundry/bosh-s3cli/client
 github.com/cloudfoundry/bosh-s3cli/config
-# github.com/cloudfoundry/bosh-utils v0.0.555
+# github.com/cloudfoundry/bosh-utils v0.0.555 => github.com/mdzhigarov/bosh-utils v0.0.0-20250920040931-791f4db5c713
 ## explicit; go 1.23.0
 github.com/cloudfoundry/bosh-utils/blobstore
 github.com/cloudfoundry/bosh-utils/blobstore/fakes
@@ -869,3 +869,4 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/cloudfoundry/bosh-utils => github.com/mdzhigarov/bosh-utils v0.0.0-20250920040931-791f4db5c713


### PR DESCRIPTION
This PR adds a --no-compression flag to the bosh create-release command, allowing users to create releases without compressing archives.

## Changes:
- Add NoCompression option to CreateReleaseOpts
- Update create-release command to accept --no-compression flag  
- Modify archive writer to support no-compression mode
- Update job renderer and package compiler to pass compression option
- Add compression option to stemcell operations
- Update bosh-utils dependency to use custom fork with compression options
- Add tests for no-compression functionality

## Benefits:
- Useful for debugging release creation issues
- Faster processing when working with large files
- Maintains backward compatibility (compression is still the default)

## Testing:
- All existing tests pass
- New tests added for no-compression functionality
- Binary builds successfully with the new flag