### PR TITLE
fix: enable file autocompletion for add-blob and vendor-package commands

### DIFF
--- a/cmd/completion/complete_functions.go
+++ b/cmd/completion/complete_functions.go
@@ -29,7 +29,7 @@ func NewCompleteFunctionsMap(logger boshlog.Logger, directorQuery DirectorQueryI
 		"--var-file":   c.listFiles,
 		"--vars-file":  c.listFiles,
 		"--vars-store": c.listFiles,
-		reflect.TypeOf(opts.AddBlobArgs{}).Name():                          c.noFile,
+		reflect.TypeOf(opts.AddBlobArgs{}).Name():                          c.listFiles,
 		reflect.TypeOf(opts.AliasEnvArgs{}).Name():                         c.listEnvAliases,
 		reflect.TypeOf(opts.AllOrInstanceGroupOrInstanceSlugArgs{}).Name(): c.listInstanceGroupsOrSlugs,
 		reflect.TypeOf(opts.AttachDiskArgs{}).Name():                       c.listDiskCIDs,
@@ -75,7 +75,7 @@ func NewCompleteFunctionsMap(logger boshlog.Logger, directorQuery DirectorQueryI
 		reflect.TypeOf(opts.UpdateRuntimeConfigArgs{}).Name():              c.listFiles,
 		reflect.TypeOf(opts.UploadReleaseArgs{}).Name():                    c.listFiles,
 		reflect.TypeOf(opts.UploadStemcellArgs{}).Name():                   c.listFiles,
-		reflect.TypeOf(opts.VendorPackageArgs{}).Name():                    c.noFile,
+		reflect.TypeOf(opts.VendorPackageArgs{}).Name():                    c.listFiles,
 	}
 	return cfm
 }


### PR DESCRIPTION
## Summary

- Fix autocompletion for `bosh add-blob` command to enable file path completion
- Fix autocompletion for `bosh vendor-package` command to enable directory path completion

## Problem

The shell autocompletion feature for the BOSH CLI has a bug affecting release developers. Several commands used during release authoring do not autocomplete as expected:

- `bosh add-blob` - should allow file/path autocompletion to find files to add as blobs
- `bosh vendor-package` - should allow directory autocompletion to specify source package directories  

Currently, these commands use the `noFile` complete function which prevents filesystem autocompletion.

## Solution

Changed the completion function mapping for both commands from `c.noFile` to `c.listFiles`:

**File**: `cmd/completion/complete_functions.go`
- **Line 32**: `AddBlobArgs` mapping changed from `c.noFile` to `c.listFiles`
- **Line 78**: `VendorPackageArgs` mapping changed from `c.noFile` to `c.listFiles`

This allows users to:
- Use `bosh add-blob <tab>` for filesystem autocompletion when selecting files
- Use `bosh vendor-package <tab>` for filesystem autocompletion when selecting package directories

## Testing

The fix enables standard shell autocompletion for file/directory paths when using these commands.

Fixes #695