### PR TITLE
Adopt latest bosh-utils version that removes -z flag from tar extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cloudfoundry/bosh-davcli v0.0.439
 	github.com/cloudfoundry/bosh-gcscli v0.0.322
 	github.com/cloudfoundry/bosh-s3cli v0.0.382
-	github.com/cloudfoundry/bosh-utils v0.0.560
+	github.com/cloudfoundry/bosh-utils v0.0.562
 	github.com/cloudfoundry/config-server v0.1.257
 	github.com/cloudfoundry/socks5-proxy v0.2.159
 	github.com/cppforlife/go-patch v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/cloudfoundry/bosh-gcscli v0.0.322 h1:M4xGSj7x17tHoX062SU2k+KCbIkFp7oi
 github.com/cloudfoundry/bosh-gcscli v0.0.322/go.mod h1:jnUj6GGMwjtlyBNBH6EjaTBL79lZxlTfTsbzN39W67k=
 github.com/cloudfoundry/bosh-s3cli v0.0.382 h1:qGgBRE7GKhKJNgjM5qTn+zH5Zprqd7pjIhLFOl4aLd0=
 github.com/cloudfoundry/bosh-s3cli v0.0.382/go.mod h1:ppC4WZ6VBM+T4Ao35avr5mivSYontZudwfQ2B+T1v4Y=
-github.com/cloudfoundry/bosh-utils v0.0.560 h1:4vsa4dbw0gDe0/5AnFSYPrt2L+lrCxKwbJDs3hhdw6M=
-github.com/cloudfoundry/bosh-utils v0.0.560/go.mod h1:LNoUi8A9pr1KHF4RjwMKx4eBF6d/jhgFxZY32QVPQGY=
+github.com/cloudfoundry/bosh-utils v0.0.562 h1:xwuPbvB4eNQe72GeKLFlHavTUCkXs1K8xvuOafTHMqU=
+github.com/cloudfoundry/bosh-utils v0.0.562/go.mod h1:LNoUi8A9pr1KHF4RjwMKx4eBF6d/jhgFxZY32QVPQGY=
 github.com/cloudfoundry/config-server v0.1.257 h1:fLNwi5nTO0cabp8Hw7xu+Vtw7ZXQhaS3HQex/tYb30o=
 github.com/cloudfoundry/config-server v0.1.257/go.mod h1:wVcZNK7SUhxZ5uswkHJoTlGl4oiWjzH8o3vYi5/3pQg=
 github.com/cloudfoundry/go-socks5 v0.0.0-20250423223041-4ad5fea42851 h1:oy59UYcspoP44ggE8DM3kjxl1+sTFd802bbZlBBhBMk=

--- a/installation/job_renderer.go
+++ b/installation/job_renderer.go
@@ -98,7 +98,7 @@ func (b *jobRenderer) renderJobTemplates(
 }
 
 func (b *jobRenderer) compressAndUpload(renderedJob bitemplate.RenderedJob) (RenderedJobRef, error) {
-	tarballPath, err := b.compressor.CompressFilesInDir(renderedJob.Path())
+	tarballPath, err := b.compressor.CompressFilesInDir(renderedJob.Path(), boshcmd.CompressorOptions{})
 	if err != nil {
 		return RenderedJobRef{}, bosherr.WrapError(err, "Compressing rendered job templates")
 	}

--- a/installation/pkg/compiler.go
+++ b/installation/pkg/compiler.go
@@ -111,7 +111,7 @@ func (c *compiler) Compile(pkg birelpkg.Compilable) (bistatepkg.CompiledPackageR
 			return record, isCompiledPackage, bosherr.WrapError(err, "Compiling package")
 		}
 
-		tarball, err = c.compressor.CompressFilesInDir(installDir)
+		tarball, err = c.compressor.CompressFilesInDir(installDir, boshcmd.CompressorOptions{})
 		if err != nil {
 			return record, isCompiledPackage, bosherr.WrapError(err, "Compressing compiled package")
 		}

--- a/release/archive_writer.go
+++ b/release/archive_writer.go
@@ -81,7 +81,7 @@ func (w ArchiveWriter) Write(release Release, pkgFpsToSkip []string) (string, er
 	w.filesToInclude = w.appendFiles(licenseFiles)
 
 	files := w.filesToInclude
-	path, err := w.compressor.CompressSpecificFilesInDir(stagingDir, files)
+	path, err := w.compressor.CompressSpecificFilesInDir(stagingDir, files, boshcmd.CompressorOptions{})
 
 	if err != nil {
 		return "", bosherr.WrapError(err, "Compressing release")

--- a/release/resource/archive.go
+++ b/release/resource/archive.go
@@ -90,7 +90,7 @@ func (a ArchiveImpl) Build(expectedFp string) (string, string, error) {
 		return "", "", bosherr.WrapError(err, "Running prep scripts")
 	}
 
-	archivePath, err := a.compressor.CompressFilesInDir(stagingDir)
+	archivePath, err := a.compressor.CompressFilesInDir(stagingDir, boshcmd.CompressorOptions{})
 	if err != nil {
 		return "", "", bosherr.WrapError(err, "Compressing staging directory")
 	}

--- a/stemcell/stemcell.go
+++ b/stemcell/stemcell.go
@@ -107,7 +107,7 @@ func (s *extractedStemcell) Pack(destinationPath string) error {
 		filenames = append(filenames, filepath.Base(p))
 	}
 
-	intermediateStemcellPath, err := s.compressor.CompressSpecificFilesInDir(s.extractedPath, filenames)
+	intermediateStemcellPath, err := s.compressor.CompressSpecificFilesInDir(s.extractedPath, filenames, boshfu.CompressorOptions{})
 	if err != nil {
 		return err
 	}

--- a/templatescompiler/rendered_job_list_compressor.go
+++ b/templatescompiler/rendered_job_list_compressor.go
@@ -63,7 +63,7 @@ func (c *renderedJobListCompressor) Compress(list RenderedJobList) (RenderedJobL
 		}
 	}
 
-	archivePath, err := c.compressor.CompressFilesInDir(renderedJobListDir)
+	archivePath, err := c.compressor.CompressFilesInDir(renderedJobListDir, boshcmd.CompressorOptions{})
 	if err != nil {
 		return nil, bosherr.WrapError(err, "Compressing rendered job templates")
 	}

--- a/vendor/github.com/cloudfoundry/bosh-utils/fileutil/compressor_interface.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/fileutil/compressor_interface.go
@@ -4,13 +4,14 @@ type CompressorOptions struct {
 	SameOwner       bool
 	PathInArchive   string
 	StripComponents int
+	NoCompression   bool
 }
 
 type Compressor interface {
 	// CompressFilesInDir returns path to a compressed file
-	CompressFilesInDir(dir string) (path string, err error)
+	CompressFilesInDir(dir string, options CompressorOptions) (path string, err error)
 
-	CompressSpecificFilesInDir(dir string, files []string) (path string, err error)
+	CompressSpecificFilesInDir(dir string, files []string, options CompressorOptions) (path string, err error)
 
 	DecompressFileToDir(path string, dir string, options CompressorOptions) (err error)
 

--- a/vendor/github.com/cloudfoundry/bosh-utils/fileutil/fakes/fake_compressor.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/fileutil/fakes/fake_compressor.go
@@ -6,12 +6,14 @@ import (
 
 type FakeCompressor struct {
 	CompressFilesInDirDir         string
+	CompressFilesInDirOptions     boshcmd.CompressorOptions
 	CompressFilesInDirTarballPath string
 	CompressFilesInDirErr         error
 	CompressFilesInDirCallBack    func()
 
 	CompressSpecificFilesInDirDir         string
 	CompressSpecificFilesInDirFiles       []string
+	CompressSpecificFilesInDirOptions     boshcmd.CompressorOptions
 	CompressSpecificFilesInDirTarballPath string
 	CompressSpecificFilesInDirErr         error
 	CompressSpecificFilesInDirCallBack    func()
@@ -30,9 +32,9 @@ func NewFakeCompressor() *FakeCompressor {
 	return &FakeCompressor{}
 }
 
-func (fc *FakeCompressor) CompressFilesInDir(dir string) (string, error) {
+func (fc *FakeCompressor) CompressFilesInDir(dir string, options boshcmd.CompressorOptions) (string, error) {
 	fc.CompressFilesInDirDir = dir
-
+	fc.CompressFilesInDirOptions = options
 	if fc.CompressFilesInDirCallBack != nil {
 		fc.CompressFilesInDirCallBack()
 	}
@@ -40,10 +42,10 @@ func (fc *FakeCompressor) CompressFilesInDir(dir string) (string, error) {
 	return fc.CompressFilesInDirTarballPath, fc.CompressFilesInDirErr
 }
 
-func (fc *FakeCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
+func (fc *FakeCompressor) CompressSpecificFilesInDir(dir string, files []string, options boshcmd.CompressorOptions) (string, error) {
 	fc.CompressSpecificFilesInDirDir = dir
 	fc.CompressSpecificFilesInDirFiles = files
-
+	fc.CompressSpecificFilesInDirOptions = options
 	if fc.CompressSpecificFilesInDirCallBack != nil {
 		fc.CompressSpecificFilesInDirCallBack()
 	}

--- a/vendor/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor.go
+++ b/vendor/github.com/cloudfoundry/bosh-utils/fileutil/tarball_compressor.go
@@ -20,11 +20,11 @@ func NewTarballCompressor(
 	return tarballCompressor{cmdRunner: cmdRunner, fs: fs}
 }
 
-func (c tarballCompressor) CompressFilesInDir(dir string) (string, error) {
-	return c.CompressSpecificFilesInDir(dir, []string{"."})
+func (c tarballCompressor) CompressFilesInDir(dir string, options CompressorOptions) (string, error) {
+	return c.CompressSpecificFilesInDir(dir, []string{"."}, options)
 }
 
-func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string) (string, error) {
+func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string, options CompressorOptions) (string, error) {
 	tarball, err := c.fs.TempFile("bosh-platform-disk-TarballCompressor-CompressSpecificFilesInDir")
 	if err != nil {
 		return "", bosherr.WrapError(err, "Creating temporary file for tarball")
@@ -34,7 +34,10 @@ func (c tarballCompressor) CompressSpecificFilesInDir(dir string, files []string
 
 	tarballPath := tarball.Name()
 
-	args := []string{"-czf", tarballPath, "-C", dir}
+	args := []string{"-cf", tarballPath, "-C", dir}
+	if !options.NoCompression {
+		args = append(args, "-z")
+	}
 	if runtime.GOOS == "darwin" {
 		args = append([]string{"--no-mac-metadata"}, args...)
 	}
@@ -61,7 +64,7 @@ func (c tarballCompressor) DecompressFileToDir(tarballPath string, dir string, o
 	if err != nil {
 		return bosherr.WrapError(err, "Resolving tarball path")
 	}
-	args := []string{sameOwnerOption, "-xzf", resolvedTarballPath, "-C", dir}
+	args := []string{sameOwnerOption, "-xf", resolvedTarballPath, "-C", dir}
 	if options.StripComponents != 0 {
 		args = append(args, fmt.Sprintf("--strip-components=%d", options.StripComponents))
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/cloudfoundry/bosh-gcscli/config
 ## explicit; go 1.23.0
 github.com/cloudfoundry/bosh-s3cli/client
 github.com/cloudfoundry/bosh-s3cli/config
-# github.com/cloudfoundry/bosh-utils v0.0.560
+# github.com/cloudfoundry/bosh-utils v0.0.562
 ## explicit; go 1.23.0
 github.com/cloudfoundry/bosh-utils/blobstore
 github.com/cloudfoundry/bosh-utils/blobstore/fakes


### PR DESCRIPTION
- Update bosh-utils to latest version that removes problematic -z flag during tar extraction
- Update Compressor interface calls to pass CompressorOptions parameter
- Fix tar decompression commands to use -xf instead of -xzf

This resolves issues with tar extraction where the -z flag was causing problems in certain environments or with specific tar implementations.