### PR TITLE
Lint: `nolint:` newly flagged issue

### DIFF
--- a/index/file_index.go
+++ b/index/file_index.go
@@ -161,7 +161,7 @@ var kindToStrMap = map[reflect.Kind]string{
 	reflect.Func:          "Func",
 	reflect.Interface:     "Interface",
 	reflect.Map:           "Map",
-	reflect.Ptr:           "Ptr",
+	reflect.Ptr:           "Ptr", //nolint:govet
 	reflect.Slice:         "Slice",
 	reflect.String:        "String",
 	reflect.Struct:        "Struct",


### PR DESCRIPTION
Fixes:
```
golangci-lint has version 2.12.1 built with go1.26.2 from (unknown, modified: ?, mod sum: "h1:Rr07Ps/u+kvQqSO4L026WOSVvOlMU+RZTa/lossFaJA=") on (unknown)
lint-ing with GOOS=linux...
index/file_index.go:164:2: inline: Constant reflect.Ptr should be inlined (govet)
	reflect.Ptr:           "Ptr",
	^
1 issues:
* govet: 1
```
^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-cli/jobs/test-unit/builds/227#L69e75076:218:224