### PR TITLE
ci: Fix config-server resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -493,8 +493,8 @@ resources:
   - name: config-server
     type: git
     source:
-      uri: git@github.com:cloudfoundry/config-server.git
-      branch: develop
+      uri: git@github.com:cloudfoundry/config-server-release.git
+      branch: main
       private_key: ((github_deploy_key_config-server.private_key))
 
   - name: bosh-warden-stemcell-jammy


### PR DESCRIPTION
config-server has been merged into config-server-release under a `src/config-server` path.'

(This change is already flown in Concourse)